### PR TITLE
feat: add i18n submodule

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
       "require": "./build/cjs/core/index.js",
       "import": "./build/esm/core/index.js"
     },
+    "./i18n": {
+      "types": "./build/esm/i18n/i18n.d.ts",
+      "require": "./build/cjs/i18n/i18n.js",
+      "import": "./build/esm/i18n/i18n.js"
+    },
     "./specs": {
       "types": "./build/esm/extensions/specs.d.ts",
       "require": "./build/cjs/extensions/specs.js",
@@ -110,6 +115,9 @@
       ],
       "core": [
         "./build/esm/core/index.d.ts"
+      ],
+      "i18n": [
+        "./build/esm/i18n/i18n.d.ts"
       ],
       "specs": [
         "./build/esm/extensions/specs.d.ts"


### PR DESCRIPTION
Added `@gravity-ui/markdown-editor/i18n` submodule, which exports an instance of `i18n` and function `registerKeyset`.

This can be useful for packages with editor extensions.