### PR TITLE
fix(Lists): check that list items are being serialized with correct markup

### DIFF
--- a/src/extensions/markdown/Lists/Lists.test.ts
+++ b/src/extensions/markdown/Lists/Lists.test.ts
@@ -30,7 +30,7 @@ describe('Lists extension', () => {
             '* one\n\n* two',
             doc(
                 ul(
-                    {[ListsAttr.Bullet]: '*'},
+                    {[ListsAttr.Markup]: '*'},
                     li({[ListsAttr.Markup]: '*'}, p('one')),
                     li({[ListsAttr.Markup]: '*'}, p('two')),
                 ),
@@ -38,13 +38,26 @@ describe('Lists extension', () => {
         );
     });
 
-    it('should parse ordered list', () => {
+    it('should parse ordered list with dots', () => {
         same(
             '1. one\n\n2. two',
             doc(
                 ol(
                     li({[ListsAttr.Markup]: '.'}, p('one')),
                     li({[ListsAttr.Markup]: '.'}, p('two')),
+                ),
+            ),
+        );
+    });
+
+    it('should parse ordered list with parenthesis', () => {
+        same(
+            '1) one\n\n2) two',
+            doc(
+                ol(
+                    {[ListsAttr.Markup]: ')'},
+                    li({[ListsAttr.Markup]: ')'}, p('one')),
+                    li({[ListsAttr.Markup]: ')'}, p('two')),
                 ),
             ),
         );
@@ -67,7 +80,7 @@ describe('Lists extension', () => {
             markup,
             doc(
                 ul(
-                    {[ListsAttr.Bullet]: '-'},
+                    {[ListsAttr.Bullet]: '-', [ListsAttr.Markup]: '-'},
                     li(
                         {[ListsAttr.Markup]: '-'},
                         p('one'),
@@ -76,7 +89,11 @@ describe('Lists extension', () => {
                                 {[ListsAttr.Markup]: '.'},
                                 p('two'),
                                 ul(
-                                    {[ListsAttr.Tight]: true, [ListsAttr.Bullet]: '+'},
+                                    {
+                                        [ListsAttr.Tight]: true,
+                                        [ListsAttr.Bullet]: '+',
+                                        [ListsAttr.Markup]: '+',
+                                    },
                                     li({[ListsAttr.Markup]: '+'}, p('three')),
                                 ),
                             ),
@@ -94,19 +111,23 @@ describe('Lists extension', () => {
             '- + * 2. item',
             doc(
                 ul(
-                    {[ListsAttr.Bullet]: '-'},
+                    {[ListsAttr.Bullet]: '-', [ListsAttr.Markup]: '-'},
                     li(
                         {[ListsAttr.Markup]: '-'},
                         ul(
-                            {[ListsAttr.Bullet]: '+'},
+                            {[ListsAttr.Bullet]: '+', [ListsAttr.Markup]: '+'},
                             li(
                                 {[ListsAttr.Markup]: '+'},
                                 ul(
-                                    {[ListsAttr.Bullet]: '*'},
+                                    {[ListsAttr.Bullet]: '*', [ListsAttr.Markup]: '*'},
                                     li(
                                         {[ListsAttr.Markup]: '*'},
                                         ol(
-                                            {[ListsAttr.Order]: 2, [ListsAttr.Tight]: true},
+                                            {
+                                                [ListsAttr.Order]: 2,
+                                                [ListsAttr.Tight]: true,
+                                                [ListsAttr.Markup]: '.',
+                                            },
                                             li({[ListsAttr.Markup]: '.'}, p('item')),
                                         ),
                                     ),

--- a/src/extensions/markdown/Lists/ListsSpecs/const.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/const.ts
@@ -6,10 +6,20 @@ export enum ListNode {
 
 export enum ListsAttr {
     Tight = 'tight',
-    /** used in bullet list only */
+    /** @deprecated Use `ListsAttr.Markup` instead */
     Bullet = 'bullet',
     /** used in ordered list only */
     Order = 'order',
-    /** used in list item only */
     Markup = 'markup',
 }
+
+export const Markup = {
+    bullet: {
+        values: ['-', '+', '*'],
+        default: '*',
+    },
+    ordered: {
+        values: ['.', ')'],
+        default: '.',
+    },
+};

--- a/src/extensions/markdown/Lists/ListsSpecs/parser.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/parser.ts
@@ -17,6 +17,7 @@ export const parserTokens: Record<ListNode, ParserToken> = {
         getAttrs: (token, tokens, i) => ({
             [ListsAttr.Tight]: listIsTight(tokens, i),
             [ListsAttr.Bullet]: token.markup,
+            [ListsAttr.Markup]: token.markup,
         }),
     },
 
@@ -26,6 +27,7 @@ export const parserTokens: Record<ListNode, ParserToken> = {
         getAttrs: (token, tokens, i) => ({
             [ListsAttr.Order]: Number(token.attrGet('start')) || 1,
             [ListsAttr.Tight]: listIsTight(tokens, i),
+            [ListsAttr.Markup]: token.markup,
         }),
     },
 };

--- a/src/extensions/markdown/Lists/ListsSpecs/schema.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/schema.ts
@@ -1,10 +1,13 @@
 import type {NodeSpec} from 'prosemirror-model';
 
-import {ListNode, ListsAttr} from './const';
+import {ListNode, ListsAttr, Markup} from './const';
 
 export const schemaSpecs: Record<ListNode, NodeSpec> = {
     [ListNode.ListItem]: {
-        attrs: {[ListsAttr.Tight]: {default: false}, [ListsAttr.Markup]: {default: null}},
+        attrs: {
+            [ListsAttr.Tight]: {default: false},
+            [ListsAttr.Markup]: {default: null},
+        },
         content: '(paragraph|block)+',
         defining: true,
         parseDOM: [{tag: 'li'}],
@@ -20,7 +23,11 @@ export const schemaSpecs: Record<ListNode, NodeSpec> = {
     [ListNode.BulletList]: {
         content: `${ListNode.ListItem}+`,
         group: 'block',
-        attrs: {[ListsAttr.Tight]: {default: false}, [ListsAttr.Bullet]: {default: '*'}},
+        attrs: {
+            [ListsAttr.Tight]: {default: false},
+            [ListsAttr.Bullet]: {default: Markup.bullet.default},
+            [ListsAttr.Markup]: {default: Markup.bullet.default},
+        },
         parseDOM: [
             {
                 tag: 'ul',
@@ -38,7 +45,11 @@ export const schemaSpecs: Record<ListNode, NodeSpec> = {
     },
 
     [ListNode.OrderedList]: {
-        attrs: {[ListsAttr.Order]: {default: 1}, [ListsAttr.Tight]: {default: false}},
+        attrs: {
+            [ListsAttr.Order]: {default: 1},
+            [ListsAttr.Tight]: {default: false},
+            [ListsAttr.Markup]: {default: Markup.ordered.default},
+        },
         content: `${ListNode.ListItem}+`,
         group: 'block',
         parseDOM: [

--- a/src/extensions/markdown/Lists/ListsSpecs/serializer.ts
+++ b/src/extensions/markdown/Lists/ListsSpecs/serializer.ts
@@ -2,7 +2,7 @@ import type {Node} from 'prosemirror-model';
 
 import type {SerializerNodeToken} from '../../../../core';
 
-import {ListNode, ListsAttr} from './const';
+import {ListNode, ListsAttr, Markup} from './const';
 
 export const serializerTokens: Record<ListNode, SerializerNodeToken> = {
     [ListNode.ListItem]: (state, node) => {
@@ -10,21 +10,36 @@ export const serializerTokens: Record<ListNode, SerializerNodeToken> = {
     },
 
     [ListNode.BulletList]: (state, node) => {
-        state.renderList(
-            node,
-            '  ',
-            (_i: number, li: Node) =>
-                (li.attrs[ListsAttr.Markup] || node.attrs[ListsAttr.Bullet] || '*') + ' ',
-        );
+        state.renderList(node, '  ', (_i: number, li: Node) => {
+            const markup = getMarkup({item: li, list: node, type: 'bullet'});
+            return markup + ' ';
+        });
     },
 
     [ListNode.OrderedList]: (state, node) => {
         const start = node.attrs[ListsAttr.Order] || 1;
         const maxW = String(start + node.childCount - 1).length;
         const space = state.repeat(' ', maxW + 2);
-        state.renderList(node, space, (i: number) => {
+        state.renderList(node, space, (i: number, li: Node) => {
             const nStr = String(start + i);
-            return state.repeat(' ', maxW - nStr.length) + nStr + '. ';
+            const markup = getMarkup({item: li, list: node, type: 'ordered'});
+            return state.repeat(' ', maxW - nStr.length) + nStr + markup + ' ';
         });
     },
 };
+
+function getMarkup({
+    item,
+    list,
+    type,
+}: {
+    item: Node;
+    list: Node;
+    type: keyof typeof Markup;
+}): string {
+    const defs = Markup[type];
+    let value = item.attrs[ListsAttr.Markup];
+    if (!defs.values.includes(value)) value = list.attrs[ListsAttr.Markup];
+    if (!defs.values.includes(value)) value = defs.default;
+    return value;
+}

--- a/src/extensions/markdown/Lists/plugins/MergeListsPlugin.test.ts
+++ b/src/extensions/markdown/Lists/plugins/MergeListsPlugin.test.ts
@@ -63,6 +63,7 @@ describe('Lists extension', () => {
                         {
                             [ListsAttr.Tight]: true,
                             [ListsAttr.Bullet]: '+',
+                            [ListsAttr.Markup]: '+',
                         },
                         li(
                             {[ListsAttr.Markup]: '+'},
@@ -82,6 +83,7 @@ describe('Lists extension', () => {
                                 {
                                     [ListsAttr.Tight]: true,
                                     [ListsAttr.Bullet]: '-',
+                                    [ListsAttr.Markup]: '-',
                                 },
                                 li(
                                     {[ListsAttr.Markup]: '-'},
@@ -116,7 +118,7 @@ describe('Lists extension', () => {
                 doc(
                     ol(
                         {
-                            [ListsAttr.Bullet]: '.',
+                            [ListsAttr.Markup]: '.',
                         },
                         li(
                             {
@@ -139,7 +141,7 @@ describe('Lists extension', () => {
                             ol(
                                 {
                                     [ListsAttr.Tight]: true,
-                                    [ListsAttr.Bullet]: '.',
+                                    [ListsAttr.Markup]: '.',
                                 },
                                 li(
                                     {[ListsAttr.Markup]: '.'},


### PR DESCRIPTION
When switch ordered_list –> bullet_list (or vice versa), the list items are serialized with incorrect markup.

This change fix it.