### PR TITLE
feat(YfmCut): support directive syntax

### DIFF
--- a/demo/components/Playground.tsx
+++ b/demo/components/Playground.tsx
@@ -5,8 +5,9 @@ import {Button, DropdownMenu} from '@gravity-ui/uikit';
 import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
 
 import {
+    type DirectiveSyntaxValue,
     type EscapeConfig,
-    FileUploadHandler,
+    type FileUploadHandler,
     type MarkdownEditorMode,
     MarkdownEditorView,
     type MarkdownEditorViewProps,
@@ -21,16 +22,16 @@ import {
     wysiwygToolbarConfigs,
 } from '../../src';
 import type {ToolbarActionData} from '../../src/bundle/Editor';
-import {Extension} from '../../src/cm/state';
+import type {Extension} from '../../src/cm/state';
 import {FoldingHeading} from '../../src/extensions/additional/FoldingHeading';
 import {Math} from '../../src/extensions/additional/Math';
 import {Mermaid} from '../../src/extensions/additional/Mermaid';
 import {YfmHtmlBlock} from '../../src/extensions/additional/YfmHtmlBlock';
 import {getSanitizeYfmHtmlBlock} from '../../src/extensions/additional/YfmHtmlBlock/utils';
 import {cloneDeep} from '../../src/lodash';
-import {CodeEditor} from '../../src/markup';
+import type {CodeEditor} from '../../src/markup';
 import {VERSION} from '../../src/version';
-import {plugins} from '../defaults/md-plugins';
+import {getPlugins} from '../defaults/md-plugins';
 import useYfmHtmlBlockStyles from '../hooks/useYfmHtmlBlockStyles';
 import {block} from '../utils/cn';
 import {randomDelay} from '../utils/delay';
@@ -91,6 +92,7 @@ export type PlaygroundProps = {
     markupToolbarConfig?: ToolbarGroupData<CodeEditor>[];
     onChangeEditorType?: (mode: MarkdownEditorMode) => void;
     onChangeSplitModeEnabled?: (splitModeEnabled: boolean) => void;
+    directiveSyntax?: DirectiveSyntaxValue;
 } & Pick<
     UseMarkdownEditorProps,
     | 'needToSetDimensionsForUploadedImages'
@@ -142,6 +144,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
         hidePreviewAfterSubmit,
         needToSetDimensionsForUploadedImages,
         experimental,
+        directiveSyntax,
     } = props;
     const [editorMode, setEditorMode] = React.useState<MarkdownEditorMode>(
         initialEditor ?? 'wysiwyg',
@@ -153,7 +156,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
     }, [mdRaw]);
 
     const renderPreview = useCallback<RenderPreview>(
-        ({getValue, md}) => (
+        ({getValue, md, directiveSyntax}) => (
             <SplitModePreview
                 getValue={getValue}
                 allowHTML={md.html}
@@ -161,7 +164,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
                 linkifyTlds={md.linkifyTlds}
                 breaks={md.breaks}
                 needToSanitizeHtml={sanitizeHtml}
-                plugins={plugins}
+                plugins={getPlugins({directiveSyntax})}
             />
         ),
         [sanitizeHtml],
@@ -182,7 +185,10 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
             needToSetDimensionsForUploadedImages,
             renderPreview: renderPreviewDefined ? renderPreview : undefined,
             fileUploadHandler,
-            experimental,
+            experimental: {
+                ...experimental,
+                directiveSyntax,
+            },
             prepareRawMarkup: prepareRawMarkup
                 ? (value) => '**prepare raw markup**\n\n' + value
                 : undefined,
@@ -249,6 +255,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
             experimental?.needToSetDimensionsForUploadedImages,
             experimental?.beforeEditorModeChange,
             experimental?.prepareRawMarkup,
+            directiveSyntax,
         ],
     );
 

--- a/demo/components/PlaygroundMini.tsx
+++ b/demo/components/PlaygroundMini.tsx
@@ -23,6 +23,7 @@ export type PlaygroundMiniProps = Pick<
     | 'onChangeEditorType'
     | 'onChangeSplitModeEnabled'
     | 'escapeConfig'
+    | 'directiveSyntax'
 > & {withDefaultInitialContent?: boolean};
 
 export const PlaygroundMini = React.memo<PlaygroundMiniProps>(

--- a/demo/defaults/args.ts
+++ b/demo/defaults/args.ts
@@ -16,4 +16,5 @@ export const args: Meta<PlaygroundMiniProps>['args'] = {
     initialSplitModeEnabled: false,
     renderPreviewDefined: true,
     height: 'initial',
+    directiveSyntax: 'disabled',
 };

--- a/demo/defaults/md-plugins.ts
+++ b/demo/defaults/md-plugins.ts
@@ -19,6 +19,7 @@ import yfmTable from '@diplodoc/transform/lib/plugins/table';
 import video from '@diplodoc/transform/lib/plugins/video';
 import type {PluginWithParams} from 'markdown-it/lib';
 
+import type {RenderPreviewParams} from '../../src';
 import {emojiDefs} from '../../src/bundle/emoji';
 import color from '../../src/markdown-it/color';
 import {bare as emoji} from '../../src/markdown-it/emoji';
@@ -30,54 +31,62 @@ export const LATEX_RUNTIME = 'extension:latex';
 export const MERMAID_RUNTIME = 'extension:mermaid';
 export const YFM_HTML_BLOCK_RUNTIME = 'extension:yfm-html-block';
 
-const defaultPlugins: PluginWithParams[] = [
-    anchors,
-    code,
-    yfmCut({bundle: false}) as PluginWithParams,
-    deflist,
-    file,
-    (md) => md.use(imsize, {enableInlineStyling: true}),
-    meta,
-    monospace,
-    notes,
-    sup,
-    yfmTabs({
-        bundle: false,
-        features: {
-            enabledVariants: {
-                regular: true,
-                radio: true,
-                dropdown: false,
-                accordion: false,
-            },
-        },
-    }),
-    video,
-    yfmTable,
-];
-const extendedPlugins = defaultPlugins.concat(
-    (md) => md.use(emoji, {defs: emojiDefs}),
-    checkbox,
-    color,
-    ins,
-    latex({bundle: false, validate: false, runtime: LATEX_RUNTIME}),
-    mark,
-    mermaid({bundle: false, runtime: MERMAID_RUNTIME}),
-    sub,
-    yfmHtmlBlock({
-        bundle: false,
-        runtimeJsPath: YFM_HTML_BLOCK_RUNTIME,
-        head: `
-            <base target="_blank" />
-            <style>
-                html, body {
-                    margin: 0;
-                    padding: 0;
-                }
-            </style
-        `,
-    }),
-    foldingHeadings({bundle: false}),
-);
+type GetPluginsOptions = {
+    directiveSyntax?: RenderPreviewParams['directiveSyntax'];
+};
 
-export {extendedPlugins as plugins};
+export function getPlugins(_opts: GetPluginsOptions = {}): markdownit.PluginWithParams[] {
+    const defaultPlugins: PluginWithParams[] = [
+        anchors,
+        code,
+        yfmCut({bundle: false}),
+        deflist,
+        file,
+        (md) => md.use(imsize, {enableInlineStyling: true}),
+        meta,
+        monospace,
+        notes,
+        sup,
+        yfmTabs({
+            bundle: false,
+            features: {
+                enabledVariants: {
+                    regular: true,
+                    radio: true,
+                    dropdown: false,
+                    accordion: false,
+                },
+            },
+        }),
+        video,
+        yfmTable,
+    ];
+    const extendedPlugins = defaultPlugins.concat(
+        (md) => md.use(emoji, {defs: emojiDefs}),
+        checkbox,
+        color,
+        ins,
+        latex({bundle: false, validate: false, runtime: LATEX_RUNTIME}),
+        mark,
+        mermaid({bundle: false, runtime: MERMAID_RUNTIME}),
+        sub,
+        yfmHtmlBlock({
+            bundle: false,
+            runtimeJsPath: YFM_HTML_BLOCK_RUNTIME,
+            head: `
+                        <base target="_blank" />
+                        <style>
+                            html, body {
+                                margin: 0;
+                                padding: 0;
+                            }
+                        </style
+                    `,
+        }),
+        foldingHeadings({bundle: false}),
+    );
+
+    return extendedPlugins;
+}
+
+export const plugins = getPlugins();

--- a/demo/defaults/md-plugins.ts
+++ b/demo/defaults/md-plugins.ts
@@ -35,11 +35,16 @@ type GetPluginsOptions = {
     directiveSyntax?: RenderPreviewParams['directiveSyntax'];
 };
 
-export function getPlugins(_opts: GetPluginsOptions = {}): markdownit.PluginWithParams[] {
+export function getPlugins({
+    directiveSyntax,
+}: GetPluginsOptions = {}): markdownit.PluginWithParams[] {
     const defaultPlugins: PluginWithParams[] = [
         anchors,
         code,
-        yfmCut({bundle: false}),
+        yfmCut({
+            bundle: false,
+            directiveSyntax: directiveSyntax?.mdPluginValueFor('yfmCut'),
+        }),
         deflist,
         file,
         (md) => md.use(imsize, {enableInlineStyling: true}),

--- a/demo/stories/markdown/Markdown.stories.tsx
+++ b/demo/stories/markdown/Markdown.stories.tsx
@@ -61,7 +61,7 @@ export default {
     args: args,
     parameters: {
         controls: {
-            exclude: excludedControls,
+            exclude: excludedControls.concat('directiveSyntax'),
         },
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@diplodoc/cut-extension": "^0.3.1",
+        "@diplodoc/cut-extension": "^0.4.0",
         "@diplodoc/folding-headings-extension": "0.1.0",
         "@diplodoc/html-extension": "2.3.2",
         "@diplodoc/latex-extension": "1.0.3",
@@ -110,11 +110,12 @@
         "sass": "^1.64.1",
         "sass-loader": "^13.3.2",
         "stylelint": "15.11.0",
+        "ts-dedent": "2.2.0",
         "ts-jest": "^27.0.7",
         "typescript": "^4.5.2"
       },
       "peerDependencies": {
-        "@diplodoc/cut-extension": "^0.3.1",
+        "@diplodoc/cut-extension": "^0.3.1 || ^0.4.0",
         "@diplodoc/folding-headings-extension": "^0.1.0",
         "@diplodoc/html-extension": "2.3.2",
         "@diplodoc/latex-extension": "^1.0.3",
@@ -2517,13 +2518,25 @@
       }
     },
     "node_modules/@diplodoc/cut-extension": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/cut-extension/-/cut-extension-0.3.1.tgz",
-      "integrity": "sha512-Em17/XxXm7V8xgaayaMqf0Yek8Rgr3lko6YbX2Z80eDLHjr7wD+C1latPo/HwZ5OS3NUjEuaM+NgIfbU0uUQgA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@diplodoc/cut-extension/-/cut-extension-0.4.0.tgz",
+      "integrity": "sha512-0H8bNRNkdXBej/gMuitHO+WyQd+vP3mSM4Ixpt2HMta+JzmQYjacFV+uxMa4Tkbzspeo6C6HAwbkvNTmedMRUw==",
       "dev": true,
+      "dependencies": {
+        "@diplodoc/directive": "^0.1.0"
+      },
       "peerDependencies": {
         "@diplodoc/utils": "1.0.0",
         "react": "^16.8.0  || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@diplodoc/directive": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@diplodoc/directive/-/directive-0.1.0.tgz",
+      "integrity": "sha512-wQ4RoCoCjbWD9r2YdVPlgTW8+a0JNmsh4OmRLq4EA5PJ1SLjUKqSP9HkHb4LjRINLFtac6SsbXtQ8Y/zUiYazA==",
+      "dev": true,
+      "dependencies": {
+        "markdown-it-directive": "2.0.2"
       }
     },
     "node_modules/@diplodoc/folding-headings-extension": {
@@ -2638,6 +2651,16 @@
         "highlight.js": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@diplodoc/transform/node_modules/@diplodoc/cut-extension": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@diplodoc/cut-extension/-/cut-extension-0.3.2.tgz",
+      "integrity": "sha512-55AgVEIiy3GHorZRht3dm1AcFWdgCMAn8yGV/8qp8sPQ4LssPPuCrVzCVFMn7o8d3KZbEDt5dDj6kI1KtVaWQg==",
+      "dev": true,
+      "peerDependencies": {
+        "@diplodoc/utils": "1.0.0",
+        "react": "^16.8.0  || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@diplodoc/transform/node_modules/js-yaml": {

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@diplodoc/cut-extension": "^0.3.1",
+    "@diplodoc/cut-extension": "^0.4.0",
     "@diplodoc/folding-headings-extension": "0.1.0",
     "@diplodoc/html-extension": "2.3.2",
     "@diplodoc/latex-extension": "1.0.3",
@@ -258,6 +258,7 @@
     "sass": "^1.64.1",
     "sass-loader": "^13.3.2",
     "stylelint": "15.11.0",
+    "ts-dedent": "2.2.0",
     "ts-jest": "^27.0.7",
     "typescript": "^4.5.2"
   },
@@ -282,7 +283,7 @@
     }
   },
   "peerDependencies": {
-    "@diplodoc/cut-extension": "^0.3.1",
+    "@diplodoc/cut-extension": "^0.3.1 || ^0.4.0",
     "@diplodoc/folding-headings-extension": "^0.1.0",
     "@diplodoc/html-extension": "2.3.2",
     "@diplodoc/latex-extension": "^1.0.3",

--- a/src/bundle/Editor.ts
+++ b/src/bundle/Editor.ts
@@ -17,6 +17,7 @@ import {logger} from '../logger';
 import {createCodemirror} from '../markup';
 import {type CodeEditor, Editor as MarkupEditor} from '../markup/editor';
 import {type Emitter, FileUploadHandler, type Receiver, SafeEventEmitter} from '../utils';
+import type {DirectiveSyntaxContext} from '../utils/directive';
 
 import type {
     MarkdownEditorMode as EditorMode,
@@ -79,6 +80,7 @@ export interface EditorInt
     readonly splitMode: SplitMode;
     readonly preset: EditorPreset;
     readonly mdOptions: Readonly<MarkdownEditorMdOptions>;
+    readonly directiveSyntax: DirectiveSyntaxContext;
 
     /** @internal used in demo for dev-tools */
     readonly _wysiwygView?: PMEditorView;
@@ -120,6 +122,7 @@ export type EditorOptions = Pick<
 > & {
     renderStorage: ReactRenderStorage;
     preset: EditorPreset;
+    directiveSyntax: DirectiveSyntaxContext;
 };
 
 /** @internal */
@@ -143,6 +146,7 @@ export class EditorImpl extends SafeEventEmitter<EventMapInt> implements EditorI
     #parseInsertedUrlAsImage?: ParseInsertedUrlAsImage;
     #needToSetDimensionsForUploadedImages: boolean;
     #enableNewImageSizeCalculation: boolean;
+    #directiveSyntax: DirectiveSyntaxContext;
     #prepareRawMarkup?: (value: MarkupString) => MarkupString;
     #beforeEditorModeChange?: (
         options: Pick<ChangeEditorModeOptions, 'mode' | 'reason'>,
@@ -215,6 +219,10 @@ export class EditorImpl extends SafeEventEmitter<EventMapInt> implements EditorI
         return this.#mdOptions;
     }
 
+    get directiveSyntax(): DirectiveSyntaxContext {
+        return this.#directiveSyntax;
+    }
+
     get renderPreview(): RenderPreview | undefined {
         return this.#renderPreview;
     }
@@ -271,6 +279,7 @@ export class EditorImpl extends SafeEventEmitter<EventMapInt> implements EditorI
                     keymaps: this.#markupConfig.keymaps,
                     yfmLangOptions: {languageData: this.#markupConfig.languageData},
                     autocompletion: this.#markupConfig.autocompletion,
+                    directiveSyntax: this.directiveSyntax,
                     receiver: this,
                 }),
             );
@@ -329,6 +338,7 @@ export class EditorImpl extends SafeEventEmitter<EventMapInt> implements EditorI
         this.#needToSetDimensionsForUploadedImages = Boolean(
             experimental.needToSetDimensionsForUploadedImages,
         );
+        this.#directiveSyntax = opts.directiveSyntax;
         this.#enableNewImageSizeCalculation = Boolean(experimental.enableNewImageSizeCalculation);
         this.#prepareRawMarkup = experimental.prepareRawMarkup;
         this.#escapeConfig = wysiwygConfig.escapeConfig;

--- a/src/bundle/MarkdownEditorView.tsx
+++ b/src/bundle/MarkdownEditorView.tsx
@@ -240,6 +240,7 @@ export const MarkdownEditorView = React.forwardRef<HTMLDivElement, MarkdownEdito
                                             getValue: editor.getValue,
                                             mode: 'preview',
                                             md: editor.mdOptions,
+                                            directiveSyntax: editor.directiveSyntax,
                                         })}
                                     </div>
                                     {settings}

--- a/src/bundle/SplitModeView.tsx
+++ b/src/bundle/SplitModeView.tsx
@@ -110,6 +110,7 @@ const SplitModeView = React.forwardRef<HTMLDivElement, SplitModeProps>(({editor}
                 getValue: editor.getValue,
                 mode: 'split',
                 md: editor.mdOptions,
+                directiveSyntax: editor.directiveSyntax,
             })}
         </div>
     );

--- a/src/bundle/types.ts
+++ b/src/bundle/types.ts
@@ -6,6 +6,7 @@ import type {MarkupString} from '../common';
 import type {EscapeConfig, Extension} from '../core';
 import type {CreateCodemirrorParams, YfmLangOptions} from '../markup';
 import type {FileUploadHandler} from '../utils';
+import type {DirectiveSyntaxContext, DirectiveSyntaxOption} from '../utils/directive';
 
 import type {ChangeEditorModeOptions} from './Editor';
 import type {ExtensionsOptions as WysiwygPresetExtensionsOptions} from './wysiwyg-preset';
@@ -19,6 +20,7 @@ export type RenderPreviewParams = {
     getValue: () => MarkupString;
     mode: 'preview' | 'split';
     md: Readonly<MarkdownEditorMdOptions>;
+    directiveSyntax: Pick<DirectiveSyntaxContext, 'option' | 'valueFor' | 'mdPluginValueFor'>;
 };
 export type RenderPreview = (params: RenderPreviewParams) => ReactNode;
 
@@ -71,6 +73,26 @@ export type MarkdownEditorExperimentalOptions = {
     beforeEditorModeChange?: (
         options: Pick<ChangeEditorModeOptions, 'mode' | 'reason'>,
     ) => boolean | undefined;
+    /**
+     * Enables support of directive syntax for diplodoc (YFM) extensions.
+     *
+     * **Note:** This setting affects parsing of markdown markup and serializing to markdown markup.
+     * Be careful with it and use it in consistency with diplodoc/transform and diplodoc-extensions.
+     *
+     * Before enabling this option, make sure that appropriate versions of diplodoc/transform and diplodoc-extensions are installed.
+     *
+     * You can pass an object in `key:value` format to provide different behaviour for each extension individually.
+     *
+     * Values:
+     * - 'disabled' – directive syntax is disabled;
+     * - 'enabled' – directive syntax is enabled. Syntax of existing blocks is preserved. New blocks will be serialized using old syntax;
+     * - 'preserve' – directive syntax is enabled. Syntax of existing blocks is preserved. New blocks will be serialized using directive syntax;
+     * - 'overwrite' – existing blocks will be overwritten using directive syntax through serialization;
+     * - 'only' – old syntax is disabled, only directive syntax available. Blocks in old syntax will not be parsed.
+     *
+     * Default value is 'disabled'.
+     */
+    directiveSyntax?: DirectiveSyntaxOption;
 };
 
 export type MarkdownEditorMarkupConfig = {

--- a/src/bundle/useMarkdownEditor.ts
+++ b/src/bundle/useMarkdownEditor.ts
@@ -3,6 +3,7 @@ import {useLayoutEffect, useMemo} from 'react';
 import type {Extension} from '../core';
 import {ReactRenderStorage} from '../extensions';
 import {logger} from '../logger';
+import {DirectiveSyntaxContext} from '../utils/directive';
 
 import {EditorImpl, type EditorInt} from './Editor';
 import type {
@@ -40,11 +41,14 @@ export function useMarkdownEditor<T extends object = {}>(
             props.needToSetDimensionsForUploadedImages;
         const enableNewImageSizeCalculation = experimental.enableNewImageSizeCalculation;
 
+        const directiveSyntax = new DirectiveSyntaxContext(experimental.directiveSyntax);
+
         const extensions: Extension = (builder) => {
             const extensionOptions = wysiwygConfig.extensionOptions ?? props.extensionOptions;
 
             builder.use(BundlePreset, {
                 ...extensionOptions,
+                directiveSyntax,
                 preset,
                 reactRenderer: renderStorage,
                 onCancel: () => {
@@ -71,6 +75,7 @@ export function useMarkdownEditor<T extends object = {}>(
             ...props,
             preset,
             renderStorage,
+            directiveSyntax,
             md: {
                 ...md,
                 breaks,

--- a/src/bundle/wysiwyg-preset.ts
+++ b/src/bundle/wysiwyg-preset.ts
@@ -1,6 +1,6 @@
 import {Node} from 'prosemirror-model';
 
-import {ExtensionAuto} from '../core';
+import type {ExtensionAuto} from '../core';
 import {BehaviorPreset, BehaviorPresetOptions} from '../extensions/behavior';
 import {EditorModeKeymap, EditorModeKeymapOptions} from '../extensions/behavior/EditorModeKeymap';
 import {BaseNode, YfmHeadingAttr, YfmNoteNode} from '../extensions/specs';
@@ -11,11 +11,12 @@ import {FullPreset, FullPresetOptions} from '../presets/full';
 import {YfmPreset, YfmPresetOptions} from '../presets/yfm';
 import {ZeroPreset, ZeroPresetOptions} from '../presets/zero';
 import {Action as A, formatter as f} from '../shortcuts';
+import type {DirectiveSyntaxContext} from '../utils/directive';
 import type {FileUploadHandler} from '../utils/upload';
 
 import {wCommandMenuConfigByPreset, wSelectionMenuConfigByPreset} from './config/wysiwyg';
 import {emojiDefs} from './emoji';
-import {MarkdownEditorPreset} from './types';
+import type {MarkdownEditorPreset} from './types';
 
 const DEFAULT_IGNORED_KEYS = ['Tab', 'Shift-Tab'] as const;
 
@@ -33,9 +34,20 @@ export type BundlePresetOptions = ExtensionsOptions &
          */
         needToSetDimensionsForUploadedImages?: boolean;
         enableNewImageSizeCalculation?: boolean;
+        directiveSyntax: DirectiveSyntaxContext;
     };
 
+declare global {
+    namespace WysiwygEditor {
+        interface Context {
+            directiveSyntax: DirectiveSyntaxContext;
+        }
+    }
+}
+
 export const BundlePreset: ExtensionAuto<BundlePresetOptions> = (builder, opts) => {
+    builder.context.set('directiveSyntax', opts.directiveSyntax);
+
     const dropCursor: NonNullable<BundlePresetOptions['cursor']>['dropOptions'] = {
         color: 'var(--g-color-line-brand)',
         width: 2,

--- a/src/extensions/yfm/YfmCut/YfmCut.test.ts
+++ b/src/extensions/yfm/YfmCut/YfmCut.test.ts
@@ -1,8 +1,10 @@
 import {builders} from 'prosemirror-test-builder';
+import dd from 'ts-dedent';
 
 import {parseDOM} from '../../../../tests/parse-dom';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
 import {ExtensionsManager} from '../../../core';
+import {DirectiveSyntaxContext, type DirectiveSyntaxOption} from '../../../utils/directive';
 import {BaseNode, BaseSchemaSpecs} from '../../base/specs';
 import {
     BlockquoteSpecs,
@@ -14,21 +16,34 @@ import {
     italicMarkName,
 } from '../../markdown/specs';
 
-import {CutNode, YfmCutSpecs} from './YfmCutSpecs';
+import {CutAttr, CutNode, YfmCutSpecs} from './YfmCutSpecs';
 
-const {
-    schema,
-    markupParser: parser,
-    serializer,
-} = new ExtensionsManager({
-    extensions: (builder) =>
-        builder
-            .use(BaseSchemaSpecs, {})
-            .use(ItalicSpecs)
-            .use(BlockquoteSpecs)
-            .use(YfmCutSpecs, {})
-            .use(ImageSpecs),
-}).buildDeps();
+class DirectiveContext extends DirectiveSyntaxContext {
+    setOption(option: DirectiveSyntaxOption | undefined) {
+        this.option = option;
+    }
+}
+const directiveContext = new DirectiveContext(undefined);
+
+function buildDeps() {
+    return new ExtensionsManager({
+        extensions: (builder) => {
+            builder.context.set('directiveSyntax', directiveContext);
+            builder
+                .use(BaseSchemaSpecs, {})
+                .use(ItalicSpecs)
+                .use(BlockquoteSpecs)
+                .use(YfmCutSpecs, {})
+                .use(ImageSpecs);
+        },
+    }).buildDeps();
+}
+function buildCheckers() {
+    const {markupParser, serializer} = buildDeps();
+    return createMarkupChecker({parser: markupParser, serializer});
+}
+
+const {schema, markupParser: parser, serializer} = buildDeps();
 
 const {doc, p, i, bq, img, cut, cutTitle, cutContent} = builders<
     'doc' | 'p' | 'bq' | 'img' | 'cut' | 'cutTitle' | 'cutContent',
@@ -48,83 +63,117 @@ const {same} = createMarkupChecker({parser, serializer});
 
 describe('YfmCut extension', () => {
     it('should parse yfm-cut', () => {
-        const markup = `
-{% cut "cut title" %}
+        const markup = dd`
+        {% cut "cut title" %}
 
-cut content
+        cut content
 
-cut content 2
+        cut content 2
 
-{% endcut %}
-`.trim();
-
-        same(
-            markup,
-            doc(cut(cutTitle('cut title'), cutContent(p('cut content'), p('cut content 2')))),
-        );
-    });
-
-    it('should parse nested yfm-cuts', () => {
-        const markup = `
-{% cut "cut title" %}
-
-{% cut "cut title 2" %}
-
-cut content
-
-{% endcut %}
-
-{% endcut %}
-`.trim();
+        {% endcut %}
+        `.trim();
 
         same(
             markup,
             doc(
                 cut(
+                    {[CutAttr.Markup]: '{%'},
                     cutTitle('cut title'),
-                    cutContent(cut(cutTitle('cut title 2'), cutContent(p('cut content')))),
+                    cutContent(p('cut content'), p('cut content 2')),
+                ),
+            ),
+        );
+    });
+
+    it('should parse nested yfm-cuts', () => {
+        const markup = dd`
+        {% cut "cut title" %}
+
+        {% cut "cut title 2" %}
+
+        cut content
+
+        {% endcut %}
+
+        {% endcut %}
+        `.trim();
+
+        same(
+            markup,
+            doc(
+                cut(
+                    {[CutAttr.Markup]: '{%'},
+                    cutTitle('cut title'),
+                    cutContent(
+                        cut(
+                            {[CutAttr.Markup]: '{%'},
+                            cutTitle('cut title 2'),
+                            cutContent(p('cut content')),
+                        ),
+                    ),
                 ),
             ),
         );
     });
 
     it('should parse yfm-cut under blockquote', () => {
-        const markup = `
-> {% cut "cut title" %}
-> 
-> cut content
->
-> {% endcut %}
-`.trim();
+        const markup = dd`
+        > {% cut "cut title" %}
+        > 
+        > cut content
+        >
+        > {% endcut %}
+        `.trim();
 
-        same(markup, doc(bq(cut(cutTitle('cut title'), cutContent(p('cut content'))))));
+        same(
+            markup,
+            doc(
+                bq(
+                    cut(
+                        {[CutAttr.Markup]: '{%'},
+                        cutTitle('cut title'),
+                        cutContent(p('cut content')),
+                    ),
+                ),
+            ),
+        );
     });
 
     it('should parse yfm-cut with inline markup in cut title', () => {
-        const markup = `
-{% cut "*cut italic title*" %}
+        const markup = dd`
+        {% cut "*cut italic title*" %}
 
-cut content
+        cut content
 
-{% endcut %}
-    `.trim();
-
-        same(markup, doc(cut(cutTitle(i('cut italic title')), cutContent(p('cut content')))));
-    });
-
-    it('should parse yfm-cut with inline node in cut title', () => {
-        const markup = `
-{% cut "![img](path/to/img)" %}
-
-cut content
-
-{% endcut %}
-    `.trim();
+        {% endcut %}
+        `.trim();
 
         same(
             markup,
             doc(
                 cut(
+                    {[CutAttr.Markup]: '{%'},
+                    cutTitle(i('cut italic title')),
+                    cutContent(p('cut content')),
+                ),
+            ),
+        );
+    });
+
+    it('should parse yfm-cut with inline node in cut title', () => {
+        const markup = dd`
+        {% cut "![img](path/to/img)" %}
+
+        cut content
+
+        {% endcut %}
+        `.trim();
+
+        same(
+            markup,
+            doc(
+                cut(
+                    {[CutAttr.Markup]: '{%'},
                     cutTitle(
                         img({
                             [ImageAttr.Src]: 'path/to/img',
@@ -137,7 +186,7 @@ cut content
         );
     });
 
-    it('should parse yfm-note from html', () => {
+    it('should parse yfm-cut from html', () => {
         parseDOM(
             schema,
             '<div class="yfm-cut">' +
@@ -146,5 +195,215 @@ cut content
                 '</div>',
             doc(cut(cutTitle('YfmCut title'), cutContent(p('YfmCut content')))),
         );
+    });
+
+    it('should parse yfm-cut with markup attr from html', () => {
+        parseDOM(
+            schema,
+            '<div class="yfm-cut" data-markup="{%">' +
+                '<div class="yfm-cut-title">YfmCut title</div>' +
+                '<div><p>YfmCut content</p></div' +
+                '</div>',
+            doc(
+                cut(
+                    {[CutAttr.Markup]: '{%'},
+                    cutTitle('YfmCut title'),
+                    cutContent(p('YfmCut content')),
+                ),
+            ),
+        );
+    });
+
+    describe('Directive syntax', () => {
+        afterAll(() => {
+            directiveContext.setOption(undefined);
+        });
+
+        const PM_DOC = {
+            CurlyCut: doc(
+                cut({[CutAttr.Markup]: '{%'}, cutTitle('title'), cutContent(p('content'))),
+            ),
+            UnknownCut: doc(cut(cutTitle('title'), cutContent(p('content')))),
+            DirectiveCut: doc(
+                cut({[CutAttr.Markup]: ':::cut'}, cutTitle('title'), cutContent(p('content'))),
+            ),
+        };
+        const MARKUP = {
+            CurlySyntax: dd`
+            {% cut "title" %}
+
+            content
+
+            {% endcut %}
+            `,
+
+            DirectiveSyntax: dd`
+            :::cut [title]
+            content
+
+            :::
+            `,
+        };
+
+        describe('directiveSyntax:disabled', () => {
+            beforeAll(() => {
+                directiveContext.setOption('disabled');
+            });
+
+            it('should parse curly cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(MARKUP.CurlySyntax, PM_DOC.CurlyCut, {json: true});
+            });
+
+            it('should not parse directive cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(MARKUP.DirectiveSyntax, doc(p(':::cut [title]\ncontent'), p(':::')), {
+                    json: true,
+                });
+            });
+
+            it('should preserve curly cut syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.CurlyCut, MARKUP.CurlySyntax);
+            });
+
+            it('should serialize cut with unknown markup to curly syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.UnknownCut, MARKUP.CurlySyntax);
+            });
+
+            it('should preserve directive cut to curly syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.DirectiveCut, MARKUP.DirectiveSyntax);
+            });
+        });
+
+        describe('directiveSyntax:enabled', () => {
+            beforeAll(() => {
+                directiveContext.setOption('enabled');
+            });
+
+            it('should parse curly cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(MARKUP.CurlySyntax, PM_DOC.CurlyCut, {json: true});
+            });
+
+            it('should parse directive cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(MARKUP.DirectiveSyntax, PM_DOC.DirectiveCut, {json: true});
+            });
+
+            it('should preserve curly cut syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.CurlyCut, MARKUP.CurlySyntax);
+            });
+
+            it('should serialize cut with unknown markup to curly syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.UnknownCut, MARKUP.CurlySyntax);
+            });
+
+            it('should preserve directive cut syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.DirectiveCut, MARKUP.DirectiveSyntax);
+            });
+        });
+
+        describe('directiveSyntax:preserve', () => {
+            beforeAll(() => {
+                directiveContext.setOption('preserve');
+            });
+
+            it('should parse curly cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(MARKUP.CurlySyntax, PM_DOC.CurlyCut, {json: true});
+            });
+
+            it('should parse directive cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(MARKUP.DirectiveSyntax, PM_DOC.DirectiveCut, {json: true});
+            });
+
+            it('should preserve curly cut syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.CurlyCut, MARKUP.CurlySyntax);
+            });
+
+            it('should serialize cut with unknown markup to directive syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.UnknownCut, MARKUP.DirectiveSyntax);
+            });
+
+            it('should preserve directive cut syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.DirectiveCut, MARKUP.DirectiveSyntax);
+            });
+        });
+
+        describe('directiveSyntax:overwrite', () => {
+            beforeAll(() => {
+                directiveContext.setOption('overwrite');
+            });
+
+            it('should parse curly cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(MARKUP.CurlySyntax, PM_DOC.CurlyCut, {json: true});
+            });
+
+            it('should parse directive cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(MARKUP.DirectiveSyntax, PM_DOC.DirectiveCut, {json: true});
+            });
+
+            it('should overwrite curly cut to directive syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.CurlyCut, MARKUP.DirectiveSyntax);
+            });
+
+            it('should serialize cut with unknown markup to directive syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.UnknownCut, MARKUP.DirectiveSyntax);
+            });
+
+            it('should preserve directive cut syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.DirectiveCut, MARKUP.DirectiveSyntax);
+            });
+        });
+
+        describe('directiveSyntax:only', () => {
+            beforeAll(() => {
+                directiveContext.setOption('only');
+            });
+
+            it('should not parse curly cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(
+                    MARKUP.CurlySyntax,
+                    doc(p('{% cut "title" %}'), p('content'), p('{% endcut %}')),
+                    {json: true},
+                );
+            });
+
+            it('should parse directive cut syntax', () => {
+                const {parse} = buildCheckers();
+                parse(MARKUP.DirectiveSyntax, PM_DOC.DirectiveCut, {json: true});
+            });
+
+            it('should overwrite curly cut to directive syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.CurlyCut, MARKUP.DirectiveSyntax);
+            });
+
+            it('should serialize cut with unknown markup to directive syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.UnknownCut, MARKUP.DirectiveSyntax);
+            });
+
+            it('should preserve directive cut syntax', () => {
+                const {serialize} = buildCheckers();
+                serialize(PM_DOC.DirectiveCut, MARKUP.DirectiveSyntax);
+            });
+        });
     });
 });

--- a/src/extensions/yfm/YfmCut/YfmCutSpecs/const.ts
+++ b/src/extensions/yfm/YfmCut/YfmCutSpecs/const.ts
@@ -6,6 +6,11 @@ export enum CutNode {
     CutContent = 'yfm_cut_content',
 }
 
+export enum CutAttr {
+    Class = 'class',
+    Markup = 'data-markup',
+}
+
 export const cutType = nodeTypeFactory(CutNode.Cut);
 export const cutTitleType = nodeTypeFactory(CutNode.CutTitle);
 export const cutContentType = nodeTypeFactory(CutNode.CutContent);

--- a/src/extensions/yfm/YfmCut/YfmCutSpecs/index.ts
+++ b/src/extensions/yfm/YfmCut/YfmCutSpecs/index.ts
@@ -6,9 +6,18 @@ import type {ExtensionAuto, ExtensionNodeSpec} from '../../../../core';
 import {CutNode} from './const';
 import {parserTokens} from './parser';
 import {getSchemaSpecs} from './schema';
-import {serializerTokens} from './serializer';
+import {getSerializerTokens} from './serializer';
 
-export {CutNode, cutType, cutTitleType, cutContentType} from './const';
+export {CutAttr, CutNode, cutType, cutTitleType, cutContentType} from './const';
+
+declare global {
+    namespace MarkdownEditor {
+        interface DirectiveSyntaxAdditionalSupportedExtensions {
+            // Mark in global types that YfmCut has support for directive syntax
+            yfmCut: true;
+        }
+    }
+}
 
 export type YfmCutSpecsOptions = {
     cutView?: ExtensionNodeSpec['view'];
@@ -26,9 +35,18 @@ export type YfmCutSpecsOptions = {
 
 export const YfmCutSpecs: ExtensionAuto<YfmCutSpecsOptions> = (builder, opts) => {
     const schemaSpecs = getSchemaSpecs(opts, builder.context.get('placeholder'));
+    const directiveSyntax = builder.context.get('directiveSyntax');
+    const serializerTokens = getSerializerTokens({directiveSyntax});
 
     builder
-        .configureMd((md) => md.use(yfmCut({bundle: false})))
+        .configureMd((md) =>
+            md.use(
+                yfmCut({
+                    bundle: false,
+                    directiveSyntax: directiveSyntax?.mdPluginValueFor('yfmCut'),
+                }),
+            ),
+        )
         .addNode(CutNode.Cut, () => ({
             spec: schemaSpecs[CutNode.Cut],
             toMd: serializerTokens[CutNode.Cut],

--- a/src/extensions/yfm/YfmCut/YfmCutSpecs/parser.ts
+++ b/src/extensions/yfm/YfmCut/YfmCutSpecs/parser.ts
@@ -1,8 +1,12 @@
 import type {ParserToken} from '../../../../core';
 
-import {CutNode} from './const';
+import {CutAttr, CutNode} from './const';
 
-const getAttrs: ParserToken['getAttrs'] = (tok) => (tok.attrs ? Object.fromEntries(tok.attrs) : {});
+const getAttrs: ParserToken['getAttrs'] = (tok) => {
+    const nodeAttrs = tok.attrs ? Object.fromEntries(tok.attrs) : {};
+    nodeAttrs[CutAttr.Markup] = tok.markup;
+    return nodeAttrs;
+};
 
 export const parserTokens: Record<CutNode, ParserToken> = {
     [CutNode.Cut]: {name: CutNode.Cut, type: 'block', getAttrs},

--- a/src/extensions/yfm/YfmCut/YfmCutSpecs/schema.ts
+++ b/src/extensions/yfm/YfmCut/YfmCutSpecs/schema.ts
@@ -1,7 +1,8 @@
 import type {NodeSpec} from 'prosemirror-model';
 
 import type {PlaceholderOptions} from '../../../../utils/placeholder';
-import {CutNode} from '../const';
+
+import {CutAttr, CutNode} from './const';
 
 import type {YfmCutSpecsOptions} from './index';
 
@@ -15,10 +16,15 @@ export const getSchemaSpecs = (
     placeholder?: PlaceholderOptions,
 ): Record<CutNode, NodeSpec> => ({
     [CutNode.Cut]: {
-        attrs: {class: {default: 'yfm-cut'}},
+        attrs: {class: {default: 'yfm-cut'}, [CutAttr.Markup]: {default: null}},
         content: `${CutNode.CutTitle} ${CutNode.CutContent}`,
         group: 'block yfm-cut',
-        parseDOM: [{tag: '.yfm-cut'}],
+        parseDOM: [
+            {
+                tag: '.yfm-cut',
+                getAttrs: (node) => ({[CutAttr.Markup]: node.getAttribute(CutAttr.Markup)}),
+            },
+        ],
         toDOM(node) {
             return ['div', node.attrs, 0];
         },

--- a/src/extensions/yfm/YfmCut/YfmCutSpecs/serializer.ts
+++ b/src/extensions/yfm/YfmCut/YfmCutSpecs/serializer.ts
@@ -1,27 +1,53 @@
+import type {Node} from 'prosemirror-model';
+
 import type {SerializerNodeToken} from '../../../../core';
 import {isNodeEmpty} from '../../../../utils/nodes';
 import {getPlaceholderContent} from '../../../../utils/placeholder';
 
-import {CutNode} from './const';
+import {CutAttr, CutNode} from './const';
 
-export const serializerTokens: Record<CutNode, SerializerNodeToken> = {
-    [CutNode.Cut]: (state, node) => {
-        state.renderContent(node);
-        state.write('{% endcut %}');
-        state.closeBlock(node);
-    },
+export function getSerializerTokens({
+    directiveSyntax,
+}: {
+    directiveSyntax?: WysiwygEditor.Context['directiveSyntax'];
+}): Record<CutNode, SerializerNodeToken> {
+    const isDirectiveCut = (node: Node): boolean | undefined => {
+        return directiveSyntax?.shouldSerializeToDirective('yfmCut', node.attrs[CutAttr.Markup]);
+    };
 
-    [CutNode.CutTitle]: (state, node) => {
-        state.write('{% cut "');
-        if (node.nodeSize > 2) state.renderInline(node);
-        else state.write(getPlaceholderContent(node));
-        state.write('" %}\n');
-        state.write('\n');
-        state.closeBlock();
-    },
+    return {
+        [CutNode.Cut]: (state, node) => {
+            state.renderContent(node);
+            state.write(isDirectiveCut(node) ? ':::' : '{% endcut %}');
+            state.closeBlock(node);
+        },
 
-    [CutNode.CutContent]: (state, node) => {
-        if (!isNodeEmpty(node)) state.renderInline(node);
-        else state.write(getPlaceholderContent(node) + '\n\n');
-    },
-};
+        [CutNode.CutTitle]: (state, node, parent) => {
+            if (isDirectiveCut(parent)) {
+                state.write(':::cut [');
+                state.renderInline(node);
+                state.write(']');
+                state.ensureNewLine();
+                state.closeBlock();
+                return;
+            }
+
+            state.write('{% cut "');
+            if (node.nodeSize > 2) state.renderInline(node);
+            else state.write(getPlaceholderContent(node));
+            state.write('" %}\n');
+            state.write('\n');
+            state.closeBlock();
+        },
+
+        [CutNode.CutContent]: (state, node, parent) => {
+            if (isDirectiveCut(parent)) {
+                state.renderContent(node);
+                return;
+            }
+
+            if (!isNodeEmpty(node)) state.renderInline(node);
+            else state.write(getPlaceholderContent(node) + '\n\n');
+        },
+    };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export * from './view';
 export * from './utils';
 export * from './bundle';
 
-export {ReactRendererFacet, getImageDimensions} from './markup';
+export {DirectiveSyntaxFacet, ReactRendererFacet, getImageDimensions} from './markup';
 export * as MarkupCommands from './markup/commands';
 export * as MarkupHelpers from './markup/commands/helpers';
 

--- a/src/markup/codemirror/create.ts
+++ b/src/markup/codemirror/create.ts
@@ -9,16 +9,17 @@ import {
 } from '@codemirror/commands';
 import {syntaxHighlighting} from '@codemirror/language';
 import type {Extension, StateCommand} from '@codemirror/state';
-import {EditorView, EditorViewConfig, KeyBinding, keymap, placeholder} from '@codemirror/view';
+import {EditorView, type EditorViewConfig, KeyBinding, keymap, placeholder} from '@codemirror/view';
 
 import type {ParseInsertedUrlAsImage} from '../../bundle';
-import {EventMap} from '../../bundle/Editor';
+import type {EventMap} from '../../bundle/Editor';
 import {ActionName} from '../../bundle/config/action-names';
-import {ReactRenderStorage} from '../../extensions';
+import type {ReactRenderStorage} from '../../extensions';
 import {DataTransferType} from '../../extensions/behavior/Clipboard/utils';
 import {logger} from '../../logger';
 import {Action as A, formatter as f} from '../../shortcuts';
-import {Receiver} from '../../utils';
+import type {Receiver} from '../../utils';
+import type {DirectiveSyntaxContext} from '../../utils/directive';
 import {
     insertImages,
     insertLink,
@@ -38,7 +39,8 @@ import {
     wrapToYfmNote,
 } from '../commands';
 
-import {FileUploadHandler, FileUploadHandlerFacet} from './files-upload-facet';
+import {DirectiveSyntaxFacet} from './directive-facet';
+import {type FileUploadHandler, FileUploadHandlerFacet} from './files-upload-facet';
 import {gravityHighlightStyle, gravityTheme} from './gravity';
 import {PairingCharactersExtension} from './pairing-chars';
 import {ReactRendererFacet} from './react-facet';
@@ -70,6 +72,7 @@ export type CreateCodemirrorParams = {
     receiver?: Receiver<EventMap>;
     yfmLangOptions?: YfmLangOptions;
     autocompletion?: Autocompletion;
+    directiveSyntax: DirectiveSyntaxContext;
 };
 
 export function createCodemirror(params: CreateCodemirrorParams) {
@@ -89,6 +92,7 @@ export function createCodemirror(params: CreateCodemirrorParams) {
         placeholder: placeholderContent,
         autocompletion: autocompletionConfig,
         parseInsertedUrlAsImage,
+        directiveSyntax,
     } = params;
 
     const extensions: Extension[] = [gravityTheme, placeholder(placeholderContent)];
@@ -144,6 +148,7 @@ export function createCodemirror(params: CreateCodemirrorParams) {
         autocompletion(autocompletionConfig),
         yfmLang(yfmLangOptions),
         ReactRendererFacet.of(reactRenderer),
+        DirectiveSyntaxFacet.of(directiveSyntax),
         PairingCharactersExtension,
         EditorView.lineWrapping,
         EditorView.contentAttributes.of({spellcheck: 'true'}),

--- a/src/markup/codemirror/directive-facet.ts
+++ b/src/markup/codemirror/directive-facet.ts
@@ -1,0 +1,11 @@
+import {Facet} from '@codemirror/state';
+
+import type {DirectiveSyntaxContext} from '../../utils/directive';
+
+export const DirectiveSyntaxFacet = Facet.define<
+    DirectiveSyntaxContext,
+    Omit<DirectiveSyntaxContext, 'shouldSerializeToDirective'>
+>({
+    combine: ([context]) => context,
+    static: true,
+});

--- a/src/markup/codemirror/index.ts
+++ b/src/markup/codemirror/index.ts
@@ -1,5 +1,6 @@
 export type {CreateCodemirrorParams} from './create';
 export {createCodemirror} from './create';
 export {ReactRendererFacet} from './react-facet';
+export {DirectiveSyntaxFacet} from './directive-facet';
 export {getImageDimensions, IMG_MAX_HEIGHT} from './files-upload-plugin';
 export type {YfmLangOptions} from './yfm';

--- a/src/markup/commands/yfm.ts
+++ b/src/markup/commands/yfm.ts
@@ -1,11 +1,24 @@
 import type {StateCommand} from '@codemirror/state';
 
+import {DirectiveSyntaxFacet} from '../codemirror/directive-facet';
+
 import {wrapToBlock} from './helpers';
 
-export const wrapToYfmCut: StateCommand = wrapToBlock(
+const wrapToYfmCutCurly: StateCommand = wrapToBlock(
     ({lineBreak}) => '{% cut "title" %}' + lineBreak.repeat(2),
     ({lineBreak}) => lineBreak.repeat(2) + '{% endcut %}',
 );
+const wrapToYfmCutDirective: StateCommand = wrapToBlock(
+    ({lineBreak}) => ':::cut [title]' + lineBreak,
+    ({lineBreak}) => lineBreak + ':::',
+);
+
+export const wrapToYfmCut: StateCommand = (target) => {
+    const cmd = target.state.facet(DirectiveSyntaxFacet).shouldInsertDirectiveMarkup('yfmCut')
+        ? wrapToYfmCutDirective
+        : wrapToYfmCutCurly;
+    return cmd(target);
+};
 
 export const wrapToYfmNote = wrapToBlock(
     ({lineBreak}) => '{% note info %}' + lineBreak.repeat(2),

--- a/src/utils/directive.ts
+++ b/src/utils/directive.ts
@@ -1,0 +1,66 @@
+export type DirectiveSyntaxValue = 'disabled' | 'enabled' | 'preserve' | 'overwrite' | 'only';
+type DirectiveSyntaxMdPluginValue = 'disabled' | 'enabled' | 'only';
+export type DirectiveSyntaxOption = DirectiveSyntaxValue | DirectiveSyntaxOptionObj;
+
+type DirectiveSyntaxOptionObj = {
+    [K in keyof MarkdownEditor.DirectiveSyntaxAdditionalSupportedExtensions]?: DirectiveSyntaxValue;
+};
+
+const DIRECTIVE_SYNTAX_DEFAULT: DirectiveSyntaxValue = 'disabled';
+
+declare global {
+    namespace MarkdownEditor {
+        /**
+         * Add more keys for you additional supported extensions
+         */
+        interface DirectiveSyntaxAdditionalSupportedExtensions {}
+    }
+}
+
+export class DirectiveSyntaxContext {
+    #option: DirectiveSyntaxOption;
+
+    protected set option(value: DirectiveSyntaxOption | undefined) {
+        this.#option = value ?? DIRECTIVE_SYNTAX_DEFAULT;
+    }
+
+    get option(): DirectiveSyntaxOption {
+        return this.#option;
+    }
+
+    constructor(option: DirectiveSyntaxOption | undefined) {
+        this.option = option;
+        this.#option = this.option;
+    }
+
+    valueFor(key: keyof DirectiveSyntaxOptionObj): DirectiveSyntaxValue {
+        let value: DirectiveSyntaxValue | undefined;
+        if (typeof this.option === 'object') value = this.option[key];
+        if (typeof this.option === 'string') value = this.option;
+        return value ?? DIRECTIVE_SYNTAX_DEFAULT;
+    }
+
+    mdPluginValueFor(key: keyof DirectiveSyntaxOptionObj): DirectiveSyntaxMdPluginValue {
+        const value = this.valueFor(key);
+        return value === 'preserve' || value === 'overwrite' ? 'enabled' : value;
+    }
+
+    /** helper for wisywig serializer */
+    shouldSerializeToDirective(key: keyof DirectiveSyntaxOptionObj, tokenMarkup: unknown): boolean {
+        const option = this.valueFor(key);
+        if (option === 'overwrite' || option === 'only') return true;
+        if (typeof tokenMarkup === 'string') {
+            if (tokenMarkup.startsWith(':')) return true;
+            if (tokenMarkup.startsWith('{')) return false;
+        }
+        if (option === 'preserve') return true;
+        return false;
+    }
+
+    /** helper for markup-mode commands and actions */
+    shouldInsertDirectiveMarkup(key: keyof DirectiveSyntaxOptionObj) {
+        const value = this.valueFor(key);
+        if (value === 'disabled' || value === 'enabled') return false;
+        return true;
+    }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,3 +19,4 @@ export * from './serialize-for-clipboard';
 export * from './sync-scroll';
 export * from './upload';
 export * from './get-proportional-size';
+export type {DirectiveSyntaxValue, DirectiveSyntaxOption} from './directive';

--- a/tests/sameMarkup.ts
+++ b/tests/sameMarkup.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-implicit-globals */
 
 import type {Node} from 'prosemirror-model';
-import {Parser, Serializer} from '../src/core';
+
+import type {Parser, Serializer} from '../src/core';
 
 export function createMarkupChecker({
     parser,
@@ -10,8 +11,9 @@ export function createMarkupChecker({
     parser: Parser;
     serializer: Serializer;
 }) {
-    function parse(text: string, doc: Node) {
-        expect(parser.parse(text)).toMatchNode(doc);
+    function parse(text: string, doc: Node, {json}: {json?: boolean} = {}) {
+        if (json) expect(parser.parse(text)).toMatchNodeJson(doc);
+        else expect(parser.parse(text)).toMatchNode(doc);
     }
 
     function serialize(doc: Node, text: string) {

--- a/tests/toMatchNode.ts
+++ b/tests/toMatchNode.ts
@@ -15,12 +15,22 @@ expect.extend({
             pass: eq(received, expect),
         };
     },
+    toMatchNodeJson: (received: Node, expect: Node) => {
+        return {
+            message: () =>
+                `nodes do not match.\n\nreceived: ${received}\n\tjson: ${toJson(
+                    received,
+                )}\n\nexpect: ${expect}\n\tjson: ${toJson(expect)}`,
+            pass: toJson(received) === toJson(expect),
+        };
+    },
 });
 
 declare global {
     namespace jest {
         interface Matchers<R> {
             toMatchNode(expect: Node): R;
+            toMatchNodeJson(expect: Node): R;
         }
     }
 }


### PR DESCRIPTION
- added `directiveSyntax` experiment. It can be accessed from `builder.context` for wysiwyg extensions, and via state facet in markup mode.

- added support for directive syntax for YfmCut. See syntax example here: diplodoc-platform/cut-extension#22