### PR TITLE
feat (core): add empty row placeholder

### DIFF
--- a/demo/components/Playground.tsx
+++ b/demo/components/Playground.tsx
@@ -79,6 +79,7 @@ export type PlaygroundProps = {
     breaks?: boolean;
     linkify?: boolean;
     linkifyTlds?: string | string[];
+    emptyRowPlaceholder?: boolean;
     sanitizeHtml?: boolean;
     prepareRawMarkup?: boolean;
     splitModeOrientation?: 'horizontal' | 'vertical' | false;
@@ -124,6 +125,7 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
         initialSplitModeEnabled,
         settingsVisible,
         allowHTML,
+        emptyRowPlaceholder,
         breaks,
         linkify,
         linkifyTlds,
@@ -185,6 +187,9 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
             needToSetDimensionsForUploadedImages,
             renderPreview: renderPreviewDefined ? renderPreview : undefined,
             fileUploadHandler,
+            md: {
+                emptyRowPlaceholder: emptyRowPlaceholder,
+            },
             experimental: {
                 ...experimental,
                 directiveSyntax,

--- a/src/bundle/types.ts
+++ b/src/bundle/types.ts
@@ -28,6 +28,7 @@ export type ParseInsertedUrlAsImage = (text: string) => {imageUrl: string; title
 
 export type MarkdownEditorMdOptions = {
     html?: boolean;
+    emptyRowPlaceholder?: boolean;
     breaks?: boolean;
     linkify?: boolean;
     linkifyTlds?: string | string[];

--- a/src/bundle/useMarkdownEditor.ts
+++ b/src/bundle/useMarkdownEditor.ts
@@ -59,6 +59,7 @@ export function useMarkdownEditor<T extends object = {}>(
                     editor.emit('submit', null);
                     return true;
                 },
+                emptyRowPlaceholder: md.emptyRowPlaceholder,
                 mdBreaks: breaks,
                 fileUploadHandler: uploadFile,
                 needToSetDimensionsForUploadedImages,

--- a/src/bundle/wysiwyg-preset.ts
+++ b/src/bundle/wysiwyg-preset.ts
@@ -27,6 +27,7 @@ export type BundlePresetOptions = ExtensionsOptions &
         preset: MarkdownEditorPreset;
         mdBreaks?: boolean;
         fileUploadHandler?: FileUploadHandler;
+        emptyRowPlaceholder?: boolean;
         /**
          * If we need to set dimensions for uploaded images
          *
@@ -64,7 +65,10 @@ export const BundlePreset: ExtensionAuto<BundlePresetOptions> = (builder, opts) 
             paragraphKey: f.toPM(A.Text),
             paragraphPlaceholder: (node: Node, parent?: Node | null) => {
                 const isDocEmpty =
-                    !node.text && parent?.type.name === BaseNode.Doc && parent.childCount === 1;
+                    !node.text &&
+                    ((opts.emptyRowPlaceholder && parent?.type.name === 'doc') ||
+                        (parent?.type.name === BaseNode.Doc && parent.childCount === 1));
+
                 return isDocEmpty ? i18nPlaceholder('doc_empty') : null;
             },
             ...opts.baseSchema,


### PR DESCRIPTION
Adds a flag "emptyRowPlaceholder" where a placeholder will be displayed in every empty line that is in focus, not just in an empty document

BEFORE
![image](https://github.com/user-attachments/assets/fcfa99ed-fb6a-4ff1-a9b5-83e4154179e7)

AFTER
![image](https://github.com/user-attachments/assets/88f360a0-0c94-464d-9f74-ac8877c849ba)

