### PR TITLE
feat(bundle): group editor settings by scope

### DIFF
--- a/demo/Playground.tsx
+++ b/demo/Playground.tsx
@@ -5,20 +5,21 @@ import {Button, DropdownMenu} from '@gravity-ui/uikit';
 import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
 
 import {
-    MarkdownEditorMode,
+    type EscapeConfig,
+    type MarkdownEditorMode,
     MarkdownEditorView,
-    MarkdownEditorViewProps,
-    MarkupString,
+    type MarkdownEditorViewProps,
+    type MarkupString,
     NumberInput,
-    RenderPreview,
-    ToolbarGroupData,
-    UseMarkdownEditorProps,
+    type RenderPreview,
+    type ToolbarGroupData,
+    type UseMarkdownEditorProps,
     logger,
     markupToolbarConfigs,
     useMarkdownEditor,
     wysiwygToolbarConfigs,
 } from '../src';
-import type {EscapeConfig, ToolbarActionData} from '../src/bundle/Editor';
+import type {ToolbarActionData} from '../src/bundle/Editor';
 import {Extension} from '../src/cm/state';
 import {FoldingHeading} from '../src/extensions/yfm/FoldingHeading';
 import {Math} from '../src/extensions/yfm/Math';

--- a/demo/RememberMode.stories.tsx
+++ b/demo/RememberMode.stories.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type {Meta, StoryFn} from '@storybook/react';
 
-import {EditorMode} from '../src/bundle/Editor';
+import type {MarkdownEditorMode} from '../src/bundle';
 
 import {Playground as PlaygroundComponent, PlaygroundProps} from './Playground';
 
@@ -167,10 +167,10 @@ const args: Partial<PlaygroundStoryProps> = {
 };
 
 export const RememberMode: StoryFn<PlaygroundStoryProps> = (props) => {
-    const [mode, setMode] = useState<EditorMode>();
+    const [mode, setMode] = useState<MarkdownEditorMode>();
     const [splitModeEnabled, setSplitModeEnabled] = useState<boolean>();
 
-    const handleChangeEditorType = (mode: EditorMode) => {
+    const handleChangeEditorType = (mode: MarkdownEditorMode) => {
         localStorage.setItem('markdownEditorMode', mode);
     };
 
@@ -183,7 +183,7 @@ export const RememberMode: StoryFn<PlaygroundStoryProps> = (props) => {
         const storedSplitModeEnabled = localStorage.getItem('markdownEditorSplitModeEnabled');
 
         if (storedMode) {
-            setMode(storedMode as EditorMode);
+            setMode(storedMode as MarkdownEditorMode);
             setSplitModeEnabled(storedSplitModeEnabled === 'true');
         }
     }, []);

--- a/src/bundle/MarkdownEditorView.tsx
+++ b/src/bundle/MarkdownEditorView.tsx
@@ -10,7 +10,7 @@ import {logger} from '../logger';
 import {ToasterContext, useBooleanState, useSticky} from '../react-utils';
 import {isMac} from '../utils';
 
-import type {Editor, EditorInt, EditorMode} from './Editor';
+import type {Editor, EditorInt} from './Editor';
 import {HorizontalDrag} from './HorizontalDrag';
 import {MarkupEditorView} from './MarkupEditorView';
 import {SplitModeView} from './SplitModeView';
@@ -28,6 +28,7 @@ import {
 import {useMarkdownEditorContext} from './context';
 import {EditorSettings, EditorSettingsProps} from './settings';
 import {stickyCn} from './sticky';
+import type {MarkdownEditorMode} from './types';
 
 import '../styles/styles.scss';
 import './MarkdownEditorView.scss'; // eslint-disable-line import/order
@@ -91,7 +92,7 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
         }, [editor, rerender]);
 
         const onModeChange = React.useCallback(
-            (type: EditorMode) => {
+            (type: MarkdownEditorMode) => {
                 editor.changeEditorMode({mode: type, reason: 'settings'});
                 unsetShowPreview();
             },

--- a/src/bundle/MarkupEditorView.tsx
+++ b/src/bundle/MarkupEditorView.tsx
@@ -5,11 +5,12 @@ import {ReactRendererComponent} from '../extensions';
 import {logger} from '../logger';
 import {useRenderTime} from '../react-utils/hooks';
 
-import type {EditorInt, SplitMode} from './Editor';
+import type {EditorInt} from './Editor';
 import {MarkupEditorComponent} from './MarkupEditorComponent';
 import {ToolbarView} from './ToolbarView';
 import type {MToolbarData, MToolbarItemData} from './config/markup';
 import {MarkupToolbarContextProvider} from './toolbar/markup/context';
+import type {MarkdownEditorSplitMode} from './types';
 
 import './MarkupEditorView.scss';
 
@@ -23,7 +24,7 @@ export type MarkupEditorViewProps = ClassNameProps & {
     toolbarVisible?: boolean;
     stickyToolbar?: boolean;
     toolbarClassName?: string;
-    splitMode?: SplitMode;
+    splitMode?: MarkdownEditorSplitMode;
     splitModeEnabled: boolean;
     hiddenActionsConfig?: MToolbarItemData[];
     children?: React.ReactNode;

--- a/src/bundle/ToolbarView.tsx
+++ b/src/bundle/ToolbarView.tsx
@@ -7,12 +7,13 @@ import {i18n} from '../i18n/menubar';
 import {useSticky} from '../react-utils/useSticky';
 import {FlexToolbar, ToolbarData, ToolbarItemData} from '../toolbar';
 
-import type {EditorInt, EditorMode} from './Editor';
+import type {EditorInt} from './Editor';
 import {stickyCn} from './sticky';
+import type {MarkdownEditorMode} from './types';
 
 export type ToolbarViewProps<T> = ClassNameProps & {
     editor: EditorInt;
-    editorMode: EditorMode;
+    editorMode: MarkdownEditorMode;
     toolbarEditor: T;
     toolbarFocus: () => void;
     toolbarConfig: ToolbarData<T>;

--- a/src/bundle/config/markup.tsx
+++ b/src/bundle/config/markup.tsx
@@ -50,10 +50,10 @@ import {
     ToolbarReactComponentData,
     ToolbarSingleItemData,
 } from '../../toolbar/types';
-import type {EditorPreset} from '../Editor';
 import {MToolbarColors} from '../toolbar/markup/MToolbarColors';
 import {MToolbarFilePopup} from '../toolbar/markup/MToolbarFilePopup';
 import {MToolbarImagePopup} from '../toolbar/markup/MToolbarImagePopup';
+import type {MarkdownEditorPreset} from '../types';
 
 import {ActionName} from './action-names';
 import {icons} from './icons';
@@ -545,7 +545,7 @@ export const mTabsItemData: MToolbarSingleItemData = {
 
 export const mHiddenData = [mHruleItemData, mTabsItemData];
 
-export const mToolbarConfigByPreset: Record<EditorPreset, MToolbarData> = {
+export const mToolbarConfigByPreset: Record<MarkdownEditorPreset, MToolbarData> = {
     zero: [mHistoryGroupConfig],
     commonmark: [
         mHistoryGroupConfig,
@@ -592,7 +592,7 @@ export const mToolbarConfigByPreset: Record<EditorPreset, MToolbarData> = {
     full: mToolbarConfig.slice(),
 };
 
-export const mHiddenDataByPreset: Record<EditorPreset, MToolbarItemData[]> = {
+export const mHiddenDataByPreset: Record<MarkdownEditorPreset, MToolbarItemData[]> = {
     zero: [],
     commonmark: [
         ...mHeadingListConfig.data,

--- a/src/bundle/config/wysiwyg.ts
+++ b/src/bundle/config/wysiwyg.ts
@@ -22,9 +22,9 @@ import {
     ToolbarListItemData,
     ToolbarSingleItemData,
 } from '../../toolbar/types';
-import type {EditorPreset} from '../Editor';
 import {WToolbarColors} from '../toolbar/wysiwyg/WToolbarColors';
 import {WToolbarTextSelect} from '../toolbar/wysiwyg/WToolbarTextSelect';
+import type {MarkdownEditorPreset} from '../types';
 
 import {ActionName} from './action-names';
 import {icons} from './icons';
@@ -581,7 +581,7 @@ export const wMermaidItemData: WToolbarSingleItemData = {
     isEnable: (e) => e.actions.createMermaid.isEnable(),
 };
 
-export const wToolbarConfigByPreset: Record<EditorPreset, WToolbarData> = {
+export const wToolbarConfigByPreset: Record<MarkdownEditorPreset, WToolbarData> = {
     zero: [wHistoryGroupConfig],
     commonmark: [
         wHistoryGroupConfig,
@@ -652,7 +652,7 @@ export const wToolbarConfigByPreset: Record<EditorPreset, WToolbarData> = {
     full: wToolbarConfig.slice(),
 };
 
-export const wCommandMenuConfigByPreset: Record<EditorPreset, WToolbarItemData[]> = {
+export const wCommandMenuConfigByPreset: Record<MarkdownEditorPreset, WToolbarItemData[]> = {
     zero: [],
     commonmark: [
         ...wHeadingListConfig.data,
@@ -688,7 +688,7 @@ export const wCommandMenuConfigByPreset: Record<EditorPreset, WToolbarItemData[]
     full: wCommandMenuConfig.slice(),
 };
 
-export const wHiddenDataByPreset: Record<EditorPreset, WToolbarItemData[]> = {
+export const wHiddenDataByPreset: Record<MarkdownEditorPreset, WToolbarItemData[]> = {
     zero: wCommandMenuConfigByPreset.zero.slice(),
     commonmark: wCommandMenuConfigByPreset.commonmark.slice(),
     default: wCommandMenuConfigByPreset.default.slice(),
@@ -696,7 +696,7 @@ export const wHiddenDataByPreset: Record<EditorPreset, WToolbarItemData[]> = {
     full: wCommandMenuConfigByPreset.full.slice(),
 };
 
-export const wSelectionMenuConfigByPreset: Record<EditorPreset, SelectionContextConfig> = {
+export const wSelectionMenuConfigByPreset: Record<MarkdownEditorPreset, SelectionContextConfig> = {
     zero: [],
     commonmark: [
         [textContextItemData],

--- a/src/bundle/index.ts
+++ b/src/bundle/index.ts
@@ -1,11 +1,4 @@
-export type {
-    Editor as MarkdownEditorInstance,
-    EditorMode as MarkdownEditorMode,
-    EditorPreset as MarkdownEditorPreset,
-    MarkupConfig as MarkdownEditorMarkupConfig,
-    RenderPreview,
-    SplitMode,
-} from './Editor';
+export * from './types';
 export {MarkdownEditorProvider, useMarkdownEditorContext} from './context';
 export {useMarkdownEditor} from './useMarkdownEditor';
 export type {UseMarkdownEditorProps} from './useMarkdownEditor';

--- a/src/bundle/settings/index.tsx
+++ b/src/bundle/settings/index.tsx
@@ -21,7 +21,7 @@ import {noop} from '../../lodash';
 import {useBooleanState} from '../../react-utils/hooks';
 import {ToolbarTooltipDelay} from '../../toolbar';
 import {VERSION} from '../../version';
-import type {EditorMode, SplitMode} from '../Editor';
+import type {MarkdownEditorMode, MarkdownEditorSplitMode} from '../types';
 
 import {MarkdownHints} from './MarkdownHints';
 
@@ -98,14 +98,14 @@ export const EditorSettings = React.memo<EditorSettingsProps>(function EditorSet
 });
 
 type SettingsContentProps = ClassNameProps & {
-    mode: EditorMode;
+    mode: MarkdownEditorMode;
     onClose: () => void;
-    onModeChange: (mode: EditorMode) => void;
+    onModeChange: (mode: MarkdownEditorMode) => void;
     onShowPreviewChange: (showPreview: boolean) => void;
     showPreview: boolean;
     toolbarVisibility: boolean;
     onToolbarVisibilityChange: (val: boolean) => void;
-    splitMode?: SplitMode;
+    splitMode?: MarkdownEditorSplitMode;
     splitModeEnabled?: boolean;
     onSplitModeChange?: (splitModeEnabled: boolean) => void;
 };

--- a/src/bundle/types.ts
+++ b/src/bundle/types.ts
@@ -1,0 +1,196 @@
+// public types, re-exported in src/bundle/index.ts
+
+import type {ReactNode} from 'react';
+
+import type {MarkupString} from '../common';
+import type {EscapeConfig, Extension} from '../core';
+import type {CreateCodemirrorParams, YfmLangOptions} from '../markup/codemirror';
+import type {FileUploadHandler} from '../utils/upload';
+
+import type {ChangeEditorModeOptions} from './Editor';
+import type {ExtensionsOptions as WysiwygPresetExtensionsOptions} from './wysiwyg-preset';
+
+export type {Editor as MarkdownEditorInstance} from './Editor';
+export type MarkdownEditorMode = 'wysiwyg' | 'markup';
+export type MarkdownEditorPreset = 'zero' | 'commonmark' | 'default' | 'yfm' | 'full';
+export type MarkdownEditorSplitMode = false | 'horizontal' | 'vertical';
+
+export type RenderPreviewParams = {
+    getValue: () => MarkupString;
+    mode: 'preview' | 'split';
+};
+export type RenderPreview = (params: RenderPreviewParams) => ReactNode;
+
+export type MarkdownEditorMdOptions = {
+    html?: boolean;
+    breaks?: boolean;
+    linkify?: boolean;
+    linkifyTlds?: string | string[];
+};
+
+export type MarkdownEditorInitialOptions = {
+    markup?: MarkupString;
+    /** Default – wysiwyg */
+    mode?: MarkdownEditorMode;
+    /** Default – true */
+    toolbarVisible?: boolean;
+    /**
+     * Default – false
+     *
+     * Note: has no effect if `MarkdownEditorMarkupConfig.splitMode` is set to false or is not set.
+     */
+    splitModeEnabled?: boolean;
+};
+
+export type MarkdownEditorHandlers = {
+    /** Pass this handler to allow uploading files from device. */
+    uploadFile?: FileUploadHandler;
+};
+
+export type MarkdownEditorExperimentalOptions = {
+    /**
+     * If we need to set dimensions for uploaded images
+     *
+     * @default false
+     */
+    needToSetDimensionsForUploadedImages?: boolean;
+    /**
+     * Called before switching from the markup editor to the wysiwyg editor.
+     * You can use it to pre-process the value from the markup editor before it gets into the wysiwyg editor.
+     */
+    prepareRawMarkup?: (value: MarkupString) => MarkupString;
+    beforeEditorModeChange?: (
+        options: Pick<ChangeEditorModeOptions, 'mode' | 'reason'>,
+    ) => boolean | undefined;
+};
+
+export type MarkdownEditorMarkupConfig = {
+    /**
+     * Pass the rendering function to preview the markdown content.
+     *
+     * It is also used for split view rendering.
+     *
+     * If false is passed, preview will be disabled.
+     */
+    renderPreview?: RenderPreview;
+    /**
+     * Pass position of split view.
+     *
+     * Note: for enable split view, you need to pass renderPreview function too.
+     *
+     * If false is passed, split view will be disabled.
+     */
+    splitMode?: MarkdownEditorSplitMode;
+    /** Additional extensions for codemirror instance. */
+    extensions?: CreateCodemirrorParams['extensions'];
+    /** Can be used to disable some of the default extensions */
+    disabledExtensions?: CreateCodemirrorParams['disabledExtensions'];
+    /** Additional keymaps for codemirror instance */
+    keymaps?: CreateCodemirrorParams['keymaps'];
+    /** Overrides the default placeholder content. */
+    placeholder?: CreateCodemirrorParams['placeholder'];
+    /**
+     * Additional language data for markdown language in codemirror.
+     * Can be used to configure additional autocompletions and others.
+     * See more https://codemirror.net/docs/ref/#state.EditorState.languageDataAt
+     */
+    languageData?: YfmLangOptions['languageData'];
+    /** Config for @codemirror/autocomplete https://codemirror.net/docs/ref/#autocomplete.autocompletion%5Econfig */
+    autocompletion?: CreateCodemirrorParams['autocompletion'];
+};
+
+// do not export this type
+type ExtensionsOptions<T extends object = {}> = Omit<
+    WysiwygPresetExtensionsOptions,
+    'reactRenderer'
+> &
+    T;
+
+export type MarkdownEditorWysiwygConfig = {
+    /** Additional extensions */
+    extensions?: Extension;
+    extensionOptions?: ExtensionsOptions;
+    escapeConfig?: EscapeConfig;
+};
+
+// [major] TODO: remove generic type
+export type MarkdownEditorOptions<T extends object = {}> = {
+    /**
+     * A set of plug-in extensions.
+     *
+     * @default 'full'
+     */
+    preset?: MarkdownEditorPreset;
+    /** Markdown parser options */
+    md?: MarkdownEditorMdOptions;
+    /** Initial values */
+    initial?: MarkdownEditorInitialOptions;
+    handlers?: MarkdownEditorHandlers;
+    experimental?: MarkdownEditorExperimentalOptions;
+    /** Options for markup mode */
+    markupConfig?: MarkdownEditorMarkupConfig;
+    /** Options for wysiwyg mode */
+    wysiwygConfig?: MarkdownEditorWysiwygConfig;
+
+    /** @deprecated Put allowHTML via MarkdownEditorMdOptions */
+    allowHTML?: boolean;
+    /** @deprecated Put breaks via MarkdownEditorMdOptions */
+    breaks?: boolean;
+    /** @deprecated Put linkify via MarkdownEditorMdOptions */
+    linkify?: boolean;
+    /** @deprecated Put linkifyTlds via MarkdownEditorMdOptions */
+    linkifyTlds?: string | string[];
+    /** @deprecated Put initial markup via MarkdownEditorInitialOptions */
+    initialMarkup?: MarkdownEditorInitialOptions['markup'];
+    /**
+     * @default 'wysiwyg'
+     *
+     * @deprecated Put initial editor mode via MarkdownEditorInitialOptions
+     */
+    initialEditorMode?: MarkdownEditorInitialOptions['mode'];
+    /**
+     * @default true
+     *
+     * @deprecated Put initial toolbar visibility via MarkdownEditorInitialOptions
+     */
+    initialToolbarVisible?: MarkdownEditorInitialOptions['toolbarVisible'];
+    /**
+     * Has no effect if splitMode is false or undefined
+     *
+     * @default false
+     *
+     * @deprecated Put initialSplitModeEnabled via MarkdownEditorInitialOptions
+     */
+    initialSplitModeEnabled?: MarkdownEditorInitialOptions['splitModeEnabled'];
+    /**
+     * If we need to set dimensions for uploaded images
+     *
+     * @default false
+     *
+     * @deprecated Put needToSetDimensionsForUploadedImages via MarkdownEditorExperimentalOptions
+     */
+    needToSetDimensionsForUploadedImages?: MarkdownEditorExperimentalOptions['needToSetDimensionsForUploadedImages'];
+    /**
+     * Called before switching from the markup editor to the wysiwyg editor.
+     * You can use it to pre-process the value from the markup editor before it gets into the wysiwyg editor.
+     *
+     * @deprecated Put prepareRawMarkup via MarkdownEditorExperimentalOptions
+     */
+    prepareRawMarkup?: MarkdownEditorExperimentalOptions['prepareRawMarkup'];
+    /** @deprecated Put beforeEditorModeChange via MarkdownEditorExperimentalOptions */
+    experimental_beforeEditorModeChange?: MarkdownEditorExperimentalOptions['beforeEditorModeChange'];
+    /** @deprecated Put split mode via MarkdownEditorMarkupConfig */
+    splitMode?: MarkdownEditorMarkupConfig['splitMode'];
+    /** @deprecated Put render preview function via MarkdownEditorMarkupConfig */
+    renderPreview?: MarkdownEditorMarkupConfig['renderPreview'];
+    /** @deprecated Put extensions via MarkdownEditorWysiwygConfig */
+    extraExtensions?: MarkdownEditorWysiwygConfig['extensions'];
+    /** @deprecated Put extension options via MarkdownEditorWysiwygConfig */
+    extensionOptions?: ExtensionsOptions<T>;
+    /** @deprecated Put extra extensions via MarkdownEditorMarkupConfig */
+    extraMarkupExtensions?: MarkdownEditorMarkupConfig['extensions'];
+    /** @deprecated Put escapeConfig via MarkdownEditorWysiwygConfig */
+    escapeConfig?: MarkdownEditorWysiwygConfig['escapeConfig'];
+    /** @deprecated Put file upload handler via MarkdownEditorHandlers */
+    fileUploadHandler?: MarkdownEditorHandlers['uploadFile'];
+};

--- a/src/bundle/wysiwyg-preset.ts
+++ b/src/bundle/wysiwyg-preset.ts
@@ -13,9 +13,9 @@ import {ZeroPreset, ZeroPresetOptions} from '../presets/zero';
 import {Action as A, formatter as f} from '../shortcuts';
 import type {FileUploadHandler} from '../utils/upload';
 
-import {EditorPreset} from './Editor';
 import {wCommandMenuConfigByPreset, wSelectionMenuConfigByPreset} from './config/wysiwyg';
 import {emojiDefs} from './emoji';
+import {MarkdownEditorPreset} from './types';
 
 const DEFAULT_IGNORED_KEYS = ['Tab', 'Shift-Tab'] as const;
 
@@ -23,7 +23,7 @@ export type ExtensionsOptions = BehaviorPresetOptions & FullPresetOptions;
 
 export type BundlePresetOptions = ExtensionsOptions &
     EditorModeKeymapOptions & {
-        preset: EditorPreset;
+        preset: MarkdownEditorPreset;
         mdBreaks?: boolean;
         fileUploadHandler?: FileUploadHandler;
         /**

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -16,7 +16,7 @@ import {logTransactionMetrics} from './utils/metrics';
 
 type OnChange = (editor: WysiwygEditor) => void;
 
-type EscapeConfig = {
+export type EscapeConfig = {
     commonEscape?: RegExp;
     startOfLineEscape?: RegExp;
 };

--- a/src/markup/codemirror/index.ts
+++ b/src/markup/codemirror/index.ts
@@ -2,3 +2,4 @@ export type {CreateCodemirrorParams} from './create';
 export {createCodemirror} from './create';
 export {ReactRendererFacet} from './react-facet';
 export {getImageDimensions, IMG_MAX_HEIGHT} from './files-upload-plugin';
+export type {YfmLangOptions} from './yfm';

--- a/src/markup/codemirror/search-plugin/plugin.ts
+++ b/src/markup/codemirror/search-plugin/plugin.ts
@@ -10,7 +10,8 @@ import {
 } from '@codemirror/search';
 import {EditorView, PluginValue, ViewPlugin, ViewUpdate, keymap} from '@codemirror/view';
 
-import {EditorMode, EventMap} from '../../../bundle/Editor';
+import type {MarkdownEditorMode} from '../../../bundle';
+import type {EventMap} from '../../../bundle/Editor';
 import type {RendererItem} from '../../../extensions';
 import {debounce} from '../../../lodash';
 import {Receiver} from '../../../utils';
@@ -116,7 +117,7 @@ export const SearchPanelPlugin = (params: SearchPanelPluginParams) =>
                 this.view.dispatch({effects: setSearchQuery.of(searchQuery)});
             }
 
-            handleEditorModeChange({mode}: {mode: EditorMode}) {
+            handleEditorModeChange({mode}: {mode: MarkdownEditorMode}) {
                 if (mode === 'wysiwyg') {
                     closeSearchPanel(this.view);
                 }


### PR DESCRIPTION
Preparation to major #423

Scopes of options:
- `md` – markdown parser options
- `initial` – initial values
- `handlers` – various handlers
- `experimental` – experimental features
- `markup` – configuration of markup mode
- `wysiwyg` – configuration of wysiwyg mode