### PR TITLE
fix(YfmTable): fix border style for tbody

### DIFF
--- a/src/extensions/yfm/YfmTable/plugins/YfmTableControls/view.scss
+++ b/src/extensions/yfm/YfmTable/plugins/YfmTableControls/view.scss
@@ -1,4 +1,5 @@
-$buttons-size: 18px;
+$buttons-size: 16px;
+$buttons-offset: 2px;
 
 .g-md-table-view {
     &__hack-strip {
@@ -43,29 +44,31 @@ $buttons-size: 18px;
             position: absolute;
             z-index: 100;
             top: 0;
-            right: -$buttons-size;
+            right: -$buttons-size - $buttons-offset;
 
             display: flex;
             align-items: center;
 
-            width: 16px;
+            width: $buttons-size;
             height: 100%;
         }
 
         &_bottom {
             position: absolute;
             z-index: 100;
-            bottom: -$buttons-size;
+            bottom: -$buttons-size - $buttons-offset;
 
             display: flex;
             justify-content: center;
 
             width: 100%;
-            height: 16px;
+            height: $buttons-size;
         }
     }
 
     &__plus-button {
+        --_--padding: 8px;
+
         display: flex;
         justify-content: center;
         align-items: center;
@@ -73,12 +76,12 @@ $buttons-size: 18px;
         height: 100%;
 
         &_right {
-            width: 16px;
+            width: $buttons-size;
             height: 100%;
         }
         &_bottom {
             width: 100%;
-            height: 16px;
+            height: $buttons-size;
         }
     }
 }

--- a/src/extensions/yfm/YfmTable/plugins/YfmTableControls/view.scss
+++ b/src/extensions/yfm/YfmTable/plugins/YfmTableControls/view.scss
@@ -107,8 +107,6 @@ $buttons-size: 18px;
 
     // now borders are drawn not in the table but in tbody
     tbody {
-        display: block;
-
         border-radius: 8px;
         background: var(--g-color-base-background);
         box-shadow: inset 0 0 0 1px var(--g-color-line-generic);


### PR DESCRIPTION
<details>
  <summary>Before fix</summary>
<img width="1374" alt="image" src="https://github.com/user-attachments/assets/01c818cb-ed3e-4356-ab77-924d16a43f81">
</details>

<details>
  <summary>After fix</summary>
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/37641729-d4ee-4ea8-b58b-a953d56ad207">
</details>


Also fixed control buttons' offsets and sizes 