### PR TITLE
fix(Video): backward compability between diferent versions of `@diplodoc/transform`

### DIFF
--- a/src/extensions/yfm/Video/VideoSpecs/index.ts
+++ b/src/extensions/yfm/Video/VideoSpecs/index.ts
@@ -57,6 +57,11 @@ export const VideoSpecs: ExtensionAuto<VideoSpecsOptions> = (builder, opts) => {
                 const videoId = node.attrs[VideoAttr.VideoID];
 
                 if (availableServices.has(service) || !videoId) {
+                    let src = '';
+                    if (typeof (options as any).url === 'function')
+                        src = (options as any).url(service, videoId, options);
+                    else if (typeof (options as any).videoUrl === 'function')
+                        src = (options as any).videoUrl(service, videoId, options);
                     return [
                         'div',
                         {
@@ -69,7 +74,7 @@ export const VideoSpecs: ExtensionAuto<VideoSpecsOptions> = (builder, opts) => {
                                 type: 'text/html',
                                 width: String(options[service as VideoService].width),
                                 height: String(options[service as VideoService].height),
-                                src: options.videoUrl(service, videoId, options),
+                                src: src,
                                 frameborder: '0',
                                 webkitallowfullscreen: '',
                                 mozallowfullscreen: '',


### PR DESCRIPTION
In `@diplodoc/transform@4.34` and earlier versions [property named `url`](https://github.com/diplodoc-platform/transform/blob/v4.34.0/src/transform/plugins/video/types.ts#L19-L21C3): 
```ts
export type VideoFullOptions = VideoServicesOptions & {
    url: VideoUrlFn;
};
```

Since `@diplodoc/transform@4.35` [property named `videoUrl`](https://github.com/diplodoc-platform/transform/blob/v4.35.0/src/transform/plugins/video/types.ts#L27-L29C3):
```ts
export type VideoFullOptions = VideoServicesOptions & {
    videoUrl: VideoUrlFn;
};
```