### PR TITLE
chore(demo): added new story; rewritten some other stories

### DIFF
--- a/demo/components/Playground.tsx
+++ b/demo/components/Playground.tsx
@@ -6,7 +6,6 @@ import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
 
 import {
     type DirectiveSyntaxValue,
-    type EscapeConfig,
     type FileUploadHandler,
     type MarkdownEditorMode,
     MarkdownEditorView,
@@ -30,21 +29,15 @@ import {YfmHtmlBlock} from '../../src/extensions/additional/YfmHtmlBlock';
 import {getSanitizeYfmHtmlBlock} from '../../src/extensions/additional/YfmHtmlBlock/utils';
 import type {CodeEditor} from '../../src/markup';
 import {ToolbarsPreset} from '../../src/modules/toolbars/types';
-import {VERSION} from '../../src/version';
 import {getPlugins} from '../defaults/md-plugins';
 import useYfmHtmlBlockStyles from '../hooks/useYfmHtmlBlockStyles';
-import {block} from '../utils/cn';
 import {randomDelay} from '../utils/delay';
 import {parseInsertedUrlAsImage} from '../utils/imageUrl';
 import {debouncedUpdateLocation as updateLocation} from '../utils/location';
 
-import {WysiwygSelection} from './PMSelection';
-import {WysiwygDevTools} from './ProseMirrorDevTools';
+import {PlaygroundLayout, b} from './PlaygroundLayout';
 import {SplitModePreview} from './SplitModePreview';
 
-import './Playground.scss';
-
-const b = block('playground');
 const fileUploadHandler: FileUploadHandler = async (file) => {
     console.info('[Playground] Uploading file: ' + file.name);
     await randomDelay(1000, 3000);
@@ -76,7 +69,6 @@ export type PlaygroundProps = {
     renderPreviewDefined?: boolean;
     height?: CSSProperties['height'];
     markupConfigExtensions?: Extension[];
-    escapeConfig?: EscapeConfig;
     wysiwygCommandMenuConfig?: wysiwygToolbarConfigs.WToolbarItemData[];
     markupToolbarConfig?: ToolbarGroupData<CodeEditor>[];
     toolbarsPreset?: ToolbarsPreset;
@@ -132,7 +124,6 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
         markupConfigExtensions,
         markupToolbarConfig,
         placeholderOptions,
-        escapeConfig,
         enableSubmitInPreview,
         hidePreviewAfterSubmit,
         needToSetDimensionsForUploadedImages,
@@ -167,7 +158,6 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
         {
             preset: 'full',
             wysiwygConfig: {
-                escapeConfig,
                 placeholderOptions: placeholderOptions,
                 extensions: (builder) => {
                     builder
@@ -304,107 +294,96 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
     }, [mdEditor]);
 
     return (
-        <div className={b()}>
-            <div className={b('header')}>
-                Markdown Editor Playground
-                <span className={b('version')}>{VERSION}</span>
-            </div>
-            <div className={b('actions')}>
-                <DropdownMenu
-                    size="s"
-                    switcher={
-                        <Button size="s" view="flat">
-                            isEmpty: {String(mdEditor.isEmpty())}
-                        </Button>
-                    }
-                >
-                    <DropdownMenu.Item
-                        text="Clear"
-                        action={() => {
-                            mdEditor.clear();
-                            mdEditor.focus();
-                        }}
-                    />
-                    <DropdownMenu.Item
-                        text="Append"
-                        action={() => {
-                            mdEditor.append('> append');
-                            mdEditor.focus();
-                        }}
-                    />
-                    <DropdownMenu.Item
-                        text="Prepend"
-                        action={() => {
-                            mdEditor.prepend('> prepend');
-                            mdEditor.focus();
-                        }}
-                    />
-                    <DropdownMenu.Item
-                        text="Replace"
-                        action={() => {
-                            mdEditor.replace('> replace');
-                            mdEditor.focus();
-                        }}
-                    />
-                    <DropdownMenu.Item
-                        text="Move cursor to start"
-                        action={() => {
-                            mdEditor.moveCursor('start');
-                            mdEditor.focus();
-                        }}
-                    />
-                    <DropdownMenu.Item
-                        text="Move cursor to end"
-                        action={() => {
-                            mdEditor.moveCursor('end');
-                            mdEditor.focus();
-                        }}
-                    />
-                    <DropdownMenu.Item
-                        text="Move to line"
-                        action={() => {
-                            mdEditor.moveCursor({line: 115});
-                            mdEditor.focus();
-                        }}
-                    />
-                </DropdownMenu>
-                {mdEditor.currentMode === 'markup' && (
-                    <MoveToLine
-                        onClick={(line) => {
-                            if (typeof line !== 'number' || Number.isNaN(line)) return;
-                            mdEditor.moveCursor({line});
-                            mdEditor.focus();
-                        }}
-                    />
-                )}
-            </div>
-            <hr />
-            <React.StrictMode>
-                <div className={b('editor')} style={{height: height ?? 'initial'}}>
-                    <MarkdownEditorView
-                        autofocus
-                        toaster={toaster}
-                        className={b('editor-view')}
-                        stickyToolbar={Boolean(stickyToolbar)}
-                        toolbarsPreset={toolbarsPreset}
-                        wysiwygToolbarConfig={wysiwygToolbarConfig}
-                        markupToolbarConfig={markupToolbarConfig}
-                        settingsVisible={settingsVisible}
-                        editor={mdEditor}
-                        enableSubmitInPreview={enableSubmitInPreview}
-                        hidePreviewAfterSubmit={hidePreviewAfterSubmit}
-                    />
-                    <WysiwygDevTools editor={mdEditor} />
-                    <WysiwygSelection editor={mdEditor} className={b('pm-selection')} />
-                </div>
-            </React.StrictMode>
-
-            <hr />
-
-            <div className={b('preview')}>
-                {editorMode === 'wysiwyg' && <pre className={b('markup')}>{mdRaw}</pre>}
-            </div>
-        </div>
+        <PlaygroundLayout
+            editor={mdEditor}
+            viewHeight={height}
+            view={({className}) => (
+                <MarkdownEditorView
+                    autofocus
+                    toaster={toaster}
+                    className={className}
+                    stickyToolbar={Boolean(stickyToolbar)}
+                    toolbarsPreset={toolbarsPreset}
+                    wysiwygToolbarConfig={wysiwygToolbarConfig}
+                    markupToolbarConfig={markupToolbarConfig}
+                    settingsVisible={settingsVisible}
+                    editor={mdEditor}
+                    enableSubmitInPreview={enableSubmitInPreview}
+                    hidePreviewAfterSubmit={hidePreviewAfterSubmit}
+                />
+            )}
+            actions={() => (
+                <>
+                    <DropdownMenu
+                        size="s"
+                        switcher={
+                            <Button size="s" view="flat">
+                                isEmpty: {String(mdEditor.isEmpty())}
+                            </Button>
+                        }
+                    >
+                        <DropdownMenu.Item
+                            text="Clear"
+                            action={() => {
+                                mdEditor.clear();
+                                mdEditor.focus();
+                            }}
+                        />
+                        <DropdownMenu.Item
+                            text="Append"
+                            action={() => {
+                                mdEditor.append('> append');
+                                mdEditor.focus();
+                            }}
+                        />
+                        <DropdownMenu.Item
+                            text="Prepend"
+                            action={() => {
+                                mdEditor.prepend('> prepend');
+                                mdEditor.focus();
+                            }}
+                        />
+                        <DropdownMenu.Item
+                            text="Replace"
+                            action={() => {
+                                mdEditor.replace('> replace');
+                                mdEditor.focus();
+                            }}
+                        />
+                        <DropdownMenu.Item
+                            text="Move cursor to start"
+                            action={() => {
+                                mdEditor.moveCursor('start');
+                                mdEditor.focus();
+                            }}
+                        />
+                        <DropdownMenu.Item
+                            text="Move cursor to end"
+                            action={() => {
+                                mdEditor.moveCursor('end');
+                                mdEditor.focus();
+                            }}
+                        />
+                        <DropdownMenu.Item
+                            text="Move to line"
+                            action={() => {
+                                mdEditor.moveCursor({line: 115});
+                                mdEditor.focus();
+                            }}
+                        />
+                    </DropdownMenu>
+                    {mdEditor.currentMode === 'markup' && (
+                        <MoveToLine
+                            onClick={(line) => {
+                                if (typeof line !== 'number' || Number.isNaN(line)) return;
+                                mdEditor.moveCursor({line});
+                                mdEditor.focus();
+                            }}
+                        />
+                    )}
+                </>
+            )}
+        />
     );
 });
 

--- a/demo/components/PlaygroundLayout.tsx
+++ b/demo/components/PlaygroundLayout.tsx
@@ -1,0 +1,68 @@
+import React, {useEffect} from 'react';
+
+import {useUpdate} from 'react-use';
+
+import type {MarkdownEditorInstance} from '../../src';
+import {VERSION} from '../../src/version';
+import {useMarkdownEditorValue} from '../hooks/useMarkdownEditorValue';
+import {block} from '../utils/cn';
+
+import {WysiwygSelection} from './PMSelection';
+import {WysiwygDevTools} from './ProseMirrorDevTools';
+
+import './Playground.scss';
+
+export const b = block('playground');
+
+export type RenderFn = (props: {className?: string}) => React.ReactNode;
+
+export type PlaygroundLayoutProps = {
+    title?: string;
+    editor: MarkdownEditorInstance;
+    view: RenderFn;
+    viewHeight?: React.CSSProperties['height'];
+    actions?: RenderFn;
+    style?: React.CSSProperties;
+};
+
+export const PlaygroundLayout: React.FC<PlaygroundLayoutProps> = function PlaygroundLayout(props) {
+    const {editor} = props;
+
+    const forceRender = useUpdate();
+    const mdMarkup = useMarkdownEditorValue(editor);
+
+    useEffect(() => {
+        editor.on('change-editor-mode', forceRender);
+        return () => {
+            editor.off('change-editor-mode', forceRender);
+        };
+    }, [editor, forceRender]);
+
+    return (
+        <div className={b()} style={props.style}>
+            <div className={b('header')}>
+                {props.title ?? 'Markdown Editor Playground'}
+                <span className={b('version')}>{VERSION}</span>
+            </div>
+
+            <div className={b('actions')}>{props.actions?.({})}</div>
+
+            <hr />
+
+            <React.StrictMode>
+                <div className={b('editor')} style={{height: props.viewHeight ?? 'initial'}}>
+                    {props.view({className: b('editor-view')})}
+
+                    <WysiwygDevTools editor={editor} />
+                    <WysiwygSelection editor={editor} className={b('pm-selection')} />
+                </div>
+            </React.StrictMode>
+
+            <hr />
+
+            <div className={b('preview')}>
+                {editor.currentMode === 'wysiwyg' && <pre className={b('markup')}>{mdMarkup}</pre>}
+            </div>
+        </div>
+    );
+};

--- a/demo/components/PlaygroundMini.tsx
+++ b/demo/components/PlaygroundMini.tsx
@@ -22,7 +22,6 @@ export type PlaygroundMiniProps = Pick<
     | 'initial'
     | 'onChangeEditorType'
     | 'onChangeSplitModeEnabled'
-    | 'escapeConfig'
     | 'directiveSyntax'
 > & {withDefaultInitialContent?: boolean};
 

--- a/demo/defaults/excluded-controls.ts
+++ b/demo/defaults/excluded-controls.ts
@@ -3,5 +3,4 @@ export const excludedControls = [
     'withDefaultInitialContent',
     'onChangeEditorType',
     'onChangeSplitModeEnabled',
-    'escapeConfig',
 ];

--- a/demo/hooks/useMarkdownEditorValue.ts
+++ b/demo/hooks/useMarkdownEditorValue.ts
@@ -1,0 +1,18 @@
+import {useEffect, useState} from 'react';
+
+import {type MarkdownEditorInstance, type MarkupString, useDebounce} from '../../src';
+
+export function useMarkdownEditorValue(editor: MarkdownEditorInstance, delay = 500): MarkupString {
+    const [value, setValue] = useState(() => editor.getValue());
+
+    const fn = useDebounce(() => setValue(editor.getValue()), delay);
+
+    useEffect(() => {
+        editor.on('change', fn);
+        return () => {
+            editor.off('change', fn);
+        };
+    }, [editor, fn]);
+
+    return value;
+}

--- a/demo/stories/css-variables/CSSVariables.tsx
+++ b/demo/stories/css-variables/CSSVariables.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
 
-import {PlaygroundMini} from '../../components/PlaygroundMini';
+import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
+
+import {MarkdownEditorView, useMarkdownEditor} from '../../../src';
+import {PlaygroundLayout} from '../../components/PlaygroundLayout';
+import {markup} from '../../defaults/content';
 
 export const CustomCSSVariablesDemo = React.memo((styles) => {
+    const editor = useMarkdownEditor({initial: {markup}});
+
     return (
-        <div style={styles}>
-            <PlaygroundMini
-                initialEditor="wysiwyg"
-                settingsVisible
-                withDefaultInitialContent
-                stickyToolbar
-            />
-        </div>
+        <PlaygroundLayout
+            editor={editor}
+            style={styles}
+            view={({className}) => (
+                <MarkdownEditorView
+                    autofocus
+                    stickyToolbar
+                    settingsVisible
+                    editor={editor}
+                    toaster={toaster}
+                    className={className}
+                />
+            )}
+        />
     );
 });
 

--- a/demo/stories/editor-in-editor/EditorInEditor.tsx
+++ b/demo/stories/editor-in-editor/EditorInEditor.tsx
@@ -3,8 +3,7 @@ import React, {FC, useEffect} from 'react';
 import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
 
 import {BaseNode, MarkdownEditorView, useMarkdownEditor} from '../../../src';
-import {VERSION} from '../../../src/version';
-import {block} from '../../utils/cn';
+import {PlaygroundLayout} from '../../components/PlaygroundLayout';
 
 import {
     EditorInEditorAttr,
@@ -12,10 +11,8 @@ import {
     EditorInEditor as extension,
 } from './EditorInEditorExtension';
 
-const b = block('playground');
-
 export const EditorInEditor: FC = () => {
-    const mdEditor = useMarkdownEditor({
+    const editor = useMarkdownEditor({
         initialEditorMode: 'wysiwyg',
         initialToolbarVisible: true,
         allowHTML: false,
@@ -28,7 +25,7 @@ export const EditorInEditor: FC = () => {
     });
 
     useEffect(() => {
-        const view = mdEditor._wysiwygView;
+        const view = editor._wysiwygView;
         if (view) {
             const {schema} = view.state;
             const tr = view.state.tr;
@@ -44,21 +41,18 @@ export const EditorInEditor: FC = () => {
     }, []);
 
     return (
-        <div className={b()}>
-            <div className={b('header')}>
-                Editor In Editor Playground
-                <span className={b('version')}>{VERSION}</span>
-            </div>
-            <hr />
-            <div className={b('editor')}>
+        <PlaygroundLayout
+            editor={editor}
+            title="Editor In Editor Playground"
+            view={({className}) => (
                 <MarkdownEditorView
                     stickyToolbar
                     settingsVisible
-                    editor={mdEditor}
+                    editor={editor}
                     toaster={toaster}
-                    className={b('editor-view')}
+                    className={className}
                 />
-            </div>
-        </div>
+            )}
+        />
     );
 };

--- a/demo/stories/escape-config/EscapeConfig.stories.tsx
+++ b/demo/stories/escape-config/EscapeConfig.stories.tsx
@@ -7,11 +7,9 @@ Story.storyName = 'Escape config';
 
 export default {
     args: {
-        initialEditor: 'wysiwyg',
         commonEscapeRegexp: '^$',
         startOfLineEscapeRegexp: '^$',
-        withDefaultInitialContent: true,
     },
     component,
-    title: 'Experiments / Escape config',
+    title: 'Settings / Wysiwyg / Escape config',
 };

--- a/demo/stories/escape-config/EscapeConfig.tsx
+++ b/demo/stories/escape-config/EscapeConfig.tsx
@@ -1,27 +1,46 @@
-import React, {FC} from 'react';
+import React from 'react';
 
-import {PlaygroundMini, PlaygroundMiniProps} from '../../components/PlaygroundMini';
+import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
 
-export type EscapeConfigProps = Pick<
-    PlaygroundMiniProps,
-    'initialEditor' | 'withDefaultInitialContent'
-> & {
+import {MarkdownEditorView, useMarkdownEditor} from '../../../src';
+import {PlaygroundLayout} from '../../components/PlaygroundLayout';
+import {markup} from '../../defaults/content';
+
+export type EscapeConfigProps = {
     commonEscapeRegexp: string;
     startOfLineEscapeRegexp: string;
 };
 
-export const EscapeConfig: FC<EscapeConfigProps> = ({
+export const EscapeConfig: React.FC<EscapeConfigProps> = ({
     startOfLineEscapeRegexp,
     commonEscapeRegexp,
-    ...props
 }) => {
+    const editor = useMarkdownEditor(
+        {
+            initial: {markup},
+            wysiwygConfig: {
+                escapeConfig: {
+                    commonEscape: new RegExp(commonEscapeRegexp),
+                    startOfLineEscape: new RegExp(startOfLineEscapeRegexp),
+                },
+            },
+        },
+        [commonEscapeRegexp, startOfLineEscapeRegexp],
+    );
+
     return (
-        <PlaygroundMini
-            {...props}
-            escapeConfig={{
-                commonEscape: new RegExp(commonEscapeRegexp),
-                startOfLineEscape: new RegExp(startOfLineEscapeRegexp),
-            }}
+        <PlaygroundLayout
+            editor={editor}
+            view={({className}) => (
+                <MarkdownEditorView
+                    autofocus
+                    stickyToolbar
+                    settingsVisible
+                    editor={editor}
+                    toaster={toaster}
+                    className={className}
+                />
+            )}
         />
     );
 };

--- a/demo/stories/experiments/empty-row/EmptyRow.stories.tsx
+++ b/demo/stories/experiments/empty-row/EmptyRow.stories.tsx
@@ -1,0 +1,15 @@
+import type {StoryObj} from '@storybook/react';
+
+import {PreserveEmptyRowsDemo as component} from './EmptyRows';
+
+export const Story: StoryObj<typeof component> = {
+    args: {
+        preserveEmptyRows: true,
+    },
+};
+Story.storyName = 'Preserve Empty Rows';
+
+export default {
+    title: 'Experiments',
+    component,
+};

--- a/demo/stories/experiments/empty-row/EmptyRows.tsx
+++ b/demo/stories/experiments/empty-row/EmptyRows.tsx
@@ -1,0 +1,83 @@
+import React, {useCallback, useLayoutEffect, useState} from 'react';
+
+import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
+
+import {MarkdownEditorView, type RenderPreview, useMarkdownEditor} from '../../../../src';
+import {PlaygroundLayout} from '../../../components/PlaygroundLayout';
+import {SplitModePreview} from '../../../components/SplitModePreview';
+import {plugins} from '../../../defaults/md-plugins';
+import {useMarkdownEditorValue} from '../../../hooks/useMarkdownEditorValue';
+
+const initialMarkup = `
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+Example of usage empty row experiment
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+`;
+
+type PreserveEmptyRowsDemoProps = {
+    preserveEmptyRows: boolean;
+};
+
+export const PreserveEmptyRowsDemo = React.memo<PreserveEmptyRowsDemoProps>((props) => {
+    const {preserveEmptyRows} = props;
+
+    const [mdMarkup, setMdMarkup] = useState(initialMarkup);
+
+    const renderPreview = useCallback<RenderPreview>(
+        ({getValue, md}) => (
+            <SplitModePreview
+                getValue={getValue}
+                allowHTML={md.html}
+                linkify={md.linkify}
+                linkifyTlds={md.linkifyTlds}
+                breaks={md.breaks}
+                needToSanitizeHtml
+                plugins={plugins}
+            />
+        ),
+        [],
+    );
+
+    const editor = useMarkdownEditor(
+        {
+            initial: {markup: mdMarkup},
+            experimental: {preserveEmptyRows},
+            markupConfig: {renderPreview},
+        },
+        [preserveEmptyRows],
+    );
+
+    // for preserve edited content
+    const value = useMarkdownEditorValue(editor);
+    useLayoutEffect(() => {
+        setMdMarkup(value);
+    }, [value]);
+
+    return (
+        <PlaygroundLayout
+            editor={editor}
+            view={({className}) => (
+                <MarkdownEditorView
+                    autofocus
+                    stickyToolbar
+                    settingsVisible
+                    editor={editor}
+                    toaster={toaster}
+                    className={className}
+                />
+            )}
+        />
+    );
+});
+
+PreserveEmptyRowsDemo.displayName = 'PreserveEmptyRows';

--- a/demo/stories/ghost/Ghost.tsx
+++ b/demo/stories/ghost/Ghost.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
 import cloneDeep from 'lodash/cloneDeep';
 
-import {logger, markupToolbarConfigs} from '../../../src';
-import {Playground} from '../../components/Playground';
+import {MarkdownEditorView, logger, markupToolbarConfigs, useMarkdownEditor} from '../../../src';
+import {PlaygroundLayout} from '../../components/PlaygroundLayout';
 
 import {initialMdContent} from './content';
 import {ghostPopupExtension, ghostPopupToolbarItem} from './ghostExtension';
@@ -15,17 +16,26 @@ logger.setLogger({
 });
 
 const mToolbarConfig = cloneDeep(markupToolbarConfigs.mToolbarConfig);
-
-mToolbarConfig[2].unshift(ghostPopupToolbarItem);
+mToolbarConfig.unshift([ghostPopupToolbarItem]);
 
 export const Ghost = () => {
+    const editor = useMarkdownEditor({
+        initial: {markup: initialMdContent, mode: 'markup'},
+        markupConfig: {extensions: [ghostPopupExtension]},
+    });
+
     return (
-        <Playground
-            settingsVisible
-            markupToolbarConfig={mToolbarConfig}
-            markupConfigExtensions={[ghostPopupExtension]}
-            initial={initialMdContent}
-            initialEditor="markup"
+        <PlaygroundLayout
+            editor={editor}
+            view={() => (
+                <MarkdownEditorView
+                    stickyToolbar
+                    settingsVisible
+                    editor={editor}
+                    toaster={toaster}
+                    markupToolbarConfig={mToolbarConfig}
+                />
+            )}
         />
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,8 +132,8 @@
         "lodash": "^4.17.20",
         "lowlight": "^3.0.0",
         "markdown-it": "^13.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@diplodoc/folding-headings-extension": {


### PR DESCRIPTION
For `demo` only:
1. Added PlaygroundLayout component
2. Added `useMarkdownEditorValue()` hook
3. Rewritten `CustomCSSVariables`, `EditorInEditor`, `EscapeConfig`, `Ghost`, `GPT` stories
4. Added new story – `PreserveEmptyRows`