### PR TITLE
fix(BaseSchema): fixed definition of an empty string during serialization

### DIFF
--- a/src/extensions/base/BaseSchema/BaseSchemaSpecs/index.ts
+++ b/src/extensions/base/BaseSchema/BaseSchemaSpecs/index.ts
@@ -1,4 +1,4 @@
-import type {NodeSpec} from 'prosemirror-model';
+import type {Node, NodeSpec} from 'prosemirror-model';
 
 import type {ExtensionAuto} from '../../../../core';
 import {nodeTypeFactory} from '../../../../utils/schema';
@@ -69,7 +69,7 @@ export const BaseSchemaSpecs: ExtensionAuto<BaseSchemaSpecsOptions> = (builder, 
                     An empty line is added only if there is some content in the parent element. 
                     This is necessary in order to prevent an empty document with empty lines
                 */
-                if (opts.preserveEmptyRows && !node.content.size) {
+                if (opts.preserveEmptyRows && isEmptyString(node)) {
                     let isParentEmpty = true;
 
                     for (let index = 0; index < parent.content.childCount; index++) {
@@ -91,4 +91,20 @@ export const BaseSchemaSpecs: ExtensionAuto<BaseSchemaSpecsOptions> = (builder, 
                 }
             },
         }));
+};
+
+const isEmptyString = (node: Node) => {
+    if (!node.content.size) {
+        return true;
+    }
+
+    if (
+        node.childCount === 1 &&
+        node.child(0).type.name === 'text' &&
+        node.child(0).text?.trim() === ''
+    ) {
+        return true;
+    }
+
+    return false;
 };


### PR DESCRIPTION
Fixed an issue where a space in a string was not recognized as an empty string, and therefore the "&nbsp;" was not added to the markup. This problem could occur when copying rendered markup to the editor.

Before:
![image](https://github.com/user-attachments/assets/3844608b-2d7c-4d3b-b709-096899f02784)

After
![image](https://github.com/user-attachments/assets/56a5778e-8082-4542-96df-d39b5fd30491)
