### PR TITLE
fix(YfmCut): fixed open state styles

### DIFF
--- a/src/extensions/yfm/YfmCut/index.scss
+++ b/src/extensions/yfm/YfmCut/index.scss
@@ -1,12 +1,17 @@
 @use '../../../styles/mixins.scss';
 
-.ProseMirror.yfm .yfm-cut {
-    @include mixins.block-border-hover();
+.ProseMirror.yfm {
+    .yfm-cut {
+        @include mixins.block-border-hover();
 
-    &.yfm-cut-active {
-        border-color: var(--g-color-line-generic);
+        &.yfm-cut-active {
+            border-color: var(--g-color-line-generic);
+        }
+        .yfm-cut-title:focus {
+            outline: 0;
+        }
     }
-    .yfm-cut-title:focus {
-        outline: 0;
+    .yfm-cut.open .yfm-cut-title:before {
+        transform: translateY(-50%);
     }
 }


### PR DESCRIPTION
After updates in [cut-extension@171da43](https://github.com/diplodoc-platform/cut-extension/commit/171da43b970d08afde5411a602ab11fba4bc76ac) and [markdown-editor#591](https://github.com/gravity-ui/markdown-editor/pull/591), cut styles changed, causing incongruity. This fix adjusts `translateX(-50%)` for arrow positioning.