### PR TITLE
feat: add re-export of codemirror core modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
       "require": "./build/cjs/bundle/*",
       "import": "./build/esm/bundle/*"
     },
+    "./cm/*": {
+      "types": "./build/esm/cm/*",
+      "require": "./build/cjs/cm/*",
+      "import": "./build/esm/cm/*"
+    },
     "./pm/*": {
       "types": "./build/esm/pm/*",
       "require": "./build/cjs/pm/*",
@@ -108,6 +113,9 @@
       ],
       "specs": [
         "./build/esm/extensions/specs.d.ts"
+      ],
+      "cm/*": [
+        "./build/esm/cm/*"
       ],
       "pm/*": [
         "./build/esm/pm/*"

--- a/src/cm/autocomplete.ts
+++ b/src/cm/autocomplete.ts
@@ -1,0 +1,1 @@
+export * from '@codemirror/autocomplete';

--- a/src/cm/commands.ts
+++ b/src/cm/commands.ts
@@ -1,0 +1,1 @@
+export * from '@codemirror/commands';

--- a/src/cm/language.ts
+++ b/src/cm/language.ts
@@ -1,0 +1,1 @@
+export * from '@codemirror/language';

--- a/src/cm/readme.md
+++ b/src/cm/readme.md
@@ -1,0 +1,15 @@
+## CM submodule
+
+### Re-exports codemirror core modules:
+
+- [@codemirror/autocomplete](https://github.com/codemirror/autocomplete)
+- [@codemirror/commands](https://github.com/codemirror/commands)
+- [@codemirror/language](https://github.com/codemirror/language)
+- [@codemirror/state](https://github.com/codemirror/state)
+- [@codemirror/view](https://github.com/codemirror/view)
+
+### Usage
+
+```js
+import {EditorView} from '@gravity-ui/markdown-editor/cm/view';
+```

--- a/src/cm/state.ts
+++ b/src/cm/state.ts
@@ -1,0 +1,1 @@
+export * from '@codemirror/state';

--- a/src/cm/view.ts
+++ b/src/cm/view.ts
@@ -1,0 +1,1 @@
+export * from '@codemirror/view';

--- a/src/pm/readme.md
+++ b/src/pm/readme.md
@@ -15,3 +15,9 @@
 
 - [prosemirror-utils](https://github.com/atlassian/prosemirror-utils)
 - [prosemirror-test-builder](https://github.com/ProseMirror/prosemirror-test-builder)
+
+### Usage
+
+```js
+import {EditorView} from '@gravity-ui/markdown-editor/pm/view';
+```


### PR DESCRIPTION
Added submodule `@gravity-ui/markdown-editor/cm/*` with re-export of core codemirror modules