### PR TITLE
fix(deps): sync version of markdown-it-attrs with @diplodoc/transform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/markdown-it": "^12.2.3",
         "base64-arraybuffer": "1.0.2",
         "is-number": "^7.0.0",
-        "markdown-it-attrs": "4.1.4",
+        "markdown-it-attrs": "^4.2.0",
         "markdown-it-color": "^2.1.1",
         "markdown-it-emoji": "2.0.2",
         "markdown-it-ins": "^3.0.1",
@@ -2759,18 +2759,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@diplodoc/transform/node_modules/markdown-it-attrs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.2.0.tgz",
-      "integrity": "sha512-m7svtUBythvcGFFZAv9VjMEvs8UbHri2sojJ3juJumoOzv8sdkx9a7W3KxiHbXxAbvL3Xauak8TMwCnvigVPKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "markdown-it": ">= 9.0.0"
       }
     },
     "node_modules/@diplodoc/utils": {
@@ -20787,9 +20775,9 @@
       }
     },
     "node_modules/markdown-it-attrs": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.1.4.tgz",
-      "integrity": "sha512-53Zfv8PTb6rlVFDlD106xcZHKBSsRZKJ2IW/rTxEJBEVbVaoxaNsmRkG0HXfbHl2SK8kaxZ2QKqdthWy/QBwmA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.2.0.tgz",
+      "integrity": "sha512-m7svtUBythvcGFFZAv9VjMEvs8UbHri2sojJ3juJumoOzv8sdkx9a7W3KxiHbXxAbvL3Xauak8TMwCnvigVPKw==",
       "engines": {
         "node": ">=6"
       },

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "@types/markdown-it": "^12.2.3",
     "base64-arraybuffer": "1.0.2",
     "is-number": "^7.0.0",
-    "markdown-it-attrs": "4.1.4",
+    "markdown-it-attrs": "^4.2.0",
     "markdown-it-color": "^2.1.1",
     "markdown-it-emoji": "2.0.2",
     "markdown-it-ins": "^3.0.1",


### PR DESCRIPTION
Although this is minor update of markdown-it-attrs, it contains only  a fix: arve0/markdown-it-attrs#155