### PR TITLE
feat!: rename yfm -> md in core and dependent modules

### DIFF
--- a/demo/editor-in-editor/EditorInEditorExtension/index.tsx
+++ b/demo/editor-in-editor/EditorInEditorExtension/index.tsx
@@ -30,13 +30,13 @@ export const EditorInEditor: ExtensionAuto<EditorInEditorOptions> = (builder, op
             toDOM: (node) => ['div', {class: CONTAINER_CLASSNAME, ...node.attrs}, 0],
             parseDOM: [{tag: `div.${CONTAINER_CLASSNAME}`, priority: 100}],
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: editorInEditorNodeName,
                 type: 'block',
             },
         },
-        toYfm: (state, node) => {
+        toMd: (state, node) => {
             state.closeBlock(node);
         },
         view: () => (node, view) => new EditorInEditorNodeView(node, view, opts),

--- a/src/bundle/Editor.ts
+++ b/src/bundle/Editor.ts
@@ -4,11 +4,7 @@ import {TextSelection} from 'prosemirror-state';
 import {EditorView as PMEditorView} from 'prosemirror-view';
 
 import {CommonEditor, MarkupString} from '../common';
-import {
-    ActionStorage,
-    YfmEditor as WysiwygEditor,
-    YfmEditorOptions as WysiwygOptions,
-} from '../core';
+import {ActionStorage, WysiwygEditor, WysiwygEditorOptions} from '../core';
 import {ReactRenderStorage, RenderStorage} from '../extensions';
 import {i18n} from '../i18n/bundle';
 import {logger} from '../logger';
@@ -107,7 +103,7 @@ type ChangeEditorTypeOptions = {
 };
 
 export type EditorOptions = Pick<
-    WysiwygOptions,
+    WysiwygEditorOptions,
     'allowHTML' | 'linkify' | 'linkifyTlds' | 'attrs' | 'extensions'
 > & {
     initialMarkup?: MarkupString;
@@ -150,8 +146,8 @@ export class EditorImpl extends SafeEventEmitter<EventMapInt> implements EditorI
     #allowHTML?: boolean;
     #linkify?: boolean;
     #linkifyTlds?: string | string[];
-    #attrs?: WysiwygOptions['attrs'];
-    #extensions?: WysiwygOptions['extensions'];
+    #attrs?: WysiwygEditorOptions['attrs'];
+    #extensions?: WysiwygEditorOptions['extensions'];
     #renderStorage: ReactRenderStorage;
     #fileUploadHandler?: FileUploadHandler;
     #needToSetDimensionsForUploadedImages: boolean;
@@ -313,11 +309,11 @@ export class EditorImpl extends SafeEventEmitter<EventMapInt> implements EditorI
     // <--- implements CodeEditor
 
     // ---> implements ActionStorage
-    get actions(): YfmEditor.Actions {
+    get actions(): WysiwygEditor.Actions {
         return this.wysiwygEditor.actions;
     }
 
-    action<T extends keyof YfmEditor.Actions>(actionName: T): YfmEditor.Actions[T] {
+    action<T extends keyof WysiwygEditor.Actions>(actionName: T): WysiwygEditor.Actions[T] {
         return this.wysiwygEditor.action(actionName);
     }
 

--- a/src/core/ActionsManager.tsx
+++ b/src/core/ActionsManager.tsx
@@ -1,21 +1,21 @@
 import type {ActionStorage} from './types/actions';
 
 export class ActionsManager implements ActionStorage {
-    #actions: YfmEditor.Actions;
+    #actions: WysiwygEditor.Actions;
 
     get actions() {
         return this.#actions;
     }
 
-    constructor(actions?: YfmEditor.Actions) {
-        this.#actions = actions ?? ({} as YfmEditor.Actions);
+    constructor(actions?: WysiwygEditor.Actions) {
+        this.#actions = actions ?? ({} as WysiwygEditor.Actions);
     }
 
-    action<T extends keyof YfmEditor.Actions>(actionName: T): YfmEditor.Actions[T] {
+    action<T extends keyof WysiwygEditor.Actions>(actionName: T): WysiwygEditor.Actions[T] {
         return this.#actions[actionName];
     }
 
-    setActions(actions: YfmEditor.Actions) {
+    setActions(actions: WysiwygEditor.Actions) {
         this.#actions = actions;
         return this;
     }

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -13,11 +13,11 @@ import type {Serializer} from './types/serializer';
 import {bindActions} from './utils/actions';
 import {logTransactionMetrics} from './utils/metrics';
 
-type OnChange = (editor: YfmEditor) => void;
+type OnChange = (editor: WysiwygEditor) => void;
 
-export type YfmEditorOptions = {
+export type WysiwygEditorOptions = {
     domElem?: Element;
-    /** yfm markup */
+    /** markdown markup */
     initialContent?: string;
     extensions?: Extension;
     allowHTML?: boolean;
@@ -34,7 +34,7 @@ export type YfmEditorOptions = {
     onDocChange?: OnChange;
 };
 
-export class YfmEditor implements CommonEditor, ActionStorage {
+export class WysiwygEditor implements CommonEditor, ActionStorage {
     #view: EditorView;
     #serializer: Serializer;
     #parser: Parser;
@@ -72,7 +72,7 @@ export class YfmEditor implements CommonEditor, ActionStorage {
         linkifyTlds,
         onChange,
         onDocChange,
-    }: YfmEditorOptions) {
+    }: WysiwygEditorOptions) {
         const {schema, parser, serializer, nodeViews, markViews, plugins, rawActions, actions} =
             ExtensionsManager.process(extensions, {
                 // "breaks" option only affects the renderer, but not the parser
@@ -105,14 +105,16 @@ export class YfmEditor implements CommonEditor, ActionStorage {
             },
         });
         this.#actions = actions.setActions(
-            bindActions<keyof YfmEditor.Actions>(rawActions)(this.#view) as YfmEditor.Actions,
+            bindActions<keyof WysiwygEditor.Actions>(rawActions)(
+                this.#view,
+            ) as WysiwygEditor.Actions,
         );
         this.#serializer = serializer;
         this.#parser = parser;
         this.#contentHandler = new WysiwygContentHandler(this.#view, parser);
     }
 
-    action<T extends keyof YfmEditor.Actions>(actionName: T): YfmEditor.Actions[T] {
+    action<T extends keyof WysiwygEditor.Actions>(actionName: T): WysiwygEditor.Actions[T] {
         return this.#actions.action(actionName);
     }
 
@@ -173,7 +175,7 @@ export class YfmEditor implements CommonEditor, ActionStorage {
 }
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         // eslint-disable-next-line @typescript-eslint/no-empty-interface
         interface Actions {}
     }

--- a/src/core/ExtensionBuilder.test.ts
+++ b/src/core/ExtensionBuilder.test.ts
@@ -1,7 +1,7 @@
 import {Plugin} from 'prosemirror-state';
 
 import {ExtensionBuilder} from './ExtensionBuilder';
-import type {ExtensionDeps, WEMarkSpec} from './types/extension';
+import type {ExtensionDeps, ExtensionMarkSpec} from './types/extension';
 
 describe('ExtensionBuilder', () => {
     it('should build empty extension', () => {
@@ -66,22 +66,22 @@ describe('ExtensionBuilder', () => {
     });
 
     it('should sort marks by priority', () => {
-        const mark0: WEMarkSpec = {
+        const mark0: ExtensionMarkSpec = {
             spec: {},
             fromMd: {tokenSpec: {type: 'mark', name: 'mark0'}},
             toMd: {open: '', close: ''},
         };
-        const mark1: WEMarkSpec = {
+        const mark1: ExtensionMarkSpec = {
             spec: {},
             fromMd: {tokenSpec: {type: 'mark', name: 'mark1'}},
             toMd: {open: '', close: ''},
         };
-        const mark2: WEMarkSpec = {
+        const mark2: ExtensionMarkSpec = {
             spec: {},
             fromMd: {tokenSpec: {type: 'mark', name: 'mark2'}},
             toMd: {open: '', close: ''},
         };
-        const mark3: WEMarkSpec = {
+        const mark3: ExtensionMarkSpec = {
             spec: {},
             fromMd: {tokenSpec: {type: 'mark', name: 'mark3'}},
             toMd: {open: '', close: ''},
@@ -93,7 +93,7 @@ describe('ExtensionBuilder', () => {
             .addMark('mark2', () => mark2)
             .build()
             .marks();
-        const marksList: {name: string; spec: WEMarkSpec}[] = [];
+        const marksList: {name: string; spec: ExtensionMarkSpec}[] = [];
         marksOrderedMap.forEach((name, spec) => marksList.push({name, spec}));
         expect(marksList[0].name).toBe('mark0');
         expect(marksList[0].spec === mark0).toBe(true);

--- a/src/core/ExtensionBuilder.test.ts
+++ b/src/core/ExtensionBuilder.test.ts
@@ -1,7 +1,7 @@
 import {Plugin} from 'prosemirror-state';
 
 import {ExtensionBuilder} from './ExtensionBuilder';
-import type {ExtensionDeps, YEMarkSpec} from './types/extension';
+import type {ExtensionDeps, WEMarkSpec} from './types/extension';
 
 describe('ExtensionBuilder', () => {
     it('should build empty extension', () => {
@@ -29,13 +29,13 @@ describe('ExtensionBuilder', () => {
         const nodes = new ExtensionBuilder()
             .addNode('node1', () => ({
                 spec: {},
-                fromYfm: {tokenSpec: {type: 'block', name: 'node1'}},
-                toYfm: () => {},
+                fromMd: {tokenSpec: {type: 'block', name: 'node1'}},
+                toMd: () => {},
             }))
             .addNode('node2', () => ({
                 spec: {},
-                fromYfm: {tokenSpec: {type: 'block', name: 'node2'}},
-                toYfm: () => {},
+                fromMd: {tokenSpec: {type: 'block', name: 'node2'}},
+                toMd: () => {},
             }))
             .build()
             .nodes();
@@ -49,13 +49,13 @@ describe('ExtensionBuilder', () => {
         const marks = new ExtensionBuilder()
             .addMark('mark1', () => ({
                 spec: {},
-                fromYfm: {tokenSpec: {type: 'mark', name: 'mark1'}},
-                toYfm: {open: '', close: ''},
+                fromMd: {tokenSpec: {type: 'mark', name: 'mark1'}},
+                toMd: {open: '', close: ''},
             }))
             .addMark('mark2', () => ({
                 spec: {},
-                fromYfm: {tokenSpec: {type: 'mark', name: 'mark2'}},
-                toYfm: {open: '', close: ''},
+                fromMd: {tokenSpec: {type: 'mark', name: 'mark2'}},
+                toMd: {open: '', close: ''},
             }))
             .build()
             .marks();
@@ -66,25 +66,25 @@ describe('ExtensionBuilder', () => {
     });
 
     it('should sort marks by priority', () => {
-        const mark0: YEMarkSpec = {
+        const mark0: WEMarkSpec = {
             spec: {},
-            fromYfm: {tokenSpec: {type: 'mark', name: 'mark0'}},
-            toYfm: {open: '', close: ''},
+            fromMd: {tokenSpec: {type: 'mark', name: 'mark0'}},
+            toMd: {open: '', close: ''},
         };
-        const mark1: YEMarkSpec = {
+        const mark1: WEMarkSpec = {
             spec: {},
-            fromYfm: {tokenSpec: {type: 'mark', name: 'mark1'}},
-            toYfm: {open: '', close: ''},
+            fromMd: {tokenSpec: {type: 'mark', name: 'mark1'}},
+            toMd: {open: '', close: ''},
         };
-        const mark2: YEMarkSpec = {
+        const mark2: WEMarkSpec = {
             spec: {},
-            fromYfm: {tokenSpec: {type: 'mark', name: 'mark2'}},
-            toYfm: {open: '', close: ''},
+            fromMd: {tokenSpec: {type: 'mark', name: 'mark2'}},
+            toMd: {open: '', close: ''},
         };
-        const mark3: YEMarkSpec = {
+        const mark3: WEMarkSpec = {
             spec: {},
-            fromYfm: {tokenSpec: {type: 'mark', name: 'mark3'}},
-            toYfm: {open: '', close: ''},
+            fromMd: {tokenSpec: {type: 'mark', name: 'mark3'}},
+            toMd: {open: '', close: ''},
         };
         const marksOrderedMap = new ExtensionBuilder()
             .addMark('mark3', () => mark3, ExtensionBuilder.Priority.VeryLow)
@@ -93,7 +93,7 @@ describe('ExtensionBuilder', () => {
             .addMark('mark2', () => mark2)
             .build()
             .marks();
-        const marksList: {name: string; spec: YEMarkSpec}[] = [];
+        const marksList: {name: string; spec: WEMarkSpec}[] = [];
         marksOrderedMap.forEach((name, spec) => marksList.push({name, spec}));
         expect(marksList[0].name).toBe('mark0');
         expect(marksList[0].spec === mark0).toBe(true);
@@ -157,15 +157,15 @@ describe('ExtensionBuilder', () => {
     it('should throw error when add nodes with the same names', () => {
         const builder = new ExtensionBuilder().addNode('node', () => ({
             spec: {},
-            toYfm: () => {},
-            fromYfm: {tokenSpec: {type: 'block', name: 'node'}},
+            toMd: () => {},
+            fromMd: {tokenSpec: {type: 'block', name: 'node'}},
         }));
 
         const fn = () => {
             builder.addNode('node', () => ({
                 spec: {},
-                toYfm: () => {},
-                fromYfm: {tokenSpec: {type: 'block', name: 'node'}},
+                toMd: () => {},
+                fromMd: {tokenSpec: {type: 'block', name: 'node'}},
             }));
         };
 
@@ -175,15 +175,15 @@ describe('ExtensionBuilder', () => {
     it('should throw error when add marks with the same names', () => {
         const builder = new ExtensionBuilder().addMark('mark', () => ({
             spec: {},
-            toYfm: {open: '', close: ''},
-            fromYfm: {tokenSpec: {type: 'mark', name: 'mark'}},
+            toMd: {open: '', close: ''},
+            fromMd: {tokenSpec: {type: 'mark', name: 'mark'}},
         }));
 
         const fn = () => {
             builder.addMark('mark', () => ({
                 spec: {},
-                toYfm: {open: '', close: ''},
-                fromYfm: {tokenSpec: {type: 'mark', name: 'mark'}},
+                toMd: {open: '', close: ''},
+                fromMd: {tokenSpec: {type: 'mark', name: 'mark'}},
             }));
         };
 

--- a/src/core/ExtensionBuilder.ts
+++ b/src/core/ExtensionBuilder.ts
@@ -10,8 +10,8 @@ import type {
     ExtensionDeps,
     ExtensionSpec,
     ExtensionWithOptions,
-    YEMarkSpec,
-    YENodeSpec,
+    WEMarkSpec,
+    WENodeSpec,
 } from './types/extension';
 import type {Keymap} from './types/keymap';
 
@@ -19,8 +19,8 @@ type InputRulesConfig = Parameters<typeof inputRules>[0];
 type ExtensionWithParams = (builder: ExtensionBuilder, ...params: any[]) => void;
 
 type ConfigureMdCallback = (md: MarkdownIt) => MarkdownIt;
-type AddPmNodeCallback = () => YENodeSpec;
-type AddPmMarkCallback = () => YEMarkSpec;
+type AddPmNodeCallback = () => WENodeSpec;
+type AddPmMarkCallback = () => WEMarkSpec;
 type AddPmPluginCallback = (deps: ExtensionDeps) => Plugin | Plugin[];
 type AddPmKeymapCallback = (deps: ExtensionDeps) => Keymap;
 type AddPmInputRulesCallback = (deps: ExtensionDeps) => InputRulesConfig;
@@ -45,13 +45,13 @@ type BuilderContext<T extends object> = {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Context {}
     }
 }
 
 export class ExtensionBuilder {
-    static createContext(): BuilderContext<YfmEditor.Context> {
+    static createContext(): BuilderContext<WysiwygEditor.Context> {
         return new Map();
     }
 
@@ -70,9 +70,9 @@ export class ExtensionBuilder {
     #plugins: {cb: AddPmPluginCallback; priority: number}[] = [];
     #actions: [string, AddActionCallback][] = [];
 
-    readonly context: BuilderContext<YfmEditor.Context>;
+    readonly context: BuilderContext<WysiwygEditor.Context>;
 
-    constructor(context?: BuilderContext<YfmEditor.Context>) {
+    constructor(context?: BuilderContext<WysiwygEditor.Context>) {
         this.context = context ?? ExtensionBuilder.createContext();
     }
 
@@ -121,7 +121,9 @@ export class ExtensionBuilder {
 
     addAction(name: string, cb: AddActionCallback): this {
         if (this.#actions.some(([actionName]) => actionName === name)) {
-            throw new Error(`[YFM Editor] action with this name "${name}" already exist`);
+            throw new Error(
+                `[Markdown Wysiwyg Editor] action with this name "${name}" already exist`,
+            );
         }
         this.#actions.push([name, cb]);
         return this;
@@ -137,7 +139,7 @@ export class ExtensionBuilder {
         return {
             configureMd: (md) => confMd.reduce((pMd, cb) => cb(pMd), md),
             nodes: () => {
-                let map = OrderedMap.from<YENodeSpec>({});
+                let map = OrderedMap.from<WENodeSpec>({});
                 for (const {name, cb} of Object.values(nodes)) {
                     map = map.addToEnd(name, cb());
                 }
@@ -147,7 +149,7 @@ export class ExtensionBuilder {
                 // The order of marks in schema is important when serializing pm-document to DOM or markup
                 // https://discuss.prosemirror.net/t/marks-priority/4463
                 const sortedMarks = Object.values(marks).sort((a, b) => b.priority - a.priority);
-                let map = OrderedMap.from<YEMarkSpec>({});
+                let map = OrderedMap.from<WEMarkSpec>({});
                 for (const {name, cb} of sortedMarks) {
                     map = map.addToEnd(name, cb());
                 }

--- a/src/core/ExtensionBuilder.ts
+++ b/src/core/ExtensionBuilder.ts
@@ -8,10 +8,10 @@ import type {ActionSpec} from './types/actions';
 import type {
     Extension,
     ExtensionDeps,
+    ExtensionMarkSpec,
+    ExtensionNodeSpec,
     ExtensionSpec,
     ExtensionWithOptions,
-    WEMarkSpec,
-    WENodeSpec,
 } from './types/extension';
 import type {Keymap} from './types/keymap';
 
@@ -19,8 +19,8 @@ type InputRulesConfig = Parameters<typeof inputRules>[0];
 type ExtensionWithParams = (builder: ExtensionBuilder, ...params: any[]) => void;
 
 type ConfigureMdCallback = (md: MarkdownIt) => MarkdownIt;
-type AddPmNodeCallback = () => WENodeSpec;
-type AddPmMarkCallback = () => WEMarkSpec;
+type AddPmNodeCallback = () => ExtensionNodeSpec;
+type AddPmMarkCallback = () => ExtensionMarkSpec;
 type AddPmPluginCallback = (deps: ExtensionDeps) => Plugin | Plugin[];
 type AddPmKeymapCallback = (deps: ExtensionDeps) => Keymap;
 type AddPmInputRulesCallback = (deps: ExtensionDeps) => InputRulesConfig;
@@ -139,7 +139,7 @@ export class ExtensionBuilder {
         return {
             configureMd: (md) => confMd.reduce((pMd, cb) => cb(pMd), md),
             nodes: () => {
-                let map = OrderedMap.from<WENodeSpec>({});
+                let map = OrderedMap.from<ExtensionNodeSpec>({});
                 for (const {name, cb} of Object.values(nodes)) {
                     map = map.addToEnd(name, cb());
                 }
@@ -149,7 +149,7 @@ export class ExtensionBuilder {
                 // The order of marks in schema is important when serializing pm-document to DOM or markup
                 // https://discuss.prosemirror.net/t/marks-priority/4463
                 const sortedMarks = Object.values(marks).sort((a, b) => b.priority - a.priority);
-                let map = OrderedMap.from<WEMarkSpec>({});
+                let map = OrderedMap.from<ExtensionMarkSpec>({});
                 for (const {name, cb} of sortedMarks) {
                     map = map.addToEnd(name, cb());
                 }

--- a/src/core/ExtensionsManager.ts
+++ b/src/core/ExtensionsManager.ts
@@ -12,8 +12,8 @@ import type {
     Extension,
     ExtensionDeps,
     ExtensionSpec,
-    YEMarkSpec,
-    YENodeSpec,
+    WEMarkSpec,
+    WENodeSpec,
 } from './types/extension';
 import type {MarkViewConstructor, NodeViewConstructor} from './types/node-views';
 
@@ -103,19 +103,19 @@ export class ExtensionsManager {
         this.#spec.marks().forEach(this.processMark);
     }
 
-    private processNode = (name: string, {spec, fromYfm, toYfm, view}: YENodeSpec) => {
+    private processNode = (name: string, {spec, fromMd, toMd: toMd, view}: WENodeSpec) => {
         this.#schemaRegistry.addNode(name, spec);
-        this.#parserRegistry.addToken(fromYfm.tokenName || name, fromYfm.tokenSpec);
-        this.#serializerRegistry.addNode(name, toYfm);
+        this.#parserRegistry.addToken(fromMd.tokenName || name, fromMd.tokenSpec);
+        this.#serializerRegistry.addNode(name, toMd);
         if (view) {
             this.#nodeViewCreators.set(name, view);
         }
     };
 
-    private processMark = (name: string, {spec, fromYfm, toYfm, view}: YEMarkSpec) => {
+    private processMark = (name: string, {spec, fromMd, toMd, view}: WEMarkSpec) => {
         this.#schemaRegistry.addMark(name, spec);
-        this.#parserRegistry.addToken(fromYfm.tokenName || name, fromYfm.tokenSpec);
-        this.#serializerRegistry.addMark(name, toYfm);
+        this.#parserRegistry.addToken(fromMd.tokenName || name, fromMd.tokenSpec);
+        this.#serializerRegistry.addMark(name, toMd);
         if (view) {
             this.#markViewCreators.set(name, view);
         }

--- a/src/core/ExtensionsManager.ts
+++ b/src/core/ExtensionsManager.ts
@@ -11,9 +11,9 @@ import type {ActionSpec} from './types/actions';
 import type {
     Extension,
     ExtensionDeps,
+    ExtensionMarkSpec,
+    ExtensionNodeSpec,
     ExtensionSpec,
-    WEMarkSpec,
-    WENodeSpec,
 } from './types/extension';
 import type {MarkViewConstructor, NodeViewConstructor} from './types/node-views';
 
@@ -103,7 +103,7 @@ export class ExtensionsManager {
         this.#spec.marks().forEach(this.processMark);
     }
 
-    private processNode = (name: string, {spec, fromMd, toMd: toMd, view}: WENodeSpec) => {
+    private processNode = (name: string, {spec, fromMd, toMd: toMd, view}: ExtensionNodeSpec) => {
         this.#schemaRegistry.addNode(name, spec);
         this.#parserRegistry.addToken(fromMd.tokenName || name, fromMd.tokenSpec);
         this.#serializerRegistry.addNode(name, toMd);
@@ -112,7 +112,7 @@ export class ExtensionsManager {
         }
     };
 
-    private processMark = (name: string, {spec, fromMd, toMd, view}: WEMarkSpec) => {
+    private processMark = (name: string, {spec, fromMd, toMd, view}: ExtensionMarkSpec) => {
         this.#schemaRegistry.addMark(name, spec);
         this.#parserRegistry.addToken(fromMd.tokenName || name, fromMd.tokenSpec);
         this.#serializerRegistry.addMark(name, toMd);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -10,8 +10,8 @@ export type {
     ExtensionAuto,
     ExtensionWithOptions,
     ExtensionDeps,
-    WENodeSpec,
-    WEMarkSpec,
+    ExtensionNodeSpec,
+    ExtensionMarkSpec,
 } from './types/extension';
 export type {Parser, ParserToken} from './types/parser';
 export type {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -10,8 +10,8 @@ export type {
     ExtensionAuto,
     ExtensionWithOptions,
     ExtensionDeps,
-    YENodeSpec,
-    YEMarkSpec,
+    WENodeSpec,
+    WEMarkSpec,
 } from './types/extension';
 export type {Parser, ParserToken} from './types/parser';
 export type {

--- a/src/core/types/actions.ts
+++ b/src/core/types/actions.ts
@@ -35,6 +35,6 @@ export interface Action<A extends {} = never, M = unknown> {
 }
 
 export interface ActionStorage {
-    actions: YfmEditor.Actions;
-    action<T extends keyof YfmEditor.Actions>(actionName: T): YfmEditor.Actions[T];
+    actions: WysiwygEditor.Actions;
+    action<T extends keyof WysiwygEditor.Actions>(actionName: T): WysiwygEditor.Actions[T];
 }

--- a/src/core/types/extension.ts
+++ b/src/core/types/extension.ts
@@ -16,30 +16,30 @@ export type ExtensionAuto<T = void> = T extends void ? Extension : ExtensionWith
 
 export type ExtensionSpec = {
     configureMd(md: MarkdownIt): MarkdownIt;
-    nodes(): OrderedMap<YENodeSpec>;
-    marks(): OrderedMap<YEMarkSpec>;
+    nodes(): OrderedMap<WENodeSpec>;
+    marks(): OrderedMap<WEMarkSpec>;
     plugins(deps: ExtensionDeps): Plugin[];
     actions(deps: ExtensionDeps): Record<string, ActionSpec>;
 };
 
-export type YENodeSpec = {
+export type WENodeSpec = {
     spec: NodeSpec;
     view?: (deps: ExtensionDeps) => NodeViewConstructor;
-    fromYfm: {
+    fromMd: {
         tokenName?: string;
         tokenSpec: ParserToken;
     };
-    toYfm: SerializerNodeToken;
+    toMd: SerializerNodeToken;
 };
 
-export type YEMarkSpec = {
+export type WEMarkSpec = {
     spec: MarkSpec;
     view?: (deps: ExtensionDeps) => MarkViewConstructor;
-    fromYfm: {
+    fromMd: {
         tokenName?: string;
         tokenSpec: ParserToken;
     };
-    toYfm: SerializerMarkToken;
+    toMd: SerializerMarkToken;
 };
 
 export type ExtensionDeps = {

--- a/src/core/types/extension.ts
+++ b/src/core/types/extension.ts
@@ -16,13 +16,13 @@ export type ExtensionAuto<T = void> = T extends void ? Extension : ExtensionWith
 
 export type ExtensionSpec = {
     configureMd(md: MarkdownIt): MarkdownIt;
-    nodes(): OrderedMap<WENodeSpec>;
-    marks(): OrderedMap<WEMarkSpec>;
+    nodes(): OrderedMap<ExtensionNodeSpec>;
+    marks(): OrderedMap<ExtensionMarkSpec>;
     plugins(deps: ExtensionDeps): Plugin[];
     actions(deps: ExtensionDeps): Record<string, ActionSpec>;
 };
 
-export type WENodeSpec = {
+export type ExtensionNodeSpec = {
     spec: NodeSpec;
     view?: (deps: ExtensionDeps) => NodeViewConstructor;
     fromMd: {
@@ -32,7 +32,7 @@ export type WENodeSpec = {
     toMd: SerializerNodeToken;
 };
 
-export type WEMarkSpec = {
+export type ExtensionMarkSpec = {
     spec: MarkSpec;
     view?: (deps: ExtensionDeps) => MarkViewConstructor;
     fromMd: {

--- a/src/extensions/base/BaseSchema/BaseSchemaSpecs/index.ts
+++ b/src/extensions/base/BaseSchema/BaseSchemaSpecs/index.ts
@@ -24,17 +24,17 @@ export const BaseSchemaSpecs: ExtensionAuto<BaseSchemaSpecsOptions> = (builder, 
             spec: {
                 content: 'block+',
             },
-            fromYfm: {tokenSpec: {name: BaseNode.Doc, type: 'block', ignore: true}},
-            toYfm: () => {
-                throw new Error('Unexpected toYfm() call on doc node');
+            fromMd: {tokenSpec: {name: BaseNode.Doc, type: 'block', ignore: true}},
+            toMd: () => {
+                throw new Error('Unexpected toMd() call on doc node');
             },
         }))
         .addNode(BaseNode.Text, () => ({
             spec: {
                 group: 'inline',
             },
-            fromYfm: {tokenSpec: {name: BaseNode.Text, type: 'node', ignore: true}},
-            toYfm: (state, node, parent) => {
+            fromMd: {tokenSpec: {name: BaseNode.Text, type: 'node', ignore: true}},
+            toMd: (state, node, parent) => {
                 const {escapeText} = parent.type.spec;
                 state.text(node.text, escapeText ?? !state.isAutolink);
             },
@@ -61,8 +61,8 @@ export const BaseSchemaSpecs: ExtensionAuto<BaseSchemaSpecsOptions> = (builder, 
                       }
                     : undefined,
             },
-            fromYfm: {tokenSpec: {name: BaseNode.Paragraph, type: 'block'}},
-            toYfm: (state, node) => {
+            fromMd: {tokenSpec: {name: BaseNode.Paragraph, type: 'block'}},
+            toMd: (state, node) => {
                 state.renderInline(node);
                 state.closeBlock(node);
             },

--- a/src/extensions/base/BaseSchema/index.ts
+++ b/src/extensions/base/BaseSchema/index.ts
@@ -42,7 +42,7 @@ export const BaseSchema: ExtensionAuto<BaseSchemaOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [pAction]: Action;
         }

--- a/src/extensions/behavior/Autocomplete/index.ts
+++ b/src/extensions/behavior/Autocomplete/index.ts
@@ -62,7 +62,7 @@ export const Autocomplete: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Context {
             autocomplete: Storage;
         }

--- a/src/extensions/behavior/ClicksOnEdges/ClicksOnEdges.ts
+++ b/src/extensions/behavior/ClicksOnEdges/ClicksOnEdges.ts
@@ -50,7 +50,7 @@ export const ClicksOnEdges: Extension = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [startActionName]: Action;
             [endActionName]: Action;

--- a/src/extensions/behavior/History/index.ts
+++ b/src/extensions/behavior/History/index.ts
@@ -30,7 +30,7 @@ export const History: ExtensionAuto<HistoryOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [HistoryAction.Undo]: Action;
             [HistoryAction.Redo]: Action;

--- a/src/extensions/behavior/Placeholder/index.ts
+++ b/src/extensions/behavior/Placeholder/index.ts
@@ -245,7 +245,7 @@ declare module 'prosemirror-model' {
 }
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Context {
             placeholder: PlaceholderOptions;
         }

--- a/src/extensions/behavior/ReactRenderer/index.ts
+++ b/src/extensions/behavior/ReactRenderer/index.ts
@@ -44,7 +44,7 @@ export const ReactRendererExtension: ExtensionAuto<ReactRenderer> = (builder, re
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Context {
             reactrenderer: ReactRenderer;
         }

--- a/src/extensions/behavior/Selection/commands.test.ts
+++ b/src/extensions/behavior/Selection/commands.test.ts
@@ -24,8 +24,8 @@ const {schema} = new ExtensionsManager({
             .use(YfmTable, {})
             .addNode('testnode', () => ({
                 spec: {content: `block*`, group: 'block', gapcursor: false},
-                fromYfm: {tokenSpec: {name: 'testnode', type: 'block', ignore: true}},
-                toYfm: () => {},
+                fromMd: {tokenSpec: {name: 'testnode', type: 'block', ignore: true}},
+                toMd: () => {},
             })),
 }).buildDeps();
 

--- a/src/extensions/markdown/Blockquote/BlockquoteSpecs/index.ts
+++ b/src/extensions/markdown/Blockquote/BlockquoteSpecs/index.ts
@@ -18,8 +18,8 @@ export const BlockquoteSpecs: ExtensionAuto = (builder) => {
                 return ['blockquote', 0];
             },
         },
-        fromYfm: {tokenSpec: {name: blockquoteNodeName, type: 'block'}},
-        toYfm: (state, node) => {
+        fromMd: {tokenSpec: {name: blockquoteNodeName, type: 'block'}},
+        toMd: (state, node) => {
             state.wrapBlock('> ', null, node, () => state.renderContent(node));
         },
     }));

--- a/src/extensions/markdown/Blockquote/index.ts
+++ b/src/extensions/markdown/Blockquote/index.ts
@@ -43,7 +43,7 @@ export const Blockquote: ExtensionAuto<BlockquoteOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [bqAction]: Action;
         }

--- a/src/extensions/markdown/Bold/BoldSpecs/index.ts
+++ b/src/extensions/markdown/Bold/BoldSpecs/index.ts
@@ -19,12 +19,12 @@ export const BoldSpecs: ExtensionAuto = (builder) => {
                 return ['strong'];
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: boldMarkName,
                 type: 'mark',
             },
         },
-        toYfm: {open: '**', close: '**', mixable: true, expelEnclosingWhitespace: true},
+        toMd: {open: '**', close: '**', mixable: true, expelEnclosingWhitespace: true},
     }));
 };

--- a/src/extensions/markdown/Bold/index.ts
+++ b/src/extensions/markdown/Bold/index.ts
@@ -36,7 +36,7 @@ export const Bold: ExtensionAuto<BoldOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [bAction]: Action;
         }

--- a/src/extensions/markdown/Breaks/BreaksSpecs/index.ts
+++ b/src/extensions/markdown/Breaks/BreaksSpecs/index.ts
@@ -35,8 +35,8 @@ export const BreaksSpecs: ExtensionAuto<BreaksSpecsOptions> = (builder, opts) =>
                 return ['br'];
             },
         },
-        fromYfm: {tokenName: 'hardbreak', tokenSpec: {name: BreakNodeName.HardBreak, type: 'node'}},
-        toYfm: (state, node, parent, index) => {
+        fromMd: {tokenName: 'hardbreak', tokenSpec: {name: BreakNodeName.HardBreak, type: 'node'}},
+        toMd: (state, node, parent, index) => {
             for (let i = index + 1; i < parent.childCount; i++) {
                 if (parent.child(i).type !== node.type) {
                     state.write('\\\n');
@@ -62,8 +62,8 @@ export const BreaksSpecs: ExtensionAuto<BreaksSpecsOptions> = (builder, opts) =>
                 return ['br'];
             },
         },
-        fromYfm: {tokenName: 'softbreak', tokenSpec: {name: BreakNodeName.SoftBreak, type: 'node'}},
-        toYfm: (state, node, parent, index) => {
+        fromMd: {tokenName: 'softbreak', tokenSpec: {name: BreakNodeName.SoftBreak, type: 'node'}},
+        toMd: (state, node, parent, index) => {
             for (let i = index + 1; i < parent.childCount; i++) {
                 if (parent.child(i).type !== node.type) {
                     state.write('\n');

--- a/src/extensions/markdown/Breaks/index.ts
+++ b/src/extensions/markdown/Breaks/index.ts
@@ -87,7 +87,7 @@ const addBr = (br: NodeType) =>
     });
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Context {
             /**
              * Same as @type {MarkdownIt.Options.breaks}

--- a/src/extensions/markdown/Code/CodeSpecs/index.ts
+++ b/src/extensions/markdown/Code/CodeSpecs/index.ts
@@ -17,7 +17,7 @@ export const CodeSpecs: ExtensionAuto = (builder) => {
                     return ['code'];
                 },
             },
-            toYfm: {
+            toMd: {
                 open(_state, _mark, parent, index) {
                     return backticksFor(parent.child(index), -1);
                 },
@@ -26,7 +26,7 @@ export const CodeSpecs: ExtensionAuto = (builder) => {
                 },
                 escape: false,
             },
-            fromYfm: {
+            fromMd: {
                 tokenSpec: {name: codeMarkName, type: 'mark', code: true, noCloseToken: true},
                 tokenName: 'code_inline',
             },

--- a/src/extensions/markdown/Code/index.ts
+++ b/src/extensions/markdown/Code/index.ts
@@ -70,7 +70,7 @@ export const Code: ExtensionAuto<CodeOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [codeAction]: Action;
         }

--- a/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
@@ -1,4 +1,4 @@
-import type {ExtensionAuto, YENodeSpec} from '../../../../core';
+import type {ExtensionAuto, WENodeSpec} from '../../../../core';
 import {nodeTypeFactory} from '../../../../utils/schema';
 
 export const CodeBlockNodeAttr = {
@@ -12,7 +12,7 @@ export const codeBlockLangAttr = CodeBlockNodeAttr.Lang;
 export const codeBlockType = nodeTypeFactory(codeBlockNodeName);
 
 export type CodeBlockSpecsOptions = {
-    nodeview?: YENodeSpec['view'];
+    nodeview?: WENodeSpec['view'];
 };
 
 export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, opts) => {
@@ -43,7 +43,7 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
                 return ['pre', attrs, ['code', 0]];
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: codeBlockNodeName,
                 type: 'block',
@@ -51,7 +51,7 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
                 prepareContent: removeNewLineAtEnd, // content of code blocks contains extra \n at the end
             },
         },
-        toYfm: (state, node) => {
+        toMd: (state, node) => {
             const lang: string = node.attrs[CodeBlockNodeAttr.Lang];
             const markup: string = node.attrs[CodeBlockNodeAttr.Markup];
 
@@ -67,7 +67,7 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
         //  we adding this node only for define specific 'fence' parser token,
         //  which parse fence md token to code_block node
         spec: {},
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: codeBlockNodeName,
                 type: 'block',
@@ -86,8 +86,8 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
                 prepareContent: removeNewLineAtEnd, // content of fence blocks contains extra \n at the end
             },
         },
-        toYfm: () => {
-            throw new Error('Unexpected toYfm() call on fence node');
+        toMd: () => {
+            throw new Error('Unexpected toMd() call on fence node');
         },
     }));
     builder.addKeymap(() => ({

--- a/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
@@ -1,4 +1,4 @@
-import type {ExtensionAuto, WENodeSpec} from '../../../../core';
+import type {ExtensionAuto, ExtensionNodeSpec} from '../../../../core';
 import {nodeTypeFactory} from '../../../../utils/schema';
 
 export const CodeBlockNodeAttr = {
@@ -12,7 +12,7 @@ export const codeBlockLangAttr = CodeBlockNodeAttr.Lang;
 export const codeBlockType = nodeTypeFactory(codeBlockNodeName);
 
 export type CodeBlockSpecsOptions = {
-    nodeview?: WENodeSpec['view'];
+    nodeview?: ExtensionNodeSpec['view'];
 };
 
 export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, opts) => {

--- a/src/extensions/markdown/CodeBlock/index.ts
+++ b/src/extensions/markdown/CodeBlock/index.ts
@@ -74,7 +74,7 @@ export const CodeBlock: ExtensionAuto<CodeBlockOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [cbAction]: Action;
         }

--- a/src/extensions/markdown/Deflist/DeflistSpecs/index.ts
+++ b/src/extensions/markdown/Deflist/DeflistSpecs/index.ts
@@ -32,17 +32,17 @@ export const DeflistSpecs: ExtensionAuto<DeflistSpecsOptions> = (builder, opts) 
     builder
         .addNode(DeflistNode.List, () => ({
             spec: spec[DeflistNode.List],
-            fromYfm: {tokenSpec: fromYfm[DeflistNode.List]},
-            toYfm: toYfm[DeflistNode.List],
+            fromMd: {tokenSpec: fromYfm[DeflistNode.List]},
+            toMd: toYfm[DeflistNode.List],
         }))
         .addNode(DeflistNode.Term, () => ({
             spec: spec[DeflistNode.Term],
-            fromYfm: {tokenSpec: fromYfm[DeflistNode.Term]},
-            toYfm: toYfm[DeflistNode.Term],
+            fromMd: {tokenSpec: fromYfm[DeflistNode.Term]},
+            toMd: toYfm[DeflistNode.Term],
         }))
         .addNode(DeflistNode.Desc, () => ({
             spec: spec[DeflistNode.Desc],
-            fromYfm: {tokenSpec: fromYfm[DeflistNode.Desc]},
-            toYfm: toYfm[DeflistNode.Desc],
+            fromMd: {tokenSpec: fromYfm[DeflistNode.Desc]},
+            toMd: toYfm[DeflistNode.Desc],
         }));
 };

--- a/src/extensions/markdown/Deflist/index.ts
+++ b/src/extensions/markdown/Deflist/index.ts
@@ -22,7 +22,7 @@ export const Deflist: ExtensionAuto<DeflistOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [dlAction]: Action;
         }

--- a/src/extensions/markdown/Heading/HeadingSpecs/index.ts
+++ b/src/extensions/markdown/Heading/HeadingSpecs/index.ts
@@ -49,14 +49,14 @@ export const HeadingSpecs: ExtensionAuto<HeadingSpecsOptions> = (builder, opts) 
                 alwaysVisible: true,
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: headingNodeName,
                 type: 'block',
                 getAttrs: (tok) => ({[headingLevelAttr]: Number(tok.tag.slice(1))}),
             },
         },
-        toYfm: (state, node) => {
+        toMd: (state, node) => {
             state.write(state.repeat('#', node.attrs[headingLevelAttr]) + ' ');
             state.renderInline(node);
             state.closeBlock(node);

--- a/src/extensions/markdown/Heading/index.ts
+++ b/src/extensions/markdown/Heading/index.ts
@@ -52,7 +52,7 @@ export const Heading: ExtensionAuto<HeadingOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [HeadingAction.ToH1]: Action;
             [HeadingAction.ToH2]: Action;

--- a/src/extensions/markdown/HorizontalRule/HorizontalRuleSpecs/index.ts
+++ b/src/extensions/markdown/HorizontalRule/HorizontalRuleSpecs/index.ts
@@ -15,7 +15,7 @@ export const HorizontalRuleSpecs: ExtensionAuto = (builder) => {
                 return ['div', ['hr']];
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenName: 'hr',
             tokenSpec: {
                 name: horizontalRuleNodeName,
@@ -23,7 +23,7 @@ export const HorizontalRuleSpecs: ExtensionAuto = (builder) => {
                 getAttrs: (token) => ({[horizontalRuleMarkupAttr]: token.markup}),
             },
         },
-        toYfm: (state, node) => {
+        toMd: (state, node) => {
             state.write(node.attrs[horizontalRuleMarkupAttr]);
             state.closeBlock(node);
         },

--- a/src/extensions/markdown/HorizontalRule/index.ts
+++ b/src/extensions/markdown/HorizontalRule/index.ts
@@ -55,7 +55,7 @@ export const HorizontalRule: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [hrAction]: Action;
         }

--- a/src/extensions/markdown/Html/index.ts
+++ b/src/extensions/markdown/Html/index.ts
@@ -16,19 +16,19 @@ export const Html: ExtensionAuto = (builder) => {
 
     builder.addNode(HtmlNode.Block, () => ({
         spec: spec[HtmlNode.Block],
-        fromYfm: {tokenSpec: fromYfm[HtmlNode.Block]},
-        toYfm: toYfm[HtmlNode.Block],
+        fromMd: {tokenSpec: fromYfm[HtmlNode.Block]},
+        toMd: toYfm[HtmlNode.Block],
     }));
 
     builder.addNode(HtmlNode.Inline, () => ({
         spec: spec[HtmlNode.Inline],
-        fromYfm: {tokenSpec: fromYfm[HtmlNode.Inline]},
-        toYfm: toYfm[HtmlNode.Inline],
+        fromMd: {tokenSpec: fromYfm[HtmlNode.Inline]},
+        toMd: toYfm[HtmlNode.Inline],
     }));
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Context {
             /**
              * Same as @type {MarkdownIt.Options.html}

--- a/src/extensions/markdown/Image/ImageSpecs/index.ts
+++ b/src/extensions/markdown/Image/ImageSpecs/index.ts
@@ -40,7 +40,7 @@ export const ImageSpecs: ExtensionAuto = (builder) => {
                 return ['img', node.attrs];
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: imageNodeName,
                 type: 'node',
@@ -52,7 +52,7 @@ export const ImageSpecs: ExtensionAuto = (builder) => {
                 }),
             },
         },
-        toYfm: (state, {attrs}) => {
+        toMd: (state, {attrs}) => {
             state.write(
                 '![' +
                     state.esc(attrs.alt || '') +

--- a/src/extensions/markdown/Image/index.ts
+++ b/src/extensions/markdown/Image/index.ts
@@ -16,7 +16,7 @@ export const Image: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [addImageAction]: Action<AddImageAttrs>;
         }

--- a/src/extensions/markdown/Italic/ItalicSpecs/index.ts
+++ b/src/extensions/markdown/Italic/ItalicSpecs/index.ts
@@ -16,7 +16,7 @@ export const ItalicSpecs: ExtensionAuto = (builder) => {
                 return ['em'];
             },
         },
-        toYfm: {open: '*', close: '*', mixable: true, expelEnclosingWhitespace: true},
-        fromYfm: {tokenSpec: {name: italicMarkName, type: 'mark'}},
+        toMd: {open: '*', close: '*', mixable: true, expelEnclosingWhitespace: true},
+        fromMd: {tokenSpec: {name: italicMarkName, type: 'mark'}},
     }));
 };

--- a/src/extensions/markdown/Italic/index.ts
+++ b/src/extensions/markdown/Italic/index.ts
@@ -37,7 +37,7 @@ export const Italic: ExtensionAuto<ItalicOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [iAction]: Action;
         }

--- a/src/extensions/markdown/Link/LinkSpecs/index.ts
+++ b/src/extensions/markdown/Link/LinkSpecs/index.ts
@@ -39,7 +39,7 @@ export const LinkSpecs: ExtensionAuto = (builder) => {
                 return ['a', node.attrs];
             },
         },
-        toYfm: {
+        toMd: {
             open(state, mark, parent, index) {
                 state.isAutolink = isPlainURL(mark, parent, index, 1);
                 if (state.isAutolink) {
@@ -66,7 +66,7 @@ export const LinkSpecs: ExtensionAuto = (builder) => {
                 );
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: linkMarkName,
                 type: 'mark',

--- a/src/extensions/markdown/Link/index.ts
+++ b/src/extensions/markdown/Link/index.ts
@@ -45,7 +45,7 @@ export const Link: ExtensionAuto<LinkOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [linkAction]: Action<LinkActionParams, LinkActionMeta>;
             [linkAction2]: Action;

--- a/src/extensions/markdown/Lists/ListsSpecs/index.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/index.ts
@@ -15,17 +15,17 @@ export const ListsSpecs: ExtensionAuto = (builder) => {
     builder
         .addNode(ListNode.ListItem, () => ({
             spec: spec[ListNode.ListItem],
-            toYfm: toYfm[ListNode.ListItem],
-            fromYfm: {tokenSpec: fromYfm[ListNode.ListItem]},
+            toMd: toYfm[ListNode.ListItem],
+            fromMd: {tokenSpec: fromYfm[ListNode.ListItem]},
         }))
         .addNode(ListNode.BulletList, () => ({
             spec: spec[ListNode.BulletList],
-            toYfm: toYfm[ListNode.BulletList],
-            fromYfm: {tokenSpec: fromYfm[ListNode.BulletList]},
+            toMd: toYfm[ListNode.BulletList],
+            fromMd: {tokenSpec: fromYfm[ListNode.BulletList]},
         }))
         .addNode(ListNode.OrderedList, () => ({
             spec: spec[ListNode.OrderedList],
-            toYfm: toYfm[ListNode.OrderedList],
-            fromYfm: {tokenSpec: fromYfm[ListNode.OrderedList]},
+            toMd: toYfm[ListNode.OrderedList],
+            fromMd: {tokenSpec: fromYfm[ListNode.OrderedList]},
         }));
 };

--- a/src/extensions/markdown/Lists/index.ts
+++ b/src/extensions/markdown/Lists/index.ts
@@ -59,7 +59,7 @@ export const Lists: ExtensionAuto<ListsOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [ListAction.ToBulletList]: Action;
             [ListAction.ToOrderedList]: Action;

--- a/src/extensions/markdown/Mark/MarkSpecs/index.ts
+++ b/src/extensions/markdown/Mark/MarkSpecs/index.ts
@@ -16,13 +16,13 @@ export const MarkSpecs: ExtensionAuto = (builder) => {
                     return ['mark'];
                 },
             },
-            fromYfm: {
+            fromMd: {
                 tokenSpec: {
                     name: markMarkName,
                     type: 'mark',
                 },
             },
-            toYfm: {
+            toMd: {
                 open: '==',
                 close: '==',
                 mixable: true,

--- a/src/extensions/markdown/Mark/index.ts
+++ b/src/extensions/markdown/Mark/index.ts
@@ -22,7 +22,7 @@ export const Mark: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [mAction]: Action;
         }

--- a/src/extensions/markdown/Strike/StrikeSpecs/index.ts
+++ b/src/extensions/markdown/Strike/StrikeSpecs/index.ts
@@ -12,13 +12,13 @@ export const StrikeSpecs: ExtensionAuto = (builder) => {
                 return ['strike'];
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: strikeMarkName,
                 type: 'mark',
             },
             tokenName: 's',
         },
-        toYfm: {open: '~~', close: '~~', mixable: true, expelEnclosingWhitespace: true},
+        toMd: {open: '~~', close: '~~', mixable: true, expelEnclosingWhitespace: true},
     }));
 };

--- a/src/extensions/markdown/Strike/index.ts
+++ b/src/extensions/markdown/Strike/index.ts
@@ -36,7 +36,7 @@ export const Strike: ExtensionAuto<StrikeOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [sAction]: Action;
         }

--- a/src/extensions/markdown/Subscript/SubscriptSpecs/index.ts
+++ b/src/extensions/markdown/Subscript/SubscriptSpecs/index.ts
@@ -17,7 +17,7 @@ export const SubscriptSpecs: ExtensionAuto = (builder) => {
                     return ['sub'];
                 },
             },
-            toYfm: {
+            toMd: {
                 open: (state) => {
                     state.escapeWhitespace = true;
                     return '~';
@@ -29,6 +29,6 @@ export const SubscriptSpecs: ExtensionAuto = (builder) => {
                 mixable: false,
                 expelEnclosingWhitespace: true,
             },
-            fromYfm: {tokenSpec: {name: subscriptMarkName, type: 'mark'}},
+            fromMd: {tokenSpec: {name: subscriptMarkName, type: 'mark'}},
         }));
 };

--- a/src/extensions/markdown/Subscript/index.ts
+++ b/src/extensions/markdown/Subscript/index.ts
@@ -22,7 +22,7 @@ export const Subscript: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [subAction]: Action;
         }

--- a/src/extensions/markdown/Superscript/SuperscriptSpecs/index.ts
+++ b/src/extensions/markdown/Superscript/SuperscriptSpecs/index.ts
@@ -18,7 +18,7 @@ export const SuperscriptSpecs: ExtensionAuto = (builder) => {
                     return ['sup'];
                 },
             },
-            toYfm: {
+            toMd: {
                 open: (state) => {
                     state.escapeWhitespace = true;
                     return '^';
@@ -30,6 +30,6 @@ export const SuperscriptSpecs: ExtensionAuto = (builder) => {
                 mixable: true,
                 expelEnclosingWhitespace: true,
             },
-            fromYfm: {tokenSpec: {name: superscriptMarkName, type: 'mark'}},
+            fromMd: {tokenSpec: {name: superscriptMarkName, type: 'mark'}},
         }));
 };

--- a/src/extensions/markdown/Superscript/index.ts
+++ b/src/extensions/markdown/Superscript/index.ts
@@ -22,7 +22,7 @@ export const Superscript: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [supAction]: Action;
         }

--- a/src/extensions/markdown/Table/TableSpecs/index.ts
+++ b/src/extensions/markdown/Table/TableSpecs/index.ts
@@ -11,32 +11,32 @@ export const TableSpecs: ExtensionAuto = (builder) => {
     builder
         .addNode(TableNode.Table, () => ({
             spec: spec[TableNode.Table],
-            toYfm: toYfm[TableNode.Table],
-            fromYfm: {tokenSpec: fromYfm[TableNode.Table]},
+            toMd: toYfm[TableNode.Table],
+            fromMd: {tokenSpec: fromYfm[TableNode.Table]},
         }))
         .addNode(TableNode.Head, () => ({
             spec: spec[TableNode.Head],
-            toYfm: toYfm[TableNode.Head],
-            fromYfm: {tokenSpec: fromYfm[TableNode.Head]},
+            toMd: toYfm[TableNode.Head],
+            fromMd: {tokenSpec: fromYfm[TableNode.Head]},
         }))
         .addNode(TableNode.Body, () => ({
             spec: spec[TableNode.Body],
-            toYfm: toYfm[TableNode.Body],
-            fromYfm: {tokenSpec: fromYfm[TableNode.Body]},
+            toMd: toYfm[TableNode.Body],
+            fromMd: {tokenSpec: fromYfm[TableNode.Body]},
         }))
         .addNode(TableNode.Row, () => ({
             spec: spec[TableNode.Row],
-            toYfm: toYfm[TableNode.Row],
-            fromYfm: {tokenSpec: fromYfm[TableNode.Row]},
+            toMd: toYfm[TableNode.Row],
+            fromMd: {tokenSpec: fromYfm[TableNode.Row]},
         }))
         .addNode(TableNode.HeaderCell, () => ({
             spec: spec[TableNode.HeaderCell],
-            toYfm: toYfm[TableNode.HeaderCell],
-            fromYfm: {tokenSpec: fromYfm[TableNode.HeaderCell]},
+            toMd: toYfm[TableNode.HeaderCell],
+            fromMd: {tokenSpec: fromYfm[TableNode.HeaderCell]},
         }))
         .addNode(TableNode.DataCell, () => ({
             spec: spec[TableNode.DataCell],
-            toYfm: toYfm[TableNode.DataCell],
-            fromYfm: {tokenSpec: fromYfm[TableNode.DataCell]},
+            toMd: toYfm[TableNode.DataCell],
+            fromMd: {tokenSpec: fromYfm[TableNode.DataCell]},
         }));
 };

--- a/src/extensions/markdown/Table/index.ts
+++ b/src/extensions/markdown/Table/index.ts
@@ -24,7 +24,7 @@ export const Table: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             createTable: Action;
             deleteTable: Action;

--- a/src/extensions/markdown/Underline/UnderlineSpecs/index.ts
+++ b/src/extensions/markdown/Underline/UnderlineSpecs/index.ts
@@ -16,7 +16,7 @@ export const UnderlineSpecs: ExtensionAuto = (builder) => {
                     return ['ins'];
                 },
             },
-            toYfm: {open: '++', close: '++', mixable: true, expelEnclosingWhitespace: true},
-            fromYfm: {tokenSpec: {name: underlineMarkName, type: 'mark'}},
+            toMd: {open: '++', close: '++', mixable: true, expelEnclosingWhitespace: true},
+            fromMd: {tokenSpec: {name: underlineMarkName, type: 'mark'}},
         }));
 };

--- a/src/extensions/markdown/Underline/index.ts
+++ b/src/extensions/markdown/Underline/index.ts
@@ -36,7 +36,7 @@ export const Underline: ExtensionAuto<UnderlineOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [undAction]: Action;
         }

--- a/src/extensions/yfm/Checkbox/CheckboxSpecs/index.ts
+++ b/src/extensions/yfm/Checkbox/CheckboxSpecs/index.ts
@@ -1,7 +1,7 @@
 import checkboxPlugin from '@diplodoc/transform/lib/plugins/checkbox';
 import type {NodeSpec} from 'prosemirror-model';
 
-import type {ExtensionAuto, WENodeSpec} from '../../../../core';
+import type {ExtensionAuto, ExtensionNodeSpec} from '../../../../core';
 import {nodeTypeFactory} from '../../../../utils/schema';
 
 import {CheckboxNode, b, idPrefix} from './const';
@@ -19,9 +19,9 @@ export type CheckboxSpecsOptions = {
      * @deprecated: use placeholder option in BehaviorPreset instead.
      */
     checkboxLabelPlaceholder?: NonNullable<NodeSpec['placeholder']>['content'];
-    inputView?: WENodeSpec['view'];
-    labelView?: WENodeSpec['view'];
-    checkboxView?: WENodeSpec['view'];
+    inputView?: ExtensionNodeSpec['view'];
+    labelView?: ExtensionNodeSpec['view'];
+    checkboxView?: ExtensionNodeSpec['view'];
 };
 
 export const CheckboxSpecs: ExtensionAuto<CheckboxSpecsOptions> = (builder, opts) => {

--- a/src/extensions/yfm/Checkbox/CheckboxSpecs/index.ts
+++ b/src/extensions/yfm/Checkbox/CheckboxSpecs/index.ts
@@ -1,7 +1,7 @@
 import checkboxPlugin from '@diplodoc/transform/lib/plugins/checkbox';
 import type {NodeSpec} from 'prosemirror-model';
 
-import type {ExtensionAuto, YENodeSpec} from '../../../../core';
+import type {ExtensionAuto, WENodeSpec} from '../../../../core';
 import {nodeTypeFactory} from '../../../../utils/schema';
 
 import {CheckboxNode, b, idPrefix} from './const';
@@ -19,9 +19,9 @@ export type CheckboxSpecsOptions = {
      * @deprecated: use placeholder option in BehaviorPreset instead.
      */
     checkboxLabelPlaceholder?: NonNullable<NodeSpec['placeholder']>['content'];
-    inputView?: YENodeSpec['view'];
-    labelView?: YENodeSpec['view'];
-    checkboxView?: YENodeSpec['view'];
+    inputView?: WENodeSpec['view'];
+    labelView?: WENodeSpec['view'];
+    checkboxView?: WENodeSpec['view'];
 };
 
 export const CheckboxSpecs: ExtensionAuto<CheckboxSpecsOptions> = (builder, opts) => {
@@ -31,24 +31,24 @@ export const CheckboxSpecs: ExtensionAuto<CheckboxSpecsOptions> = (builder, opts
         .configureMd((md) => checkboxPlugin(md, {idPrefix, divClass: b()}))
         .addNode(CheckboxNode.Checkbox, () => ({
             spec: spec[CheckboxNode.Checkbox],
-            toYfm: toYfm[CheckboxNode.Checkbox],
-            fromYfm: {
+            toMd: toYfm[CheckboxNode.Checkbox],
+            fromMd: {
                 tokenSpec: fromYfm[CheckboxNode.Checkbox],
             },
             view: opts.checkboxView,
         }))
         .addNode(CheckboxNode.Input, () => ({
             spec: spec[CheckboxNode.Input],
-            toYfm: toYfm[CheckboxNode.Input],
-            fromYfm: {
+            toMd: toYfm[CheckboxNode.Input],
+            fromMd: {
                 tokenSpec: fromYfm[CheckboxNode.Input],
             },
             view: opts.inputView,
         }))
         .addNode(CheckboxNode.Label, () => ({
             spec: spec[CheckboxNode.Label],
-            toYfm: toYfm[CheckboxNode.Label],
-            fromYfm: {
+            toMd: toYfm[CheckboxNode.Label],
+            fromMd: {
                 tokenSpec: fromYfm[CheckboxNode.Label],
                 tokenName: 'checkbox_label',
             },

--- a/src/extensions/yfm/Checkbox/index.ts
+++ b/src/extensions/yfm/Checkbox/index.ts
@@ -91,7 +91,7 @@ export const Checkbox: ExtensionAuto<CheckboxOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [checkboxAction]: Action;
         }

--- a/src/extensions/yfm/Color/ColorSpecs/index.ts
+++ b/src/extensions/yfm/Color/ColorSpecs/index.ts
@@ -75,7 +75,7 @@ export const ColorSpecs: ExtensionAuto<ColorSpecsOptions> = (builder, opts) => {
                     ];
                 },
             },
-            fromYfm: {
+            fromMd: {
                 tokenSpec: {
                     name: colorMarkName,
                     type: 'mark',
@@ -86,7 +86,7 @@ export const ColorSpecs: ExtensionAuto<ColorSpecsOptions> = (builder, opts) => {
                     },
                 },
             },
-            toYfm: {
+            toMd: {
                 open: (_state, mark) => {
                     return `{${mark.attrs[colorMarkName]}}(`;
                 },

--- a/src/extensions/yfm/Color/index.ts
+++ b/src/extensions/yfm/Color/index.ts
@@ -54,7 +54,7 @@ export const Color: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [colorAction]: Action<ColorActionParams, Colors>;
         }

--- a/src/extensions/yfm/Emoji/EmojiSpecs/EmojiSpecs.ts
+++ b/src/extensions/yfm/Emoji/EmojiSpecs/EmojiSpecs.ts
@@ -42,7 +42,7 @@ const EmojiSpecsExtension: ExtensionAuto<EmojiSpecsOptions> = (builder, opts) =>
                 return ['span', {contentEditable: false, [markupDataAttribute]: markup}, 0];
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenName: emojiTokenName,
             tokenSpec: {
                 name: EmojiConsts.NodeName,
@@ -53,7 +53,7 @@ const EmojiSpecsExtension: ExtensionAuto<EmojiSpecsOptions> = (builder, opts) =>
                 }),
             },
         },
-        toYfm: (state, node) => {
+        toMd: (state, node) => {
             state.text(`:${node.attrs[EmojiConsts.NodeAttrs.Markup]}:`, false);
         },
     }));

--- a/src/extensions/yfm/Emoji/EmojiSuggest/EmojiSuggest.ts
+++ b/src/extensions/yfm/Emoji/EmojiSuggest/EmojiSuggest.ts
@@ -41,7 +41,7 @@ export const EmojiSuggest: ExtensionAuto<EmojiSpecsOptions> = (builder, {defs, s
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [emojiSuggestActionName]: Action<EmojiSuggestActionAttrs>;
         }

--- a/src/extensions/yfm/ImgSize/ImageWidget/index.ts
+++ b/src/extensions/yfm/ImgSize/ImageWidget/index.ts
@@ -23,7 +23,7 @@ export const ImageWidget: ExtensionAuto<ImageWidgetOptions> = (builder, opts) =>
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [addImageWidgetAction]: Action;
         }

--- a/src/extensions/yfm/ImgSize/ImgSizeSpecs/index.ts
+++ b/src/extensions/yfm/ImgSize/ImgSizeSpecs/index.ts
@@ -68,7 +68,7 @@ export const ImgSizeSpecs: ExtensionAuto<ImgSizeSpecsOptions> = (builder, opts) 
                 return ['img', node.attrs];
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: imageNodeName,
                 type: 'node',
@@ -82,7 +82,7 @@ export const ImgSizeSpecs: ExtensionAuto<ImgSizeSpecsOptions> = (builder, opts) 
                 }),
             },
         },
-        toYfm: (state, node) => {
+        toMd: (state, node) => {
             const attrs = node.attrs as ImsizeTypedAttributes;
             state.write(
                 '![' +

--- a/src/extensions/yfm/ImgSize/index.ts
+++ b/src/extensions/yfm/ImgSize/index.ts
@@ -39,7 +39,7 @@ export const ImgSize: ExtensionAuto<ImgSizeOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             // @ts-expect-error
             [addImageAction]: Action<AddImageAttrs>;

--- a/src/extensions/yfm/Math/MathSpecs/index.ts
+++ b/src/extensions/yfm/Math/MathSpecs/index.ts
@@ -28,11 +28,11 @@ export const MathSpecs: ExtensionAuto = (builder) => {
                 ],
                 parseDOM: [{tag: `span.${CLASSNAMES.Inline.Content}`, priority: 200}],
             },
-            fromYfm: {
+            fromMd: {
                 tokenName: 'math_inline',
                 tokenSpec: {name: MathNode.Inline, type: 'block', noCloseToken: true},
             },
-            toYfm: (state, node) => {
+            toMd: (state, node) => {
                 state.text(`$${node.textContent}$`, false);
                 state.closeBlock();
             },
@@ -46,11 +46,11 @@ export const MathSpecs: ExtensionAuto = (builder) => {
                 toDOM: () => ['div', {class: 'math-block'}, 0],
                 parseDOM: [{tag: 'div.math-block', priority: 200}],
             },
-            fromYfm: {
+            fromMd: {
                 tokenName: 'math_block',
                 tokenSpec: {name: MathNode.Block, type: 'block', noCloseToken: true},
             },
-            toYfm: (state, node) => {
+            toMd: (state, node) => {
                 state.text(`$$${node.textContent}$$\n\n`, false);
                 state.closeBlock();
             },

--- a/src/extensions/yfm/Math/index.ts
+++ b/src/extensions/yfm/Math/index.ts
@@ -100,7 +100,7 @@ export const Math: ExtensionAuto<MathOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [mathIAction]: Action;
             [mathBAction]: Action;

--- a/src/extensions/yfm/Mermaid/MermaidSpecs/index.tsx
+++ b/src/extensions/yfm/Mermaid/MermaidSpecs/index.tsx
@@ -1,13 +1,13 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {transform} from '@diplodoc/mermaid-extension';
 
-import {ExtensionAuto, WENodeSpec} from '../../../../core';
+import type {ExtensionAuto, ExtensionNodeSpec} from '../../../../core';
 
 import {MermaidConsts, mermaidNodeName as mermaidNodeName} from './const';
 export {mermaidNodeName} from './const';
 
 export type MermaidSpecsOptions = {
-    nodeView?: WENodeSpec['view'];
+    nodeView?: ExtensionNodeSpec['view'];
 };
 
 const MermaidSpecsExtension: ExtensionAuto<MermaidSpecsOptions> = (builder, {nodeView}) => {

--- a/src/extensions/yfm/Mermaid/MermaidSpecs/index.tsx
+++ b/src/extensions/yfm/Mermaid/MermaidSpecs/index.tsx
@@ -1,20 +1,20 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {transform} from '@diplodoc/mermaid-extension';
 
-import {ExtensionAuto, YENodeSpec} from '../../../../core';
+import {ExtensionAuto, WENodeSpec} from '../../../../core';
 
 import {MermaidConsts, mermaidNodeName as mermaidNodeName} from './const';
 export {mermaidNodeName} from './const';
 
 export type MermaidSpecsOptions = {
-    nodeView?: YENodeSpec['view'];
+    nodeView?: WENodeSpec['view'];
 };
 
 const MermaidSpecsExtension: ExtensionAuto<MermaidSpecsOptions> = (builder, {nodeView}) => {
     builder
         .configureMd((md) => md.use(transform({runtime: 'mermaid', bundle: false}), {}))
         .addNode(mermaidNodeName, () => ({
-            fromYfm: {
+            fromMd: {
                 tokenSpec: {
                     name: mermaidNodeName,
                     type: 'node',
@@ -36,7 +36,7 @@ const MermaidSpecsExtension: ExtensionAuto<MermaidSpecsOptions> = (builder, {nod
                 },
                 dnd: {props: {offset: [8, 1]}},
             },
-            toYfm: (state, node) => {
+            toMd: (state, node) => {
                 state.write('```mermaid\n');
                 state.ensureNewLine();
                 state.write(node.attrs.content);

--- a/src/extensions/yfm/Mermaid/index.ts
+++ b/src/extensions/yfm/Mermaid/index.ts
@@ -25,7 +25,7 @@ const MermaidNodeViewFactory: (
     };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [MermaidAction]: Action;
         }

--- a/src/extensions/yfm/Monospace/MonospaceSpecs/index.ts
+++ b/src/extensions/yfm/Monospace/MonospaceSpecs/index.ts
@@ -17,13 +17,13 @@ export const MonospaceSpecs: ExtensionAuto = (builder) => {
                     return ['samp'];
                 },
             },
-            fromYfm: {
+            fromMd: {
                 tokenSpec: {
                     name: monospaceMarkName,
                     type: 'mark',
                 },
             },
-            toYfm: {
+            toMd: {
                 open: '##',
                 close: '##',
                 mixable: true,

--- a/src/extensions/yfm/Monospace/index.ts
+++ b/src/extensions/yfm/Monospace/index.ts
@@ -22,7 +22,7 @@ export const Monospace: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [monoAction]: Action;
         }

--- a/src/extensions/yfm/Video/VideoSpecs/index.ts
+++ b/src/extensions/yfm/Video/VideoSpecs/index.ts
@@ -84,7 +84,7 @@ export const VideoSpecs: ExtensionAuto<VideoSpecsOptions> = (builder, opts) => {
                 return createViewStub(node);
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: videoNodeName,
                 type: 'node',
@@ -94,7 +94,7 @@ export const VideoSpecs: ExtensionAuto<VideoSpecsOptions> = (builder, opts) => {
                 }),
             },
         },
-        toYfm: (state, node) => {
+        toMd: (state, node) => {
             state.write(serializeNodeToString(node));
         },
     }));

--- a/src/extensions/yfm/Video/index.ts
+++ b/src/extensions/yfm/Video/index.ts
@@ -21,7 +21,7 @@ export const Video: ExtensionAuto<VideoOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [vAction]: Action<VideoActionAttrs>;
         }

--- a/src/extensions/yfm/YfmCut/YfmCutSpecs/index.ts
+++ b/src/extensions/yfm/YfmCut/YfmCutSpecs/index.ts
@@ -2,7 +2,7 @@ import log from '@diplodoc/transform/lib/log';
 import yfmPlugin from '@diplodoc/transform/lib/plugins/cut';
 import type {NodeSpec} from 'prosemirror-model';
 
-import type {ExtensionAuto, YENodeSpec} from '../../../../core';
+import type {ExtensionAuto, WENodeSpec} from '../../../../core';
 
 import {CutNode} from './const';
 import {fromYfm} from './fromYfm';
@@ -12,9 +12,9 @@ import {toYfm} from './toYfm';
 export {CutNode, cutType, cutTitleType, cutContentType} from './const';
 
 export type YfmCutSpecsOptions = {
-    cutView?: YENodeSpec['view'];
-    cutTitleView?: YENodeSpec['view'];
-    cutContentView?: YENodeSpec['view'];
+    cutView?: WENodeSpec['view'];
+    cutTitleView?: WENodeSpec['view'];
+    cutContentView?: WENodeSpec['view'];
     /**
      * @deprecated: use placeholder option in BehaviorPreset instead.
      */
@@ -32,24 +32,24 @@ export const YfmCutSpecs: ExtensionAuto<YfmCutSpecsOptions> = (builder, opts) =>
         .configureMd((md) => md.use(yfmPlugin, {log}))
         .addNode(CutNode.Cut, () => ({
             spec: spec[CutNode.Cut],
-            toYfm: toYfm[CutNode.Cut],
-            fromYfm: {
+            toMd: toYfm[CutNode.Cut],
+            fromMd: {
                 tokenSpec: fromYfm[CutNode.Cut],
             },
             view: opts.cutView,
         }))
         .addNode(CutNode.CutTitle, () => ({
             spec: spec[CutNode.CutTitle],
-            toYfm: toYfm[CutNode.CutTitle],
-            fromYfm: {
+            toMd: toYfm[CutNode.CutTitle],
+            fromMd: {
                 tokenSpec: fromYfm[CutNode.CutTitle],
             },
             view: opts.cutTitleView,
         }))
         .addNode(CutNode.CutContent, () => ({
             spec: spec[CutNode.CutContent],
-            toYfm: toYfm[CutNode.CutContent],
-            fromYfm: {
+            toMd: toYfm[CutNode.CutContent],
+            fromMd: {
                 tokenSpec: fromYfm[CutNode.CutContent],
             },
             view: opts.cutContentView,

--- a/src/extensions/yfm/YfmCut/YfmCutSpecs/index.ts
+++ b/src/extensions/yfm/YfmCut/YfmCutSpecs/index.ts
@@ -2,7 +2,7 @@ import log from '@diplodoc/transform/lib/log';
 import yfmPlugin from '@diplodoc/transform/lib/plugins/cut';
 import type {NodeSpec} from 'prosemirror-model';
 
-import type {ExtensionAuto, WENodeSpec} from '../../../../core';
+import type {ExtensionAuto, ExtensionNodeSpec} from '../../../../core';
 
 import {CutNode} from './const';
 import {fromYfm} from './fromYfm';
@@ -12,9 +12,9 @@ import {toYfm} from './toYfm';
 export {CutNode, cutType, cutTitleType, cutContentType} from './const';
 
 export type YfmCutSpecsOptions = {
-    cutView?: WENodeSpec['view'];
-    cutTitleView?: WENodeSpec['view'];
-    cutContentView?: WENodeSpec['view'];
+    cutView?: ExtensionNodeSpec['view'];
+    cutTitleView?: ExtensionNodeSpec['view'];
+    cutContentView?: ExtensionNodeSpec['view'];
     /**
      * @deprecated: use placeholder option in BehaviorPreset instead.
      */

--- a/src/extensions/yfm/YfmCut/index.ts
+++ b/src/extensions/yfm/YfmCut/index.ts
@@ -58,7 +58,7 @@ export const YfmCut: ExtensionAuto<YfmCutOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [cutAction]: Action;
         }

--- a/src/extensions/yfm/YfmDist/YfmDistSpecs/index.ts
+++ b/src/extensions/yfm/YfmDist/YfmDistSpecs/index.ts
@@ -5,7 +5,7 @@ export const YfmDistSpecs: ExtensionAuto = (builder) => {
     // ignore yfm lint token
     builder.addNode('__yfm_lint', () => ({
         spec: {},
-        fromYfm: {tokenSpec: {name: '__yfm_lint', type: 'node', ignore: true}},
-        toYfm: noop,
+        fromMd: {tokenSpec: {name: '__yfm_lint', type: 'node', ignore: true}},
+        toMd: noop,
     }));
 };

--- a/src/extensions/yfm/YfmFile/YfmFileSpecs/index.ts
+++ b/src/extensions/yfm/YfmFile/YfmFileSpecs/index.ts
@@ -47,7 +47,7 @@ export const YfmFileSpecs: Extension = (builder) => {
                 return a;
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenName: yfmFileNodeName,
             tokenSpec: {
                 name: yfmFileNodeName,
@@ -57,7 +57,7 @@ export const YfmFileSpecs: Extension = (builder) => {
                 },
             },
         },
-        toYfm: (state, node) => {
+        toMd: (state, node) => {
             const attrsStr = Object.entries(node.attrs)
                 .reduce<string[]>((arr, [key, value]) => {
                     if (value) {

--- a/src/extensions/yfm/YfmFile/YfmFileWidget/index.ts
+++ b/src/extensions/yfm/YfmFile/YfmFileWidget/index.ts
@@ -14,7 +14,7 @@ export const YfmFileWidget: ExtensionAuto<YfmFileWidgetOptions> = (builder, opts
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [addFileAction]: Action;
         }

--- a/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/index.ts
+++ b/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/index.ts
@@ -67,7 +67,7 @@ export const YfmHeadingSpecs: ExtensionAuto<YfmHeadingSpecsOptions> = (builder, 
                 alwaysVisible: true,
             },
         },
-        fromYfm: {
+        fromMd: {
             tokenSpec: {
                 name: headingNodeName,
                 type: 'block',
@@ -89,7 +89,7 @@ export const YfmHeadingSpecs: ExtensionAuto<YfmHeadingSpecsOptions> = (builder, 
                 },
             },
         },
-        toYfm: (state, node) => {
+        toMd: (state, node) => {
             state.write(state.repeat('#', node.attrs[YfmHeadingAttr.Level]) + ' ');
             state.renderInline(node);
 

--- a/src/extensions/yfm/YfmHeading/index.ts
+++ b/src/extensions/yfm/YfmHeading/index.ts
@@ -46,7 +46,7 @@ export const YfmHeading: ExtensionAuto<YfmHeadingOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [HeadingAction.ToH1]: Action;
             [HeadingAction.ToH2]: Action;

--- a/src/extensions/yfm/YfmNote/YfmNoteSpecs/index.ts
+++ b/src/extensions/yfm/YfmNote/YfmNoteSpecs/index.ts
@@ -26,22 +26,22 @@ export const YfmNoteSpecs: ExtensionAuto<YfmNoteSpecsOptions> = (builder, opts) 
         .configureMd((md) => md.use(yfmPlugin, {log}))
         .addNode(NoteNode.Note, () => ({
             spec: spec[NoteNode.Note],
-            toYfm: toYfm[NoteNode.Note],
-            fromYfm: {
+            toMd: toYfm[NoteNode.Note],
+            fromMd: {
                 tokenSpec: fromYfm[NoteNode.Note],
             },
         }))
         .addNode(NoteNode.NoteTitle, () => ({
             spec: spec[NoteNode.NoteTitle],
-            toYfm: toYfm[NoteNode.NoteTitle],
-            fromYfm: {
+            toMd: toYfm[NoteNode.NoteTitle],
+            fromMd: {
                 tokenSpec: fromYfm[NoteNode.NoteTitle],
             },
         }))
         .addNode(NoteNode.NoteContent, () => ({
             spec: spec[NoteNode.NoteContent],
-            toYfm: toYfm[NoteNode.NoteContent],
-            fromYfm: {
+            toMd: toYfm[NoteNode.NoteContent],
+            fromMd: {
                 tokenSpec: fromYfm[NoteNode.NoteContent],
             },
         }));

--- a/src/extensions/yfm/YfmNote/index.ts
+++ b/src/extensions/yfm/YfmNote/index.ts
@@ -41,7 +41,7 @@ export const YfmNote: ExtensionAuto<YfmNoteOptions> = (builder, opts) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [noteAction]: Action;
         }

--- a/src/extensions/yfm/YfmTable/YfmTableSpecs/index.ts
+++ b/src/extensions/yfm/YfmTable/YfmTableSpecs/index.ts
@@ -26,22 +26,22 @@ export const YfmTableSpecs: ExtensionWithOptions<YfmTableSpecsOptions> = (builde
         .configureMd((md) => md.use(yfmTable, {log}))
         .addNode(YfmTableNode.Table, () => ({
             spec: spec[YfmTableNode.Table],
-            toYfm: toYfm[YfmTableNode.Table],
-            fromYfm: {tokenSpec: fromYfm[YfmTableNode.Table]},
+            toMd: toYfm[YfmTableNode.Table],
+            fromMd: {tokenSpec: fromYfm[YfmTableNode.Table]},
         }))
         .addNode(YfmTableNode.Body, () => ({
             spec: spec[YfmTableNode.Body],
-            toYfm: toYfm[YfmTableNode.Body],
-            fromYfm: {tokenSpec: fromYfm[YfmTableNode.Body]},
+            toMd: toYfm[YfmTableNode.Body],
+            fromMd: {tokenSpec: fromYfm[YfmTableNode.Body]},
         }))
         .addNode(YfmTableNode.Row, () => ({
             spec: spec[YfmTableNode.Row],
-            toYfm: toYfm[YfmTableNode.Row],
-            fromYfm: {tokenSpec: fromYfm[YfmTableNode.Row]},
+            toMd: toYfm[YfmTableNode.Row],
+            fromMd: {tokenSpec: fromYfm[YfmTableNode.Row]},
         }))
         .addNode(YfmTableNode.Cell, () => ({
             spec: spec[YfmTableNode.Cell],
-            toYfm: toYfm[YfmTableNode.Cell],
-            fromYfm: {tokenSpec: fromYfm[YfmTableNode.Cell]},
+            toMd: toYfm[YfmTableNode.Cell],
+            fromMd: {tokenSpec: fromYfm[YfmTableNode.Cell]},
         }));
 };

--- a/src/extensions/yfm/YfmTable/index.ts
+++ b/src/extensions/yfm/YfmTable/index.ts
@@ -37,7 +37,7 @@ export const YfmTable: ExtensionWithOptions<YfmTableOptions> = (builder, options
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [action]: Action;
         }

--- a/src/extensions/yfm/YfmTabs/YfmTabsSpecs/index.ts
+++ b/src/extensions/yfm/YfmTabs/YfmTabsSpecs/index.ts
@@ -2,7 +2,7 @@ import log from '@diplodoc/transform/lib/log';
 import yfmPlugin from '@diplodoc/transform/lib/plugins/tabs';
 import {NodeSpec} from 'prosemirror-model';
 
-import type {ExtensionAuto, YENodeSpec} from '../../../../core';
+import type {ExtensionAuto, WENodeSpec} from '../../../../core';
 import {nodeTypeFactory} from '../../../../utils/schema';
 
 import {TabsNode} from './const';
@@ -21,10 +21,10 @@ export type YfmTabsSpecsOptions = {
      * @deprecated: use placeholder option in BehaviorPreset instead.
      */
     tabPlaceholder?: NonNullable<NodeSpec['placeholder']>['content'];
-    tabView?: YENodeSpec['view'];
-    tabsListView?: YENodeSpec['view'];
-    tabPanelView?: YENodeSpec['view'];
-    tabsView?: YENodeSpec['view'];
+    tabView?: WENodeSpec['view'];
+    tabsListView?: WENodeSpec['view'];
+    tabPanelView?: WENodeSpec['view'];
+    tabsView?: WENodeSpec['view'];
 };
 
 export const YfmTabsSpecs: ExtensionAuto<YfmTabsSpecsOptions> = (builder, opts) => {
@@ -34,8 +34,8 @@ export const YfmTabsSpecs: ExtensionAuto<YfmTabsSpecsOptions> = (builder, opts) 
         .configureMd((md) => md.use(yfmPlugin, {log}))
         .addNode(TabsNode.Tab, () => ({
             spec: spec[TabsNode.Tab],
-            toYfm: toYfm[TabsNode.Tab],
-            fromYfm: {
+            toMd: toYfm[TabsNode.Tab],
+            fromMd: {
                 tokenSpec: fromYfm[TabsNode.Tab],
                 tokenName: 'tab',
             },
@@ -43,8 +43,8 @@ export const YfmTabsSpecs: ExtensionAuto<YfmTabsSpecsOptions> = (builder, opts) 
         }))
         .addNode(TabsNode.TabsList, () => ({
             spec: spec[TabsNode.TabsList],
-            toYfm: toYfm[TabsNode.TabsList],
-            fromYfm: {
+            toMd: toYfm[TabsNode.TabsList],
+            fromMd: {
                 tokenSpec: fromYfm[TabsNode.TabsList],
                 tokenName: 'tab-list',
             },
@@ -52,8 +52,8 @@ export const YfmTabsSpecs: ExtensionAuto<YfmTabsSpecsOptions> = (builder, opts) 
         }))
         .addNode(TabsNode.TabPanel, () => ({
             spec: spec[TabsNode.TabPanel],
-            toYfm: toYfm[TabsNode.TabPanel],
-            fromYfm: {
+            toMd: toYfm[TabsNode.TabPanel],
+            fromMd: {
                 tokenSpec: fromYfm[TabsNode.TabPanel],
                 tokenName: 'tab-panel',
             },
@@ -61,8 +61,8 @@ export const YfmTabsSpecs: ExtensionAuto<YfmTabsSpecsOptions> = (builder, opts) 
         }))
         .addNode(TabsNode.Tabs, () => ({
             spec: spec[TabsNode.Tabs],
-            toYfm: toYfm[TabsNode.Tabs],
-            fromYfm: {
+            toMd: toYfm[TabsNode.Tabs],
+            fromMd: {
                 tokenSpec: fromYfm[TabsNode.Tabs],
                 tokenName: 'tabs',
             },

--- a/src/extensions/yfm/YfmTabs/YfmTabsSpecs/index.ts
+++ b/src/extensions/yfm/YfmTabs/YfmTabsSpecs/index.ts
@@ -2,7 +2,7 @@ import log from '@diplodoc/transform/lib/log';
 import yfmPlugin from '@diplodoc/transform/lib/plugins/tabs';
 import {NodeSpec} from 'prosemirror-model';
 
-import type {ExtensionAuto, WENodeSpec} from '../../../../core';
+import type {ExtensionAuto, ExtensionNodeSpec} from '../../../../core';
 import {nodeTypeFactory} from '../../../../utils/schema';
 
 import {TabsNode} from './const';
@@ -21,10 +21,10 @@ export type YfmTabsSpecsOptions = {
      * @deprecated: use placeholder option in BehaviorPreset instead.
      */
     tabPlaceholder?: NonNullable<NodeSpec['placeholder']>['content'];
-    tabView?: WENodeSpec['view'];
-    tabsListView?: WENodeSpec['view'];
-    tabPanelView?: WENodeSpec['view'];
-    tabsView?: WENodeSpec['view'];
+    tabView?: ExtensionNodeSpec['view'];
+    tabsListView?: ExtensionNodeSpec['view'];
+    tabPanelView?: ExtensionNodeSpec['view'];
+    tabsView?: ExtensionNodeSpec['view'];
 };
 
 export const YfmTabsSpecs: ExtensionAuto<YfmTabsSpecsOptions> = (builder, opts) => {

--- a/src/extensions/yfm/YfmTabs/index.ts
+++ b/src/extensions/yfm/YfmTabs/index.ts
@@ -39,7 +39,7 @@ export const YfmTabs: ExtensionAuto = (builder) => {
 };
 
 declare global {
-    namespace YfmEditor {
+    namespace WysiwygEditor {
         interface Actions {
             [actionName]: Action;
         }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,7 @@
 const noop = () => {};
 
 declare global {
-    namespace YfmEditorLogger {
+    namespace MdEditorLogger {
         type MetricsData = {
             component: string;
             event: string;
@@ -28,8 +28,8 @@ declare global {
     }
 }
 
-class Logger implements YfmEditorLogger.Logger {
-    #logger: YfmEditorLogger.Logger = this.createLogger({});
+class Logger implements MdEditorLogger.Logger {
+    #logger: MdEditorLogger.Logger = this.createLogger({});
 
     get log() {
         return this.#logger.log;
@@ -55,7 +55,7 @@ class Logger implements YfmEditorLogger.Logger {
         return this.#logger.action;
     }
 
-    setLogger(settings: YfmEditorLogger.Settings = {}) {
+    setLogger(settings: MdEditorLogger.Settings = {}) {
         this.#logger = this.createLogger(settings);
     }
 
@@ -64,7 +64,7 @@ class Logger implements YfmEditorLogger.Logger {
      *
      * To override the default logger, use setLogger
      */
-    createLogger(settings: YfmEditorLogger.Settings): YfmEditorLogger.Logger {
+    createLogger(settings: MdEditorLogger.Settings): MdEditorLogger.Logger {
         return {
             log: settings.log ?? noop,
             info: settings.info ?? noop,


### PR DESCRIPTION
Rename:
- `YfmEditor` namespace to `WysiwygEditor` namespace
- `YfmEditorOptions` type and `YfmEditor` class to `WysiwygEditorOptions` and `WysiwygEditor`
- `YENodeSpec` and `YEMarkSpec` types to `ExtensionNodeSpec` and `ExtensionMarkSpec`
- `ExtensionNodeSpec.fromYfm` and `ExtensionMarkSpec.fromYfm` to `ExtensionNodeSpec.fromMd` and `ExtensionMarkSpec.fromMd`
- `ExtensionNodeSpec.toYfm` and `ExtensionMarkSpec.toYfm` to `ExtensionNodeSpec.toMd` and `ExtensionMarkSpec.toMd`
- `YfmEditorLogger` namespace to `MdEditorLogger` namespace