### PR TITLE
fix(Lists): preserve markup of list items

### DIFF
--- a/src/core/markdown/MarkdownSerializer.js
+++ b/src/core/markdown/MarkdownSerializer.js
@@ -286,7 +286,7 @@ export class MarkdownSerializerState {
         this.inTightList = isTight;
         node.forEach((child, _, i) => {
             if (i && isTight) this.flushClose(1);
-            this.wrapBlock(delim, firstDelim(i), node, () => this.render(child, node, i));
+            this.wrapBlock(delim, firstDelim(i, child), node, () => this.render(child, node, i));
         });
         this.inTightList = prevTight;
     }

--- a/src/extensions/markdown/Lists/Lists.test.ts
+++ b/src/extensions/markdown/Lists/Lists.test.ts
@@ -4,7 +4,7 @@ import {createMarkupChecker} from '../../../../tests/sameMarkup';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchemaSpecs} from '../../base/specs';
 
-import {ListNode, ListsSpecs} from './ListsSpecs';
+import {ListNode, ListsAttr, ListsSpecs} from './ListsSpecs';
 
 const {
     schema,
@@ -26,35 +26,94 @@ const {same} = createMarkupChecker({parser, serializer});
 
 describe('Lists extension', () => {
     it('should parse bullet list', () => {
-        same('* one\n\n* two', doc(ul(li(p('one')), li(p('two')))));
+        same(
+            '* one\n\n* two',
+            doc(
+                ul(
+                    {[ListsAttr.Bullet]: '*'},
+                    li({[ListsAttr.Markup]: '*'}, p('one')),
+                    li({[ListsAttr.Markup]: '*'}, p('two')),
+                ),
+            ),
+        );
     });
 
     it('should parse ordered list', () => {
-        same('1. one\n\n2. two', doc(ol(li(p('one')), li(p('two')))));
+        same(
+            '1. one\n\n2. two',
+            doc(
+                ol(
+                    li({[ListsAttr.Markup]: '.'}, p('one')),
+                    li({[ListsAttr.Markup]: '.'}, p('two')),
+                ),
+            ),
+        );
     });
 
     it('should parse nested lists', () => {
         const markup = `
-* one
+- one
 
   1. two
 
-     * three
+     + three
 
   2. four
 
-* five
+- five
         `.trim();
 
         same(
             markup,
             doc(
                 ul(
+                    {[ListsAttr.Bullet]: '-'},
                     li(
+                        {[ListsAttr.Markup]: '-'},
                         p('one'),
-                        ol(li(p('two'), ul({tight: true}, li(p('three')))), li(p('four'))),
+                        ol(
+                            li(
+                                {[ListsAttr.Markup]: '.'},
+                                p('two'),
+                                ul(
+                                    {[ListsAttr.Tight]: true, [ListsAttr.Bullet]: '+'},
+                                    li({[ListsAttr.Markup]: '+'}, p('three')),
+                                ),
+                            ),
+                            li({[ListsAttr.Markup]: '.'}, p('four')),
+                        ),
                     ),
-                    li(p('five')),
+                    li({[ListsAttr.Markup]: '-'}, p('five')),
+                ),
+            ),
+        );
+    });
+
+    it('should parse nested lists 2', () => {
+        same(
+            '- + * 2. item',
+            doc(
+                ul(
+                    {[ListsAttr.Bullet]: '-'},
+                    li(
+                        {[ListsAttr.Markup]: '-'},
+                        ul(
+                            {[ListsAttr.Bullet]: '+'},
+                            li(
+                                {[ListsAttr.Markup]: '+'},
+                                ul(
+                                    {[ListsAttr.Bullet]: '*'},
+                                    li(
+                                        {[ListsAttr.Markup]: '*'},
+                                        ol(
+                                            {[ListsAttr.Order]: 2, [ListsAttr.Tight]: true},
+                                            li({[ListsAttr.Markup]: '.'}, p('item')),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
                 ),
             ),
         );

--- a/src/extensions/markdown/Lists/ListsSpecs/const.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/const.ts
@@ -3,3 +3,13 @@ export enum ListNode {
     BulletList = 'bullet_list',
     OrderedList = 'ordered_list',
 }
+
+export enum ListsAttr {
+    Tight = 'tight',
+    /** used in bullet list only */
+    Bullet = 'bullet',
+    /** used in ordered list only */
+    Order = 'order',
+    /** used in list item only */
+    Markup = 'markup',
+}

--- a/src/extensions/markdown/Lists/ListsSpecs/index.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/index.ts
@@ -6,7 +6,7 @@ import {parserTokens} from './parser';
 import {schemaSpecs} from './schema';
 import {serializerTokens} from './serializer';
 
-export {ListNode} from './const';
+export {ListsAttr, ListNode} from './const';
 export const liType = nodeTypeFactory(ListNode.ListItem);
 export const blType = nodeTypeFactory(ListNode.BulletList);
 export const olType = nodeTypeFactory(ListNode.OrderedList);

--- a/src/extensions/markdown/Lists/ListsSpecs/parser.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/parser.ts
@@ -2,23 +2,30 @@ import type Token from 'markdown-it/lib/token';
 
 import type {ParserToken} from '../../../../core';
 
-import {ListNode} from './const';
+import {ListNode, ListsAttr} from './const';
 
 export const parserTokens: Record<ListNode, ParserToken> = {
-    [ListNode.ListItem]: {name: ListNode.ListItem, type: 'block'},
+    [ListNode.ListItem]: {
+        name: ListNode.ListItem,
+        type: 'block',
+        getAttrs: (token) => ({[ListsAttr.Markup]: token.markup}),
+    },
 
     [ListNode.BulletList]: {
         name: ListNode.BulletList,
         type: 'block',
-        getAttrs: (_, tokens, i) => ({tight: listIsTight(tokens, i)}),
+        getAttrs: (token, tokens, i) => ({
+            [ListsAttr.Tight]: listIsTight(tokens, i),
+            [ListsAttr.Bullet]: token.markup,
+        }),
     },
 
     [ListNode.OrderedList]: {
         name: ListNode.OrderedList,
         type: 'block',
-        getAttrs: (tok, tokens, i) => ({
-            order: Number(tok.attrGet('start')) || 1,
-            tight: listIsTight(tokens, i),
+        getAttrs: (token, tokens, i) => ({
+            [ListsAttr.Order]: Number(token.attrGet('start')) || 1,
+            [ListsAttr.Tight]: listIsTight(tokens, i),
         }),
     },
 };

--- a/src/extensions/markdown/Lists/ListsSpecs/schema.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/schema.ts
@@ -1,10 +1,10 @@
 import type {NodeSpec} from 'prosemirror-model';
 
-import {ListNode} from './const';
+import {ListNode, ListsAttr} from './const';
 
 export const schemaSpecs: Record<ListNode, NodeSpec> = {
     [ListNode.ListItem]: {
-        attrs: {tight: {default: false}},
+        attrs: {[ListsAttr.Tight]: {default: false}, [ListsAttr.Markup]: {default: null}},
         content: '(paragraph|block)+',
         defining: true,
         parseDOM: [{tag: 'li'}],
@@ -20,15 +20,17 @@ export const schemaSpecs: Record<ListNode, NodeSpec> = {
     [ListNode.BulletList]: {
         content: `${ListNode.ListItem}+`,
         group: 'block',
-        attrs: {tight: {default: false}},
+        attrs: {[ListsAttr.Tight]: {default: false}, [ListsAttr.Bullet]: {default: '*'}},
         parseDOM: [
             {
                 tag: 'ul',
-                getAttrs: (dom) => ({tight: (dom as HTMLElement).hasAttribute('data-tight')}),
+                getAttrs: (dom) => ({
+                    [ListsAttr.Tight]: (dom as HTMLElement).hasAttribute('data-tight'),
+                }),
             },
         ],
         toDOM(node) {
-            return ['ul', {'data-tight': node.attrs.tight ? 'true' : null}, 0];
+            return ['ul', {'data-tight': node.attrs[ListsAttr.Tight] ? 'true' : null}, 0];
         },
         selectable: false,
         allowSelection: false,
@@ -36,7 +38,7 @@ export const schemaSpecs: Record<ListNode, NodeSpec> = {
     },
 
     [ListNode.OrderedList]: {
-        attrs: {order: {default: 1}, tight: {default: false}},
+        attrs: {[ListsAttr.Order]: {default: 1}, [ListsAttr.Tight]: {default: false}},
         content: `${ListNode.ListItem}+`,
         group: 'block',
         parseDOM: [
@@ -44,10 +46,10 @@ export const schemaSpecs: Record<ListNode, NodeSpec> = {
                 tag: 'ol',
                 getAttrs(dom) {
                     return {
-                        order: (dom as HTMLElement).hasAttribute('start')
+                        [ListsAttr.Order]: (dom as HTMLElement).hasAttribute('start')
                             ? Number((dom as HTMLElement).getAttribute('start')!)
                             : 1,
-                        tight: (dom as HTMLElement).hasAttribute('data-tight'),
+                        [ListsAttr.Tight]: (dom as HTMLElement).hasAttribute('data-tight'),
                     };
                 },
             },
@@ -56,8 +58,8 @@ export const schemaSpecs: Record<ListNode, NodeSpec> = {
             return [
                 'ol',
                 {
-                    start: node.attrs.order === 1 ? null : node.attrs.order,
-                    'data-tight': node.attrs.tight ? 'true' : null,
+                    start: node.attrs[ListsAttr.Order] === 1 ? null : node.attrs[ListsAttr.Order],
+                    'data-tight': node.attrs[ListsAttr.Tight] ? 'true' : null,
                 },
                 0,
             ];

--- a/src/extensions/markdown/Lists/ListsSpecs/serializer.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/serializer.ts
@@ -1,6 +1,8 @@
+import type {Node} from 'prosemirror-model';
+
 import type {SerializerNodeToken} from '../../../../core';
 
-import {ListNode} from './const';
+import {ListNode, ListsAttr} from './const';
 
 export const serializerTokens: Record<ListNode, SerializerNodeToken> = {
     [ListNode.ListItem]: (state, node) => {
@@ -8,11 +10,16 @@ export const serializerTokens: Record<ListNode, SerializerNodeToken> = {
     },
 
     [ListNode.BulletList]: (state, node) => {
-        state.renderList(node, '  ', () => (node.attrs.bullet || '*') + ' ');
+        state.renderList(
+            node,
+            '  ',
+            (_i: number, li: Node) =>
+                (li.attrs[ListsAttr.Markup] || node.attrs[ListsAttr.Bullet] || '*') + ' ',
+        );
     },
 
     [ListNode.OrderedList]: (state, node) => {
-        const start = node.attrs.order || 1;
+        const start = node.attrs[ListsAttr.Order] || 1;
         const maxW = String(start + node.childCount - 1).length;
         const space = state.repeat(' ', maxW + 2);
         state.renderList(node, space, (i: number) => {

--- a/src/extensions/markdown/Lists/index.ts
+++ b/src/extensions/markdown/Lists/index.ts
@@ -11,7 +11,7 @@ import {ListAction} from './const';
 import {ListsInputRulesExtension, ListsInputRulesOptions} from './inputrules';
 import {mergeListsPlugin} from './plugins/MergeListsPlugin';
 
-export {ListNode, blType, liType, olType} from './ListsSpecs';
+export {ListNode, ListsAttr, blType, liType, olType} from './ListsSpecs';
 
 export type ListsOptions = {
     ulKey?: string | null;

--- a/src/extensions/markdown/Lists/inputrules.ts
+++ b/src/extensions/markdown/Lists/inputrules.ts
@@ -3,6 +3,7 @@ import type {NodeType} from 'prosemirror-model';
 import type {ExtensionWithOptions} from '../../../core';
 import {wrappingInputRule} from '../../../utils/inputrules';
 
+import {ListsAttr} from './ListsSpecs';
 import {blType, olType} from './utils';
 
 export type ListsInputRulesOptions = {
@@ -31,8 +32,8 @@ export function orderedListRule(nodeType: NodeType) {
     return wrappingInputRule(
         /^(\d+)\.\s$/,
         nodeType,
-        (match) => ({order: Number(match[1])}),
-        (match, node) => node.childCount + node.attrs.order === Number(match[1]),
+        (match) => ({[ListsAttr.Order]: Number(match[1])}),
+        (match, node) => node.childCount + node.attrs[ListsAttr.Order] === Number(match[1]),
     );
 }
 
@@ -58,5 +59,5 @@ export function bulletListRule(nodeType: NodeType, config?: BulletListInputRuleC
     if (bullets.length === 0) return null;
 
     const regexp = new RegExp(`^\\s*([${bullets.join('')}])\\s$`); // same as /^\s*([-+*])\s$/
-    return wrappingInputRule(regexp, nodeType);
+    return wrappingInputRule(regexp, nodeType, (match) => ({[ListsAttr.Bullet]: match[1]}));
 }

--- a/src/extensions/markdown/Lists/plugins/MergeListsPlugin.test.ts
+++ b/src/extensions/markdown/Lists/plugins/MergeListsPlugin.test.ts
@@ -5,7 +5,7 @@ import {EditorView} from 'prosemirror-view';
 import {ExtensionsManager} from '../../../../core';
 import {BaseNode, BaseSchemaSpecs} from '../../../base/specs';
 import {CodeSpecs, codeMarkName} from '../../Code/CodeSpecs';
-import {ListNode, ListsSpecs} from '../ListsSpecs';
+import {ListNode, ListsAttr, ListsSpecs} from '../ListsSpecs';
 
 import {mergeListsPlugin} from './MergeListsPlugin';
 
@@ -48,8 +48,12 @@ describe('Lists extension', () => {
             expect(view.state.doc).toMatchNode(
                 doc(
                     ul(
-                        {tight: true},
+                        {
+                            [ListsAttr.Tight]: true,
+                            [ListsAttr.Bullet]: '+',
+                        },
                         li(
+                            {[ListsAttr.Markup]: '+'},
                             p(
                                 'Create a list by starting a line with ',
                                 c('+'),
@@ -60,17 +64,33 @@ describe('Lists extension', () => {
                             ),
                         ),
                         li(
+                            {[ListsAttr.Markup]: '-'},
                             p('Sub-lists are made by indenting 2 spaces:'),
                             ul(
-                                {tight: true},
-                                li(p('Marker character change forces new list start:')),
-                                li(p('Ac tristique libero volutpat at')),
-                                li(p('Facilisis in pretium nisl aliquet')),
-                                li(p('Nulla volutpat aliquam velit')),
+                                {
+                                    [ListsAttr.Tight]: true,
+                                    [ListsAttr.Bullet]: '-',
+                                },
+                                li(
+                                    {[ListsAttr.Markup]: '-'},
+                                    p('Marker character change forces new list start:'),
+                                ),
+                                li({[ListsAttr.Markup]: '*'}, p('Ac tristique libero volutpat at')),
+                                li(
+                                    {[ListsAttr.Markup]: '+'},
+                                    p('Facilisis in pretium nisl aliquet'),
+                                ),
+                                li({[ListsAttr.Markup]: '-'}, p('Nulla volutpat aliquam velit')),
                             ),
                         ),
                     ),
-                    ul({tight: true}, li(p('Very easy!'))),
+                    ul(
+                        {
+                            [ListsAttr.Tight]: true,
+                            [ListsAttr.Bullet]: '*',
+                        },
+                        li({[ListsAttr.Markup]: '*'}, p('Very easy!')),
+                    ),
                 ),
             );
         });


### PR DESCRIPTION
Before: bullet-lists are always serialized using `*`
Now: preserve bullets (`*`|`-`|`+`)