### PR TITLE
feat: add hint for upload image and file

### DIFF
--- a/src/forms/FileForm.tsx
+++ b/src/forms/FileForm.tsx
@@ -29,6 +29,7 @@ export type FileFormProps = ClassNameProps & {
     onCancel(): void;
     onAttach?: (files: File[]) => void;
     loading?: boolean;
+    uploadHint?: string;
 };
 
 export const FileForm: React.FC<FileFormProps> = ({
@@ -38,6 +39,7 @@ export const FileForm: React.FC<FileFormProps> = ({
     onSubmit,
     onAttach,
     loading,
+    uploadHint,
 }) => {
     const [tabId, setTabId] = React.useState<string>(() =>
         isFunction(onAttach) ? TabId.Attach : TabId.Link,
@@ -74,7 +76,7 @@ export const FileForm: React.FC<FileFormProps> = ({
             )}
             {tabId === TabId.Attach && onAttach && (
                 <>
-                    <Form.Layout>{i18n('file_upload_help')}</Form.Layout>
+                    <Form.Layout>{uploadHint || i18n('file_upload_help')}</Form.Layout>
                     <Form.Footer onCancel={onCancel}>
                         <ButtonAttach
                             multiple

--- a/src/forms/ImageForm.tsx
+++ b/src/forms/ImageForm.tsx
@@ -34,6 +34,7 @@ export type ImageFormProps = ClassNameProps & {
     onCancel(): void;
     onAttach?: (files: File[]) => void;
     loading?: boolean;
+    uploadHint?: string;
 };
 
 export const ImageForm: React.FC<ImageFormProps> = ({
@@ -43,6 +44,7 @@ export const ImageForm: React.FC<ImageFormProps> = ({
     onSubmit,
     onAttach,
     loading,
+    uploadHint,
 }) => {
     const [tabId, setTabId] = React.useState<string>(() =>
         isFunction(onAttach) ? ImageTabId.Attach : ImageTabId.Link,
@@ -86,7 +88,7 @@ export const ImageForm: React.FC<ImageFormProps> = ({
             )}
             {tabId === ImageTabId.Attach && onAttach && (
                 <>
-                    <Form.Layout>{i18n('image_upload_help')}</Form.Layout>
+                    <Form.Layout>{uploadHint || i18n('image_upload_help')}</Form.Layout>
                     <Form.Footer onCancel={onCancel}>
                         <ButtonAttach
                             multiple


### PR DESCRIPTION
### Intro
Added an optional uploadHint property to the ImageForm and FileForm components. This property allows customization of the upload help text.

issue [386](https://github.com/gravity-ui/markdown-editor/issues/386)