### PR TITLE
feat(bundle)!: rename editorType ––> editorMode

### DIFF
--- a/demo/PMSelection.tsx
+++ b/demo/PMSelection.tsx
@@ -16,7 +16,7 @@ export function WysiwygSelection({editor, className}: WysiwygSelectionProps) {
         rerender();
     });
 
-    const view = editor?.currentType === 'wysiwyg' && editor._wysiwygView;
+    const view = editor?.currentMode === 'wysiwyg' && editor._wysiwygView;
 
     React.useLayoutEffect(() => {
         if (!editor) return undefined;
@@ -25,14 +25,14 @@ export function WysiwygSelection({editor, className}: WysiwygSelectionProps) {
             'rerender-toolbar',
             rerender,
         );
-        editor.on('change-editor-type', rerender);
+        editor.on('change-editor-mode', rerender);
         return () => {
             editor.off(
                 // @ts-expect-error TODO: add public event for selection change
                 'rerender-toolbar',
                 rerender,
             );
-            editor.off('change-editor-type', rerender);
+            editor.off('change-editor-mode', rerender);
         };
     }, [editor, rerender]);
 

--- a/demo/Playground.tsx
+++ b/demo/Playground.tsx
@@ -5,7 +5,7 @@ import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
 
 import {MarkupString, logger} from '../src';
 import {
-    MarkdownEditorType,
+    MarkdownEditorMode,
     MarkdownEditorView,
     markupToolbarConfigs,
     useMarkdownEditor,
@@ -54,7 +54,7 @@ export type PlaygroundProps = {
     initial?: MarkupString;
     allowHTML?: boolean;
     settingsVisible?: boolean;
-    initialEditor?: MarkdownEditorType;
+    initialEditor?: MarkdownEditorMode;
     breaks?: boolean;
     linkify?: boolean;
     linkifyTlds?: string | string[];
@@ -90,7 +90,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
         renderPreviewDefined,
         height,
     } = props;
-    const [editorType, setEditorType] = React.useState<MarkdownEditorType>(
+    const [editorMode, setEditorMode] = React.useState<MarkdownEditorMode>(
         initialEditor ?? 'wysiwyg',
     );
     const [mdRaw, setMdRaw] = React.useState<MarkupString>(initial || '');
@@ -120,7 +120,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
         linkifyTlds,
         initialMarkup: mdRaw,
         breaks: breaks ?? true,
-        initialEditorType: editorType,
+        initialEditorMode: editorMode,
         initialSplitModeEnabled: initialSplitModeEnabled,
         initialToolbarVisible: true,
         splitMode: splitModeOrientation,
@@ -166,10 +166,10 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
         function onChange() {
             setMdRaw(mdEditor.getValue());
         }
-        function onChangeEditorType({type}: {type: MarkdownEditorType}) {
-            setEditorType(type);
+        function onChangeEditorType({mode}: {mode: MarkdownEditorMode}) {
+            setEditorMode(mode);
         }
-        const onToolbarAction = ({id, editorType: type}: ToolbarActionData) => {
+        const onToolbarAction = ({id, editorMode: type}: ToolbarActionData) => {
             console.info(`The '${id}' action is performed in the ${type}-editor.`);
         };
         function onChangeSplitModeEnabled({splitModeEnabled}: {splitModeEnabled: boolean}) {
@@ -183,7 +183,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
         mdEditor.on('submit', onSubmit);
         mdEditor.on('change', onChange);
         mdEditor.on('toolbar-action', onToolbarAction);
-        mdEditor.on('change-editor-type', onChangeEditorType);
+        mdEditor.on('change-editor-mode', onChangeEditorType);
         mdEditor.on('change-split-mode-enabled', onChangeSplitModeEnabled);
         mdEditor.on('change-toolbar-visibility', onChangeToolbarVisibility);
 
@@ -192,7 +192,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
             mdEditor.off('submit', onSubmit);
             mdEditor.off('change', onChange);
             mdEditor.off('toolbar-action', onToolbarAction);
-            mdEditor.off('change-editor-type', onChangeEditorType);
+            mdEditor.off('change-editor-mode', onChangeEditorType);
             mdEditor.off('change-split-mode-enabled', onChangeSplitModeEnabled);
             mdEditor.off('change-toolbar-visibility', onChangeToolbarVisibility);
         };
@@ -283,7 +283,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
             <hr />
 
             <div className={b('preview')}>
-                {editorType === 'wysiwyg' && <pre className={b('markup')}>{mdRaw}</pre>}
+                {editorMode === 'wysiwyg' && <pre className={b('markup')}>{mdRaw}</pre>}
             </div>
         </div>
     );

--- a/demo/ProseMirrorDevTools.tsx
+++ b/demo/ProseMirrorDevTools.tsx
@@ -16,13 +16,13 @@ export function WysiwygDevTools({editor}: WysiwygDevToolsProps) {
         rerender();
     });
 
-    const view = editor?.currentType === 'wysiwyg' && editor._wysiwygView;
+    const view = editor?.currentMode === 'wysiwyg' && editor._wysiwygView;
 
     React.useLayoutEffect(() => {
         if (!editor) return undefined;
-        editor.on('change-editor-type', rerender);
+        editor.on('change-editor-mode', rerender);
         return () => {
-            editor.off('change-editor-type', rerender);
+            editor.off('change-editor-mode', rerender);
         };
     }, [editor, rerender]);
 

--- a/demo/editor-in-editor/EditorInEditorExtension/index.tsx
+++ b/demo/editor-in-editor/EditorInEditorExtension/index.tsx
@@ -108,7 +108,7 @@ type YfmEditorProps = {
 function InnerEditor({initialContent, toaster}: YfmEditorProps) {
     const mdEditor = useMarkdownEditor({
         initialMarkup: initialContent,
-        initialEditorType: 'wysiwyg',
+        initialEditorMode: 'wysiwyg',
         initialToolbarVisible: true,
         linkify: true,
         breaks: true,

--- a/demo/editor-in-editor/index.tsx
+++ b/demo/editor-in-editor/index.tsx
@@ -17,7 +17,7 @@ const b = block('playground');
 
 export const PlaygroundEditorInEditor: React.FC = () => {
     const mdEditor = useMarkdownEditor({
-        initialEditorType: 'wysiwyg',
+        initialEditorMode: 'wysiwyg',
         initialToolbarVisible: true,
         allowHTML: false,
         linkify: true,

--- a/src/bundle/MarkdownEditorView.tsx
+++ b/src/bundle/MarkdownEditorView.tsx
@@ -12,7 +12,7 @@ import {ToasterContext} from '../react-utils/toaster';
 import {useSticky} from '../react-utils/useSticky';
 import {isMac} from '../utils/platform';
 
-import type {Editor, EditorInt, EditorType} from './Editor';
+import type {Editor, EditorInt, EditorMode} from './Editor';
 import {HorizontalDrag} from './HorizontalDrag';
 import {MarkupEditorView} from './MarkupEditorView';
 import {SplitModeView} from './SplitModeView';
@@ -81,8 +81,8 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
         }, [editor, rerender]);
 
         const onModeChange = React.useCallback(
-            (type: EditorType) => {
-                editor.changeEditorType({type, reason: 'settings'});
+            (type: EditorMode) => {
+                editor.changeEditorMode({mode: type, reason: 'settings'});
                 unsetShowPreview();
             },
             [editor, unsetShowPreview],
@@ -109,18 +109,18 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
             [editor, showPreview, toggleShowPreview],
         );
 
-        const editorType = editor.currentType;
+        const editorMode = editor.currentMode;
         const markupSplitMode =
-            editor.splitModeEnabled && editor.splitMode && editorType === 'markup';
+            editor.splitModeEnabled && editor.splitMode && editorMode === 'markup';
         const canRenderPreview = Boolean(
-            editor.renderPreview && editorType === 'markup' && !editor.splitModeEnabled,
+            editor.renderPreview && editorMode === 'markup' && !editor.splitModeEnabled,
         );
 
         useKey(
             (e) => canRenderPreview && isPreviewKeyDown(e),
             () => onShowPreviewChange(!showPreview),
             {event: 'keydown'},
-            [showPreview, editorType, onShowPreviewChange, canRenderPreview],
+            [showPreview, editorMode, onShowPreviewChange, canRenderPreview],
         );
 
         const editorWrapperRef = useRef(null);
@@ -129,7 +129,7 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
         const settings = useMemo(
             () => (
                 <Settings
-                    mode={editorType}
+                    mode={editorMode}
                     onModeChange={onModeChange}
                     toolbarVisibility={editor.toolbarVisible && !showPreview}
                     onToolbarVisibilityChange={onToolbarVisibilityChange}
@@ -148,7 +148,7 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
                 editor.splitMode,
                 editor.splitModeEnabled,
                 editor.toolbarVisible,
-                editorType,
+                editorMode,
                 onModeChange,
                 onShowPreviewChange,
                 onSplitModeChange,
@@ -171,7 +171,7 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
                     });
                     setTimeout(() => {
                         resetErrorBoundary();
-                        editor.changeEditorType({type: 'markup', reason: 'error-boundary'});
+                        editor.changeEditorMode({mode: 'markup', reason: 'error-boundary'});
                     });
                     return null;
                 }}
@@ -200,7 +200,7 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
                                 </>
                             ) : (
                                 <>
-                                    {editorType === 'wysiwyg' && (
+                                    {editorMode === 'wysiwyg' && (
                                         <WysiwygEditorView
                                             editor={editor}
                                             autofocus={autofocus}
@@ -208,14 +208,14 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
                                             toolbarConfig={wysiwygToolbarConfig}
                                             toolbarVisible={editor.toolbarVisible}
                                             hiddenActionsConfig={wysiwygHiddenActionsConfig}
-                                            className={b('editor', {type: editorType})}
+                                            className={b('editor', {mode: editorMode})}
                                             toolbarClassName={b('toolbar')}
                                             stickyToolbar={stickyToolbar}
                                         >
                                             {editor.toolbarVisible && settingsVisible && settings}
                                         </WysiwygEditorView>
                                     )}
-                                    {editorType === 'markup' && (
+                                    {editorMode === 'markup' && (
                                         <MarkupEditorView
                                             editor={editor}
                                             autofocus={autofocus}
@@ -225,7 +225,7 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
                                             splitMode={editor.splitMode}
                                             splitModeEnabled={editor.splitModeEnabled}
                                             hiddenActionsConfig={markupHiddenActionsConfig}
-                                            className={b('editor', {type: editorType})}
+                                            className={b('editor', {mode: editorMode})}
                                             toolbarClassName={b('toolbar')}
                                             stickyToolbar={stickyToolbar}
                                         >

--- a/src/bundle/MarkupEditorView.tsx
+++ b/src/bundle/MarkupEditorView.tsx
@@ -62,7 +62,7 @@ export const MarkupEditorView = React.memo<MarkupEditorViewProps>((props) => {
                 >
                     <ToolbarView
                         editor={editor}
-                        editorType="markup"
+                        editorMode="markup"
                         toolbarEditor={editor}
                         hiddenActionsConfig={hiddenActionsConfig}
                         stickyToolbar={stickyToolbar}

--- a/src/bundle/ToolbarView.tsx
+++ b/src/bundle/ToolbarView.tsx
@@ -7,12 +7,12 @@ import {i18n} from '../i18n/menubar';
 import {useSticky} from '../react-utils/useSticky';
 import {FlexToolbar, ToolbarData, ToolbarItemData} from '../toolbar';
 
-import type {EditorInt, EditorType} from './Editor';
+import type {EditorInt, EditorMode} from './Editor';
 import {stickyCn} from './sticky';
 
 export type ToolbarViewProps<T> = ClassNameProps & {
     editor: EditorInt;
-    editorType: EditorType;
+    editorMode: EditorMode;
     toolbarEditor: T;
     toolbarFocus: () => void;
     toolbarConfig: ToolbarData<T>;
@@ -24,7 +24,7 @@ export type ToolbarViewProps<T> = ClassNameProps & {
 
 export function ToolbarView<T>({
     editor,
-    editorType,
+    editorMode,
     toolbarEditor,
     toolbarFocus,
     toolbarConfig,
@@ -63,7 +63,7 @@ export function ToolbarView<T>({
                 editor={toolbarEditor}
                 focus={toolbarFocus}
                 dotsTitle={i18n('more_action')}
-                onClick={(id, attrs) => editor.emit('toolbar-action', {id, attrs, editorType})}
+                onClick={(id, attrs) => editor.emit('toolbar-action', {id, attrs, editorMode})}
             />
             {children}
         </div>

--- a/src/bundle/WysiwygEditorView.tsx
+++ b/src/bundle/WysiwygEditorView.tsx
@@ -51,7 +51,7 @@ export const WysiwygEditorView = React.memo<WysiwygEditorViewProps>((props) => {
             {toolbarVisible ? (
                 <ToolbarView
                     editor={editor}
-                    editorType="wysiwyg"
+                    editorMode="wysiwyg"
                     toolbarEditor={editor}
                     stickyToolbar={stickyToolbar}
                     toolbarConfig={toolbarConfig}

--- a/src/bundle/index.ts
+++ b/src/bundle/index.ts
@@ -1,5 +1,5 @@
 export type {ExtensionsOptions} from './wysiwyg-preset';
-export type {Editor, EditorType as MarkdownEditorType, RenderPreview, SplitMode} from './Editor';
+export type {Editor, EditorMode as MarkdownEditorMode, RenderPreview, SplitMode} from './Editor';
 export * from './context';
 export * from './useMarkdownEditor';
 export * from './MarkdownEditorView';

--- a/src/bundle/settings/index.tsx
+++ b/src/bundle/settings/index.tsx
@@ -21,7 +21,7 @@ import {noop} from '../../lodash';
 import {useBooleanState} from '../../react-utils/hooks';
 import {ToolbarTooltipDelay} from '../../toolbar';
 import {VERSION} from '../../version';
-import type {EditorType, SplitMode} from '../Editor';
+import type {EditorMode, SplitMode} from '../Editor';
 
 import {MarkdownHints} from './MarkdownHints';
 
@@ -86,8 +86,8 @@ export const EditorSettings = React.memo<EditorSettingsProps>(function EditorSet
 });
 
 type SettingsContentProps = ClassNameProps & {
-    mode: EditorType;
-    onModeChange: (mode: EditorType) => void;
+    mode: EditorMode;
+    onModeChange: (mode: EditorMode) => void;
     onShowPreviewChange: (showPreview: boolean) => void;
     showPreview: boolean;
     toolbarVisibility: boolean;

--- a/src/bundle/useMarkdownEditor.ts
+++ b/src/bundle/useMarkdownEditor.ts
@@ -4,7 +4,7 @@ import {Extension} from '../core';
 import {ReactRenderStorage} from '../extensions';
 import {logger} from '../logger';
 
-import {Editor, EditorImpl, EditorInt, EditorOptions, EditorType} from './Editor';
+import {Editor, EditorImpl, EditorInt, EditorMode, EditorOptions} from './Editor';
 import {BundlePreset, ExtensionsOptions} from './wysiwyg-preset';
 
 export type UseMarkdownEditorProps<T extends object = {}> = Omit<
@@ -59,8 +59,8 @@ export function useMarkdownEditor<T extends object = {}>(
     );
 
     useLayoutEffect(() => {
-        function onToolbarAction({editorType, id}: {editorType: EditorType; id: string}) {
-            logger.action({mode: editorType, source: 'toolbar', action: id});
+        function onToolbarAction({editorMode, id}: {editorMode: EditorMode; id: string}) {
+            logger.action({mode: editorMode, source: 'toolbar', action: id});
         }
 
         editor.on('toolbar-action', onToolbarAction);


### PR DESCRIPTION
Renamed:
- type `MarkdownEditorType` ––> `MarkdownEditorMode`
- event name `editor.on('change-editor-type', ...)` ––> `editor.on('change-editor-mode', ...)`
- field of type `ToolbarActionData['editorType']` ––> `ToolbarActionData['editorMode']`
- field of interface `Editor.currentType` ––> `Editor.currentMode`
- method of interface `Editor.setEditorType(...)` ––> `Editor.setEditorMode(...)`
- prop of `useMarkdownEditor` hook: `initialEditorType` ––> `initialEditorMode`