### PR TITLE
fix(YfmCut): fixed open state styles for nested cuts

### DIFF
--- a/src/extensions/yfm/YfmCut/index.scss
+++ b/src/extensions/yfm/YfmCut/index.scss
@@ -11,7 +11,7 @@
             outline: 0;
         }
     }
-    .yfm-cut.open .yfm-cut-title:before {
+    .yfm-cut.open > .yfm-cut-title:before {
         transform: translateY(-50%);
     }
 }


### PR DESCRIPTION
Fixes missed nested cuts logic in https://github.com/gravity-ui/markdown-editor/pull/616