### PR TITLE
fix(main): fix en yfm syntax documentation link #297

### DIFF
--- a/src/bundle/settings/MarkdownHints/MarkdownHints.tsx
+++ b/src/bundle/settings/MarkdownHints/MarkdownHints.tsx
@@ -8,7 +8,6 @@ import {cn} from '../../../classname';
 import './MarkdownHints.scss';
 
 const b = cn('markdown-hints');
-const YFM_DOCS_HREF = 'https://ydocs.tech';
 
 export const MarkdownHints = React.memo(function MarkdownHints() {
     const hints = [
@@ -35,7 +34,7 @@ export const MarkdownHints = React.memo(function MarkdownHints() {
                 ))}
             </div>
 
-            <Link href={YFM_DOCS_HREF} target="_blank" className={b('docs-link')}>
+            <Link href={i18n('documentation_link')} target="_blank" className={b('docs-link')}>
                 {i18n('documentation')}
             </Link>
         </div>

--- a/src/i18n/md-hints/en.json
+++ b/src/i18n/md-hints/en.json
@@ -19,5 +19,6 @@
   "list_hint": "- Your text",
   "numbered-list_title": "Numbered list",
   "numbered-list_hint": "1. Your text",
-  "documentation": "Documentation"
+  "documentation": "Documentation",
+  "documentation_link": " https://diplodoc.com/docs/en/syntax/"
 }

--- a/src/i18n/md-hints/ru.json
+++ b/src/i18n/md-hints/ru.json
@@ -19,5 +19,6 @@
   "list_hint": "- Ваш текст",
   "numbered-list_title": "Нумерованный список",
   "numbered-list_hint": "1. Ваш текст",
-  "documentation": "Документация"
+  "documentation": "Документация",
+  "documentation_link": " https://diplodoc.com/docs/ru/syntax/"
 }


### PR DESCRIPTION
The fix updates yfm markup link for both locales, and directs to an overview page in docs.