### PR TITLE
fix(nodes): fixed switching a non-empty cut block in wysiwyg

### DIFF
--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -23,7 +23,9 @@ export function findFirstTextblockChild(
 export const isNodeEmpty = (node: Node) => {
     const emptyChildren = findChildren(
         node,
-        (n) => (!n.isText && !n.isAtom && n.content.size === 0) || (n.isText && !n.textContent),
+        (n) =>
+            (!n.isText && !n.isAtom && n.content.size === 0 && n.type.name === 'paragraph') ||
+            (n.isText && !n.textContent),
         true,
     );
 


### PR DESCRIPTION
There was a problem that when using an empty block of code in cut and switching to markup mode and back, he does not see this block and puts the placeholder text. The problem can be solved by checking for a paragraph, since this is an empty node by default, now we consider a cut to be empty if there is no content in it and the only node in it is node = "paragraph", that is, if there is no text in the cut, but there is a block of code or something else, then it will not being considered empty also fixes a problem for the note node.