### PR TITLE
fix(YfmTable): revert serialization logic for yfm-table row and cell

### DIFF
--- a/src/extensions/yfm/YfmTable/YfmTableSpecs/serializer.ts
+++ b/src/extensions/yfm/YfmTable/YfmTableSpecs/serializer.ts
@@ -75,11 +75,27 @@ export const serializerTokens: Record<YfmTableNode, SerializerNodeToken> = {
         });
     },
 
-    [YfmTableNode.Row]: (_state, node) => {
-        throw new Error(`Should not serialize ${node.type.name} node via serialize-token`);
+    [YfmTableNode.Row]: (state, node) => {
+        console.warn(`Should not serialize ${node.type.name} node via serialize-token`);
+
+        state.write('||');
+        state.ensureNewLine();
+        state.write('\n');
+        state.renderContent(node);
+        state.write('||');
+        state.ensureNewLine();
     },
 
-    [YfmTableNode.Cell]: (_state, node) => {
-        throw new Error(`Should not serialize ${node.type.name} node via serialize-token`);
+    [YfmTableNode.Cell]: (state, node, parent) => {
+        console.warn(`Should not serialize ${node.type.name} node via serialize-token`);
+
+        state.renderContent(node);
+
+        const isLastCellInRow = parent.lastChild === node;
+        if (!isLastCellInRow) {
+            state.write('|');
+            state.ensureNewLine();
+            state.write('\n');
+        }
     },
 };


### PR DESCRIPTION
For some broken cases, were prosemirror document contains rows with cells without outer table and tbody