### PR TITLE
feat(types)!: updated MarkdownSerializer types

### DIFF
--- a/src/core/SerializerTokensRegistry.test.ts
+++ b/src/core/SerializerTokensRegistry.test.ts
@@ -1,5 +1,4 @@
 import {SerializerTokensRegistry} from './SerializerTokensRegistry';
-import type {SerializerTests} from './types/serializer';
 
 describe('SerializerTokensRegistry', () => {
     it('should create empty serializer', () => {
@@ -12,7 +11,7 @@ describe('SerializerTokensRegistry', () => {
 
         const serializer = new SerializerTokensRegistry()
             .addNode(nodeName, () => {})
-            .createSerializer() as SerializerTests;
+            .createSerializer();
 
         expect(serializer.containsNode(nodeName)).toBe(true);
     });
@@ -22,7 +21,7 @@ describe('SerializerTokensRegistry', () => {
 
         const serializer = new SerializerTokensRegistry()
             .addMark(markName, {open: '1', close: '2'})
-            .createSerializer() as SerializerTests;
+            .createSerializer();
 
         expect(serializer.containsMark(markName)).toBe(true);
     });

--- a/src/core/markdown/Markdown.test.ts
+++ b/src/core/markdown/Markdown.test.ts
@@ -39,7 +39,7 @@ const parser: Parser = new MarkdownParser(
 const serializer = new MarkdownSerializer(
     {
         text: ((state, node) => {
-            state.text(node.text);
+            state.text(node.text ?? '');
         }) as SerializerNodeToken,
         paragraph: ((state, node) => {
             state.renderInline(node);

--- a/src/core/markdown/MarkdownSerializer.ts
+++ b/src/core/markdown/MarkdownSerializer.ts
@@ -1,11 +1,45 @@
-/* eslint-disable */
-
 // ::- A specification for serializing a ProseMirror document as
 // Markdown/CommonMark text.
 // prettier-ignore
+import type {Mark, Node} from "prosemirror-model";
+
+export interface SerializerNodeToken {
+    (state: MarkdownSerializerState, node: Node, parent: Node, index: number): void;
+}
+
+export interface SerializerMarkToken {
+    open:
+        | string
+        | ((state: MarkdownSerializerState, mark: Mark, parent: Node, index: number) => string);
+    close:
+        | string
+        | ((state: MarkdownSerializerState, mark: Mark, parent: Node, index: number) => string);
+    mixable?: boolean;
+    expelEnclosingWhitespace?: boolean;
+    escape?: boolean;
+}
+
+interface SerializerOptions {
+    tightLists?: boolean;
+    escapeExtraCharacters?: RegExp;
+    hardBreakNodeName?: string;
+    strict?: boolean;
+    commonEscape?: RegExp;
+    startOfLineEscape?: RegExp;
+    escape?: boolean; // Added to fix types
+}
+
+interface MarkMap {
+    [markName: string]: SerializerMarkToken;
+}
+
+interface NodeMap {
+    [nodeName: string]: SerializerNodeToken;
+}
+
 export class MarkdownSerializer {
-    private readonly nodes;
-    private readonly marks;
+    private readonly nodes: NodeMap;
+    private readonly marks: MarkMap;
 
     // :: (Object<(state: MarkdownSerializerState, node: Node, parent: Node, index: number)>, Object)
     // Construct a serializer with the given configuration. The `nodes`
@@ -40,7 +74,7 @@ export class MarkdownSerializer {
     // outside the marks. This is necessary for emphasis marks as
     // CommonMark does not permit enclosing whitespace inside emphasis
     // marks, see: http://spec.commonmark.org/0.26/#example-330
-    constructor(nodes: any, marks: any) {
+    constructor(nodes: NodeMap, marks: MarkMap) {
         // :: Object<(MarkdownSerializerState, Node)> The node serializer
         // functions for this serializer.
         this.nodes = nodes;
@@ -51,19 +85,19 @@ export class MarkdownSerializer {
     // :: (Node, ?Object) → string
     // Serialize the content of the given node to
     // [CommonMark](http://commonmark.org/).
-    serialize(content: any, options: any) {
+    serialize(content: Node, options: Partial<SerializerOptions> = {}): string {
         const state = new MarkdownSerializerState(this.nodes, this.marks, options);
         state.renderContent(content);
         return state.out;
     }
 
     // for tests (implements SerializerTests interface)
-    containsNode(nodeName: any) {
+    containsNode(nodeName: string): boolean {
         return nodeName in this.nodes;
     }
 
     // for tests (implements SerializerTests interface)
-    containsMark(markName: any) {
+    containsMark(markName: string): boolean {
         return markName in this.marks;
     }
 }
@@ -73,22 +107,19 @@ export class MarkdownSerializer {
 // node and mark serialization methods (see `toMarkdown`).
 // prettier-ignore
 export class MarkdownSerializerState {
-    private readonly nodes;
-    private readonly marks;
-
-    private options;
-
-    private delim;
-    private closed: any;
-    
-    out;
-    inTightList;
-    noAutoBlank;
+    out: string;
+    inTightList: boolean;
+    noAutoBlank: boolean;
     isAutolink: boolean | undefined;
-    escapeWhitespace;
+    escapeWhitespace: boolean;
 
+    private readonly nodes: NodeMap;
+    private readonly marks: MarkMap;
+    private readonly options: SerializerOptions;
+    private delim: string;
+    private closed: Node | false;
 
-    constructor(nodes: any, marks: any, options: any) {
+    constructor(nodes: NodeMap, marks: MarkMap, options: Partial<SerializerOptions> = {}) {
         this.nodes = nodes;
         this.marks = marks;
         this.delim = this.out = '';
@@ -115,10 +146,10 @@ export class MarkdownSerializerState {
         this.noAutoBlank = false;
     }
 
-    flushClose(size?: any) {
+    flushClose(size?: number | null) {
         if (this.closed) {
             if (!this.atBlank() && !this.noAutoBlank) this.out += '\n';
-            if (size == null) size = 2;
+            if (size === null || size === undefined) size = 2;
             if (size > 1) {
                 let delimMin = this.delim;
                 const trim = /\s+$/.exec(delimMin);
@@ -137,7 +168,7 @@ export class MarkdownSerializerState {
     // line in `firstDelim`. `node` should be the node that is closed at
     // the end of the block, and `f` is a function that renders the
     // content of the block.
-    wrapBlock(delim: any, firstDelim: any, node: any, f: any) {
+    wrapBlock(delim: string, firstDelim: string | null, node: Node, f: () => void) {
         const old = this.delim;
         this.write(firstDelim || delim);
         this.delim += delim;
@@ -146,7 +177,7 @@ export class MarkdownSerializerState {
         this.closeBlock(node);
     }
 
-    atBlank() {
+    atBlank(): boolean {
         return /(^|\n)$/.test(this.out);
     }
 
@@ -160,7 +191,7 @@ export class MarkdownSerializerState {
     // Prepare the state for writing output (closing closed paragraphs,
     // adding delimiters, and so on), and then optionally add content
     // (unescaped) to the output.
-    write(content?: any) {
+    write(content?: string) {
         this.flushClose();
         if (this.delim && this.atBlank()) { this.out += this.delim }
         if (content) this.out += content;
@@ -168,20 +199,20 @@ export class MarkdownSerializerState {
 
     // :: (Node)
     // Close the block for the given node.
-    closeBlock(node?: any) {
-        this.closed = node;
+    closeBlock(node: Node) {
+        this.closed = node
     }
 
     // :: (string, ?bool)
     // Add the given text to the document. When escape is not `false`,
     // it will be escaped.
-    text(text: any, escape?: any) {
+    text(text: string, escape?: boolean) {
         const lines = text.split('\n');
         for (let i = 0; i < lines.length; i++) {
             const startOfLine = this.atBlank() || this.closed;
             this.write();
             let text = lines[i];
-            if (escape !== false && this.options.escape !== false) text = this.esc(text, startOfLine)
+            if (escape !== false && this.options.escape !== false) text = this.esc(text, startOfLine as any)
             if (this.escapeWhitespace) text = this.escWhitespace(text);
             this.out += text
             if (i != lines.length - 1) this.out += '\n';
@@ -190,7 +221,7 @@ export class MarkdownSerializerState {
 
     // :: (Node)
     // Render the given node as a block.
-    render(node: any, parent: any, index: any) {
+    render(node: Node, parent: Node, index: number) {
         if (typeof parent === 'number') throw new Error('!');
         if (!this.nodes[node.type.name]) throw new Error('Token type `' + node.type.name + '` not supported by Markdown renderer');
         this.nodes[node.type.name](this, node, parent, index);
@@ -198,16 +229,16 @@ export class MarkdownSerializerState {
 
     // :: (Node)
     // Render the contents of `parent` as block nodes.
-    renderContent(parent: any) {
-        parent.forEach((node: any, _: any, i: any) => this.render(node, parent, i));
+    renderContent(parent: Node) {
+        parent.forEach((node, _, i) => this.render(node, parent, i));
     }
 
     // :: (Node)
     // Render the contents of `parent` as inline content.
-    renderInline(parent: any) {
-        const active: any[] = []; let
+    renderInline(parent: Node) {
+        const active: Mark[] = []; let
             trailing = '';
-        const progress = (node: any, _: any, index: any) => {
+        const progress = (node: Node | null, _: any, index: number) => {
             let marks = node ? node.marks : [];
 
             // Remove marks from breaks (hard_break or soft_break) that are the edge node inside
@@ -220,8 +251,8 @@ export class MarkdownSerializerState {
                     const prev = parent.child(index - 1);
                     const next = parent.child(index + 1);
                     return (
-                        (m.isInSet(prev.marks) && (!prev.isText || /\S/.test(prev.text))) &&
-                        (m.isInSet(next.marks) && (!next.isText || /\S/.test(next.text)))
+                        (m.isInSet(prev.marks) && (!prev.isText || /\S/.test(prev.text ?? ''))) &&
+                        (m.isInSet(next.marks) && (!next.isText || /\S/.test(next.text ?? '')))
                     );
                 });
             }
@@ -234,11 +265,11 @@ export class MarkdownSerializerState {
                 const info = this.marks[mark.type.name];
                 return info && info.expelEnclosingWhitespace;
             })) {
-                const [_, lead, inner, trail] = /^(\s*)(.*?)(\s*)$/m.exec(node.text)!;
+                const [_, lead, inner, trail] = /^(\s*)(.*?)(\s*)$/m.exec(node.text ?? '')!;
                 leading += lead;
                 trailing = trail;
                 if (lead || trail) {
-                    node = inner ? node.withText(inner) : null;
+                    node = inner ? (node as any).withText(inner) : null;
                     if (!node) marks = active;
                 }
             }
@@ -251,6 +282,7 @@ export class MarkdownSerializerState {
             // in Markdown may be opened and closed in different order, so
             // that order of the marks for the token matches the order in
             // active.
+            // eslint-disable-next-line  no-labels
             outer: for (let i = 0; i < len; i++) {
                 const mark = marks[i];
                 if (!this.marks[mark.type.name].mixable) break;
@@ -259,6 +291,7 @@ export class MarkdownSerializerState {
                     if (!this.marks[other.type.name].mixable) break;
                     if (mark.eq(other)) {
                         if (i > j) { marks = marks.slice(0, j).concat(mark).concat(marks.slice(j, i)).concat(marks.slice(i + 1, len)) } else if (j > i) { marks = marks.slice(0, i).concat(marks.slice(i + 1, j)).concat(mark).concat(marks.slice(j, len)) }
+                        // eslint-disable-next-line no-labels
                         continue outer;
                     }
                 }
@@ -269,10 +302,11 @@ export class MarkdownSerializerState {
             while (keep < Math.min(active.length, len) && marks[keep].eq(active[keep])) ++keep;
 
             // Close the marks that need to be closed
-            while (keep < active.length) { this.text(this.markString(active.pop(), false, parent, index), false) }
+            while (keep < active.length)
+                this.text(this.markString(active.pop()!, false, parent, index), false)
 
             // Output any previously expelled trailing whitespace outside the marks
-            if (leading) this.text(leading);
+            if (leading) this.text(leading)
 
             // Open the marks that need to be opened
             if (node) {
@@ -299,7 +333,7 @@ export class MarkdownSerializerState {
     // indentation added to all lines except the first in an item,
     // `firstDelim` is a function going from an item index to a
     // delimiter for the first line of the item.
-    renderList(node: any, delim: any, firstDelim: any) {
+    renderList(node: Node, delim: string, firstDelim: (index: number) => string) {
         if (this.closed && this.closed.type == node.type) { this.flushClose(3) } else if (this.inTightList) { this.flushClose(1) }
 
         const isTight = typeof node.attrs.tight !== 'undefined' ? node.attrs.tight : this.options.tightLists;
@@ -307,7 +341,7 @@ export class MarkdownSerializerState {
         this.inTightList = isTight;
         node.forEach((child: any, _: any, i: any) => {
             if (i && isTight) this.flushClose(1);
-            this.wrapBlock(delim, firstDelim(i, child), node, () => this.render(child, node, i));
+            this.wrapBlock(delim, firstDelim(i), node, () => this.render(child, node, i))
         });
         this.inTightList = prevTight;
     }
@@ -316,7 +350,8 @@ export class MarkdownSerializerState {
     // Escape the given string so that it can safely appear in Markdown
     // content. If `startOfLine` is true, also escape characters that
     // have special meaning only at the start of the line.
-    esc(str: any, startOfLine?: any) {
+    esc(str: string, startOfLine = false) {
+        // eslint-disable-next-line no-useless-escape
         const escRegexp = this.options?.commonEscape || /[`\^+*\\\|~\[\]\{\}<>\$_]/g;
         const startOfLineEscRegexp = this.options?.startOfLineEscape || /^[:#\-*+>]/;
 
@@ -325,26 +360,27 @@ export class MarkdownSerializerState {
         return str;
     }
 
-    escWhitespace(str: any) {
+    escWhitespace(str: string): string {
         return str.replace(/ /g, '\\ ');
     }
 
-    quote(str: any) {
+    /// @internal
+    quote(str: string): string {
         const wrap = str.indexOf('"') == -1 ? '""' : str.indexOf("'") == -1 ? "''" : '()';
         return wrap[0] + str + wrap[1];
     }
 
     // :: (string, number) → string
     // Repeat the given string `n` times.
-    repeat(str: any, n: any) {
+    repeat(str: string, n: number) {
         let out = '';
         for (let i = 0; i < n; i++) out += str;
         return out;
     }
 
-    // : (Mark, bool, string?) → string
+    // :: (Mark, bool, string?) → string
     // Get the markdown string for a given opening or closing mark.
-    markString(mark: any, open: any, parent: any, index: any) {
+    markString(mark: Mark, open: boolean, parent: Node, index: number): string {
         const info = this.marks[mark.type.name];
         const value = open ? info.open : info.close;
         return typeof value === 'string' ? value : value(this, mark, parent, index);
@@ -354,7 +390,7 @@ export class MarkdownSerializerState {
     // Get leading and trailing whitespace from a string. Values of
     // leading or trailing property of the return object will be undefined
     // if there is no match.
-    getEnclosingWhitespace(text: any) {
+    getEnclosingWhitespace(text: string) {
         return {
             leading: (text.match(/^(\s+)/) || [])[0],
             trailing: (text.match(/(\s+)$/) || [])[0],

--- a/src/core/markdown/MarkdownSerializer.ts
+++ b/src/core/markdown/MarkdownSerializer.ts
@@ -191,7 +191,7 @@ export class MarkdownSerializerState {
     // Prepare the state for writing output (closing closed paragraphs,
     // adding delimiters, and so on), and then optionally add content
     // (unescaped) to the output.
-    write(content?: string) {
+    write(content?: string | null): void {
         this.flushClose();
         if (this.delim && this.atBlank()) { this.out += this.delim }
         if (content) this.out += content;
@@ -199,8 +199,8 @@ export class MarkdownSerializerState {
 
     // :: (Node)
     // Close the block for the given node.
-    closeBlock(node: Node) {
-        this.closed = node
+    closeBlock(node?: Node) {
+        this.closed = node ?? false;
     }
 
     // :: (string, ?bool)
@@ -333,7 +333,7 @@ export class MarkdownSerializerState {
     // indentation added to all lines except the first in an item,
     // `firstDelim` is a function going from an item index to a
     // delimiter for the first line of the item.
-    renderList(node: Node, delim: string, firstDelim: (index: number) => string) {
+    renderList(node: Node, delim: string, firstDelim: (index: number, firstDelimNode: Node) => string): void {
         if (this.closed && this.closed.type == node.type) { this.flushClose(3) } else if (this.inTightList) { this.flushClose(1) }
 
         const isTight = typeof node.attrs.tight !== 'undefined' ? node.attrs.tight : this.options.tightLists;
@@ -341,7 +341,7 @@ export class MarkdownSerializerState {
         this.inTightList = isTight;
         node.forEach((child: any, _: any, i: any) => {
             if (i && isTight) this.flushClose(1);
-            this.wrapBlock(delim, firstDelim(i), node, () => this.render(child, node, i))
+            this.wrapBlock(delim, firstDelim(i, child), node, () => this.render(child, node, i))
         });
         this.inTightList = prevTight;
     }

--- a/src/core/types/serializer.ts
+++ b/src/core/types/serializer.ts
@@ -1,36 +1,9 @@
-import type {Fragment, Mark, Node} from 'prosemirror-model';
-
-import type {MarkdownSerializerState as SerializerState} from '../markdown/MarkdownSerializer';
-
-export type {MarkdownSerializerState as SerializerState} from '../markdown/MarkdownSerializer';
-
-export interface Serializer {
-    /** Serialize the content of the given node to markup */
-    serialize(content: Node | Fragment, options?: object): string;
-}
-
-export interface SerializerTests extends Serializer {
-    containsNode(nodeName: string): boolean;
-    containsMark(markName: string): boolean;
-}
-
-/** see MarkdownSerializer */
-export interface SerializerNodeToken {
-    (state: SerializerState, node: Node, parent: Node, index: number): void;
-}
-
-/** see MarkdownSerializer */
-export interface SerializerMarkToken {
-    open:
-        | string
-        | ((state: SerializerState, node: Mark, parent: Fragment, index: number) => string);
-    close:
-        | string
-        | ((state: SerializerState, node: Mark, parent: Fragment, index: number) => string);
-    mixable?: boolean;
-    escape?: boolean;
-    expelEnclosingWhitespace?: boolean;
-}
+export type {
+    MarkdownSerializerState as SerializerState,
+    SerializerNodeToken,
+    SerializerMarkToken,
+    MarkdownSerializer as SerializerTests,
+} from '../markdown/MarkdownSerializer';
 
 declare module 'prosemirror-model' {
     interface NodeSpec {

--- a/src/core/types/serializer.ts
+++ b/src/core/types/serializer.ts
@@ -2,7 +2,7 @@ export type {
     MarkdownSerializerState as SerializerState,
     SerializerNodeToken,
     SerializerMarkToken,
-    MarkdownSerializer as SerializerTests,
+    MarkdownSerializer as Serializer,
 } from '../markdown/MarkdownSerializer';
 
 declare module 'prosemirror-model' {

--- a/src/extensions/additional/GPT/gptExtension/view.tsx
+++ b/src/extensions/additional/GPT/gptExtension/view.tsx
@@ -213,8 +213,9 @@ export class GptWidgetDecoView<
         const {from, to} = deco;
 
         try {
+            // FIXME: Verify and use Node instead of Fragment
             const fragment = this._view.state.doc.slice(from, to, true).content;
-            const yfmMarkup = this._serializer.serialize(fragment);
+            const yfmMarkup = this._serializer.serialize(fragment as any);
 
             return yfmMarkup;
         } catch (error) {

--- a/src/extensions/base/BaseSchema/BaseSchemaSpecs/index.ts
+++ b/src/extensions/base/BaseSchema/BaseSchemaSpecs/index.ts
@@ -37,7 +37,7 @@ export const BaseSchemaSpecs: ExtensionAuto<BaseSchemaSpecsOptions> = (builder, 
             fromMd: {tokenSpec: {name: BaseNode.Text, type: 'node', ignore: true}},
             toMd: (state, node, parent) => {
                 const {escapeText} = parent.type.spec;
-                state.text(node.text, escapeText ?? !state.isAutolink);
+                state.text(node.text ?? '', escapeText ?? !state.isAutolink);
             },
         }))
         .addNode(BaseNode.Paragraph, () => ({
@@ -66,7 +66,7 @@ export const BaseSchemaSpecs: ExtensionAuto<BaseSchemaSpecsOptions> = (builder, 
             fromMd: {tokenSpec: {name: BaseNode.Paragraph, type: 'block'}},
             toMd: (state, node, parent) => {
                 /*
-                    An empty line is added only if there is some content in the parent element. 
+                    An empty line is added only if there is some content in the parent element.
                     This is necessary in order to prevent an empty document with empty lines
                 */
                 if (opts.preserveEmptyRows && isEmptyString(node)) {

--- a/src/extensions/behavior/Clipboard/clipboard.ts
+++ b/src/extensions/behavior/Clipboard/clipboard.ts
@@ -211,7 +211,8 @@ function serializeSelected(view: EditorView, serializer: Serializer): SerializeR
         return {text: fragment.textBetween(0, fragment.size)};
     }
 
-    const markup = serializer.serialize(getCopyContent(view.state).content);
+    // FIXME: Verify and use Node instead of Fragment
+    const markup = serializer.serialize(getCopyContent(view.state).content as any);
     const {dom, text} = serializeForClipboard(view, sel.content());
     return {markup, text, html: dom.innerHTML};
 }

--- a/src/extensions/markdown/CodeBlock/commands.ts
+++ b/src/extensions/markdown/CodeBlock/commands.ts
@@ -28,7 +28,10 @@ export const setCodeBlockType =
         if (!setBlockType(nodeType)(state)) return false;
 
         if (dispatch) {
-            const markup = serializer.serialize(state.selection.content().content, {escape: false});
+            // FIXME: Verify and use Node instead of Fragment
+            const markup = serializer.serialize(state.selection.content().content as any, {
+                escape: false,
+            });
             dispatch(
                 state.tr.replaceSelectionWith(
                     nodeType.createAndFill({}, markup ? state.schema.text(markup) : null)!,

--- a/src/extensions/markdown/Link/LinkSpecs/index.ts
+++ b/src/extensions/markdown/Link/LinkSpecs/index.ts
@@ -43,7 +43,8 @@ export const LinkSpecs: ExtensionAuto = (builder) => {
             },
             toMd: {
                 open(state, mark, parent, index) {
-                    state.isAutolink = isPlainURL(mark, parent, index, 1);
+                    // FIXME: Verify and use Node instead of Fragment
+                    state.isAutolink = isPlainURL(mark, parent as any, index, 1);
                     if (state.isAutolink) {
                         if (mark.attrs[LinkAttr.RawLink]) return '';
                         return '<';

--- a/src/extensions/markdown/Link/LinkSpecs/index.ts
+++ b/src/extensions/markdown/Link/LinkSpecs/index.ts
@@ -1,4 +1,4 @@
-import type {Fragment, Mark} from 'prosemirror-model';
+import type {Mark, Node} from 'prosemirror-model';
 
 import type {ExtensionAuto} from '../../../../core';
 import {markTypeFactory} from '../../../../utils/schema';
@@ -84,7 +84,7 @@ export const LinkSpecs: ExtensionAuto = (builder) => {
     );
 };
 
-function isPlainURL(link: Mark, parent: Fragment, index: number, side: number) {
+function isPlainURL(link: Mark, parent: Node, index: number, side: number) {
     if (link.attrs.title || !/^\w+:/.test(link.attrs[LinkAttr.Href])) return false;
 
     const content = parent.child(index + (side < 0 ? -1 : 0));


### PR DESCRIPTION
**BREAKING CHANGE**: Updated SerializerMarkToken — parent parameter in open and close changed from Fragment to Node.