### PR TITLE
fix(Cursor): input-rules does not work when cursor in virtual selection (GapCursorSelection)

### DIFF
--- a/src/extensions/behavior/Cursor/index.ts
+++ b/src/extensions/behavior/Cursor/index.ts
@@ -11,6 +11,6 @@ export type CursorOptions = {
 };
 
 export const Cursor: ExtensionAuto<CursorOptions> = (builder, opts) => {
-    builder.addPlugin(() => gapCursor());
+    builder.addPlugin(() => gapCursor(), builder.Priority.Highest);
     builder.addPlugin(() => dropCursor(opts.dropOptions));
 };


### PR DESCRIPTION
Old behavior: when cursor has been emulated by GapCursorSelection, inputRules incorrect handling text input.
Now: GapCursorSelection will be replaced with empty textblock, and after that inputRules run his handling. So now they are correct handle user input.

Old behavior: when cursor was emulated using GapCursorSelection, inputRules handled text input incorrectly.
Now: first, the GapCursorSelection will be replaced with an empty textblock, and after that the inputRules will run their handler. So now they are correctly handling user input.