### PR TITLE
feat: new logger implementation

### DIFF
--- a/demo/components/Playground.tsx
+++ b/demo/components/Playground.tsx
@@ -1,4 +1,4 @@
-import {type CSSProperties, memo, useCallback, useEffect, useState} from 'react';
+import {type CSSProperties, memo, useCallback, useEffect, useMemo, useState} from 'react';
 
 import {defaultOptions} from '@diplodoc/transform/lib/sanitize';
 import {Button, DropdownMenu} from '@gravity-ui/uikit';
@@ -6,6 +6,7 @@ import {Button, DropdownMenu} from '@gravity-ui/uikit';
 import {
     type DirectiveSyntaxValue,
     type FileUploadHandler,
+    Logger2,
     type MarkdownEditorMode,
     MarkdownEditorView,
     type MarkdownEditorViewProps,
@@ -29,6 +30,7 @@ import {getSanitizeYfmHtmlBlock} from '../../src/extensions/additional/YfmHtmlBl
 import type {CodeEditor} from '../../src/markup';
 import type {ToolbarsPreset} from '../../src/modules/toolbars/types';
 import {getPlugins} from '../defaults/md-plugins';
+import {useLogs} from '../hooks/useLogs';
 import useYfmHtmlBlockStyles from '../hooks/useYfmHtmlBlockStyles';
 import {randomDelay} from '../utils/delay';
 import {parseInsertedUrlAsImage} from '../utils/imageUrl';
@@ -86,9 +88,12 @@ export type PlaygroundProps = {
     >;
 
 logger.setLogger({
-    metrics: console.info,
-    action: (data) => console.info(`Action: ${data.action}`, data),
-    ...console,
+    log: (...data) => console.log('[Deprecated logger]', ...data),
+    info: (...data) => console.info('[Deprecated logger]', ...data),
+    warn: (...data) => console.warn('[Deprecated logger]', ...data),
+    error: (...data) => console.error('[Deprecated logger]', ...data),
+    metrics: (...data) => console.info('[Deprecated logger]', ...data),
+    action: (data) => console.info(`[Deprecated logger] Action: ${data.action}`, data),
 });
 
 export const Playground = memo<PlaygroundProps>((props) => {
@@ -142,8 +147,12 @@ export const Playground = memo<PlaygroundProps>((props) => {
         [sanitizeHtml],
     );
 
+    const logger = useMemo(() => new Logger2().nested({env: 'playground'}), []);
+    useLogs(logger);
+
     const mdEditor = useMarkdownEditor(
         {
+            logger,
             preset: 'full',
             wysiwygConfig: {
                 placeholderOptions: placeholderOptions,

--- a/demo/hooks/useLogs.ts
+++ b/demo/hooks/useLogs.ts
@@ -1,0 +1,14 @@
+import {useMemo} from 'react';
+
+import type {Logger2} from '../../src';
+
+export function useLogs(logger: Logger2.LogReceiver) {
+    useMemo(() => {
+        logger.on('log', (data) => console.log('Log:', data.msg, data));
+        logger.on('warn', (data) => console.warn('Warn:', data.msg, data));
+        logger.on('error', (data) => console.error('Error:', data.error, data));
+        logger.on('event', (data) => console.info('Event:', data.event, data));
+        logger.on('action', (data) => console.info('Action:', data.action, data));
+        logger.on('metrics', (data) => console.info('Metrics:', data.component, data));
+    }, [logger]);
+}

--- a/demo/stories/ghost/Ghost.tsx
+++ b/demo/stories/ghost/Ghost.tsx
@@ -1,16 +1,11 @@
 import cloneDeep from 'lodash/cloneDeep';
 
-import {MarkdownEditorView, logger, markupToolbarConfigs, useMarkdownEditor} from '../../../src';
+import {MarkdownEditorView, markupToolbarConfigs, useMarkdownEditor} from '../../../src';
 import {PlaygroundLayout} from '../../components/PlaygroundLayout';
+import {useLogs} from '../../hooks/useLogs';
 
 import {initialMdContent} from './content';
 import {ghostPopupExtension, ghostPopupToolbarItem} from './ghostExtension';
-
-logger.setLogger({
-    metrics: console.info,
-    action: (data) => console.info(`Action: ${data.action}`, data),
-    ...console,
-});
 
 const mToolbarConfig = cloneDeep(markupToolbarConfigs.mToolbarConfig);
 mToolbarConfig.unshift([ghostPopupToolbarItem]);
@@ -20,6 +15,8 @@ export const Ghost = () => {
         initial: {markup: initialMdContent, mode: 'markup'},
         markupConfig: {extensions: [ghostPopupExtension]},
     });
+
+    useLogs(editor.logger);
 
     return (
         <PlaygroundLayout

--- a/demo/stories/gpt/GPT.tsx
+++ b/demo/stories/gpt/GPT.tsx
@@ -5,7 +5,6 @@ import cloneDeep from 'lodash/cloneDeep';
 import {
     MarkdownEditorView,
     gptExtension,
-    logger,
     mGptExtension,
     mGptToolbarItem,
     markupToolbarConfigs,
@@ -14,15 +13,10 @@ import {
     wysiwygToolbarConfigs,
 } from '../../../src';
 import {PlaygroundLayout} from '../../components/PlaygroundLayout';
+import {useLogs} from '../../hooks/useLogs';
 
 import {initialMdContent} from './content';
 import {gptWidgetProps} from './gptWidgetOptions';
-
-logger.setLogger({
-    metrics: console.info,
-    action: (data) => console.info(`Action: ${data.action}`, data),
-    ...console,
-});
 
 const wToolbarConfig = cloneDeep(wysiwygToolbarConfigs.wToolbarConfig);
 wToolbarConfig.unshift([wGptItemData]);
@@ -61,6 +55,8 @@ export const GPT = memo(() => {
             },
         },
     });
+
+    useLogs(editor.logger);
 
     return (
         <PlaygroundLayout

--- a/demo/stories/presets/Preset.tsx
+++ b/demo/stories/presets/Preset.tsx
@@ -6,7 +6,6 @@ import {
     MarkdownEditorView,
     type MarkupString,
     type RenderPreview,
-    logger,
     useMarkdownEditor,
 } from '../../../src';
 import type {ToolbarsPreset} from '../../../src/modules/toolbars/types';
@@ -17,6 +16,7 @@ import {WysiwygSelection} from '../../components/PMSelection';
 import {WysiwygDevTools} from '../../components/ProseMirrorDevTools';
 import {SplitModePreview} from '../../components/SplitModePreview';
 import {plugins} from '../../defaults/md-plugins';
+import {useLogs} from '../../hooks/useLogs';
 import {block} from '../../utils/cn';
 import {randomDelay} from '../../utils/delay';
 import {parseInsertedUrlAsImage} from '../../utils/imageUrl';
@@ -42,12 +42,6 @@ export type PresetDemoProps = {
     height?: React.CSSProperties['height'];
     toolbarsPreset?: ToolbarsPreset;
 };
-
-logger.setLogger({
-    metrics: console.info,
-    action: (data) => console.info(`Action: ${data.action}`, data),
-    ...console,
-});
 
 export const Preset = memo<PresetDemoProps>((props) => {
     const {
@@ -108,6 +102,8 @@ export const Preset = memo<PresetDemoProps>((props) => {
             parseInsertedUrlAsImage,
         },
     });
+
+    useLogs(mdEditor.logger);
 
     useEffect(() => {
         function onChange() {

--- a/src/bundle/MarkdownEditorView.tsx
+++ b/src/bundle/MarkdownEditorView.tsx
@@ -14,7 +14,7 @@ import {useEnsuredForwardedRef, useKey, useUpdate} from 'react-use';
 
 import {type ClassNameProps, cn} from '../classname';
 import {i18n} from '../i18n/bundle';
-import {logger} from '../logger';
+import {globalLogger} from '../logger';
 import type {ToolbarsPreset} from '../modules/toolbars/types';
 import {useBooleanState, useSticky} from '../react-utils';
 import {isMac} from '../utils';
@@ -241,7 +241,8 @@ export const MarkdownEditorView = forwardRef<HTMLDivElement, MarkdownEditorViewP
         return (
             <ErrorBoundary
                 onError={(e) => {
-                    logger.error(e);
+                    globalLogger.error(e);
+                    editor.logger.error(e);
                 }}
                 fallbackRender={({error, resetErrorBoundary}) => {
                     toaster.add({

--- a/src/bundle/MarkupEditorView.tsx
+++ b/src/bundle/MarkupEditorView.tsx
@@ -2,7 +2,7 @@ import {memo} from 'react';
 
 import {type ClassNameProps, cn} from '../classname';
 import {ReactRendererComponent} from '../extensions';
-import {logger} from '../logger';
+import {globalLogger} from '../logger';
 import {useRenderTime} from '../react-utils/hooks';
 
 import type {EditorInt} from './Editor';
@@ -44,7 +44,12 @@ export const MarkupEditorView = memo<MarkupEditorViewProps>((props) => {
         stickyToolbar = true,
     } = props;
     useRenderTime((time) => {
-        logger.metrics({
+        globalLogger.metrics({
+            component: 'markup-editor',
+            event: 'render',
+            duration: time,
+        });
+        editor.logger.metrics({
             component: 'markup-editor',
             event: 'render',
             duration: time,

--- a/src/bundle/MarkupManager.ts
+++ b/src/bundle/MarkupManager.ts
@@ -1,6 +1,7 @@
 import type {Node} from 'prosemirror-model';
 import {v4} from 'uuid';
 
+import type {Logger2} from '../logger';
 import {SafeEventEmitter} from '../utils';
 
 export interface IMarkupManager {
@@ -10,11 +11,6 @@ export interface IMarkupManager {
     getNode(id: string): Node | null;
     reset(): void;
     on<K extends keyof Events>(event: K, listener: (value: Events[K]) => void): void;
-}
-
-export interface Logger {
-    log(message: string): void;
-    error(message: string): void;
 }
 
 interface Events {
@@ -28,9 +24,9 @@ export class MarkupManager extends SafeEventEmitter<Events> implements IMarkupMa
     private _nodes: Map<string, Node> = new Map();
     private _namespace: string;
 
-    private readonly logger?: Logger;
+    private readonly logger: Logger2.ILogger;
 
-    constructor(logger?: Logger) {
+    constructor(logger: Logger2.ILogger) {
         super();
         this.logger = logger;
         this._namespace = v4();
@@ -41,13 +37,13 @@ export class MarkupManager extends SafeEventEmitter<Events> implements IMarkupMa
      */
     setMarkup(id: string, rawMarkup: string): void {
         if (typeof rawMarkup !== 'string') {
-            this.logger?.error('[MarkupManager] rawMarkup must be a string');
+            this.logger.warn('[MarkupManager] rawMarkup must be a string');
             return;
         }
         this._markups.set(id, rawMarkup);
 
         this.emit('markupChanged', {id, rawMarkup});
-        this.logger?.log(`[MarkupManager] Raw markup for ID ${id} set successfully`);
+        this.logger.log(`[MarkupManager] Raw markup for ID ${id} set successfully`);
     }
 
     /**
@@ -55,13 +51,13 @@ export class MarkupManager extends SafeEventEmitter<Events> implements IMarkupMa
      */
     setNode(id: string, node: Node): void {
         if (!node) {
-            this.logger?.error('[MarkupManager] Node must be a valid ProseMirror Node');
+            this.logger.warn('[MarkupManager] Node must be a valid ProseMirror Node');
             return;
         }
         this._nodes.set(id, node);
 
         this.emit('nodeChanged', {id, node});
-        this.logger?.log(`[MarkupManager] Node for ID ${id} set successfully`);
+        this.logger.log(`[MarkupManager] Node for ID ${id} set successfully`);
     }
 
     /**
@@ -90,6 +86,6 @@ export class MarkupManager extends SafeEventEmitter<Events> implements IMarkupMa
         this._nodes.clear();
 
         this.emit('reset', {});
-        this.logger?.log('[MarkupManager] MarkupManager has been reset');
+        this.logger.log('[MarkupManager] MarkupManager has been reset');
     }
 }

--- a/src/bundle/WysiwygEditorView.tsx
+++ b/src/bundle/WysiwygEditorView.tsx
@@ -2,7 +2,7 @@ import {memo} from 'react';
 
 import {type ClassNameProps, cn} from '../classname';
 import {ReactRendererComponent} from '../extensions';
-import {logger} from '../logger';
+import {globalLogger} from '../logger';
 import {useRenderTime} from '../react-utils/hooks';
 
 import type {EditorInt} from './Editor';
@@ -40,7 +40,12 @@ export const WysiwygEditorView = memo<WysiwygEditorViewProps>((props) => {
         stickyToolbar = true,
     } = props;
     useRenderTime((time) => {
-        logger.metrics({
+        globalLogger.metrics({
+            component: 'wysiwyg-editor',
+            event: 'render',
+            duration: time,
+        });
+        editor.logger.metrics({
             component: 'wysiwyg-editor',
             event: 'render',
             duration: time,

--- a/src/bundle/config/dynamicModifiers.test.ts
+++ b/src/bundle/config/dynamicModifiers.test.ts
@@ -3,12 +3,15 @@ import {SchemaDynamicModifier} from '../../core/SchemaDynamicModifier';
 import {MarkdownParserDynamicModifier} from '../../core/markdown/MarkdownParser';
 import {MarkdownSerializerDynamicModifier} from '../../core/markdown/MarkdownSerializerDynamicModifier';
 import {convertDynamicModifiersConfigs} from '../../core/utils/dynamicModifiers';
+import {Logger2} from '../../logger';
 import {FullSpecsPreset} from '../../presets/full-specs';
 import {MarkupManager} from '../MarkupManager';
 
 import {createDynamicModifiers} from './dynamicModifiers';
 
-const markupManager = new MarkupManager();
+const markupManager = new MarkupManager(
+    new Logger2().nested({env: 'test', module: 'markup-manager'}),
+);
 
 const dynamicModifiersConfig = convertDynamicModifiersConfigs(
     createDynamicModifiers(markupManager),

--- a/src/bundle/types.ts
+++ b/src/bundle/types.ts
@@ -4,6 +4,7 @@ import type {ReactNode} from 'react';
 
 import type {MarkupString} from '../common';
 import type {EscapeConfig, Extension} from '../core';
+import type {Logger2} from '../logger';
 import type {CreateCodemirrorParams, YfmLangOptions} from '../markup';
 import type {FileUploadHandler} from '../utils';
 import type {DirectiveSyntaxContext, DirectiveSyntaxOption} from '../utils/directive';
@@ -196,4 +197,5 @@ export type MarkdownEditorOptions = {
     markupConfig?: MarkdownEditorMarkupConfig;
     /** Options for wysiwyg mode */
     wysiwygConfig?: MarkdownEditorWysiwygConfig;
+    logger?: Logger2.ILogger;
 };

--- a/src/bundle/useMarkdownEditor.ts
+++ b/src/bundle/useMarkdownEditor.ts
@@ -3,7 +3,7 @@ import {useLayoutEffect, useMemo} from 'react';
 import type {Extension} from '../core';
 import {getPMTransformers} from '../core/markdown/ProseMirrorTransformer/getTransformers';
 import {ReactRenderStorage} from '../extensions';
-import {logger} from '../logger';
+import {Logger2, globalLogger} from '../logger';
 import {DirectiveSyntaxContext} from '../utils/directive';
 
 import {EditorImpl, type EditorInt} from './Editor';
@@ -29,6 +29,7 @@ export function useMarkdownEditor(
             experimental = {},
             markupConfig = {},
             wysiwygConfig = {},
+            logger = new Logger2(),
         } = props;
 
         const preset: MarkdownEditorPreset = props.preset ?? 'full';
@@ -74,6 +75,7 @@ export function useMarkdownEditor(
 
         return new EditorImpl({
             ...props,
+            logger,
             preset,
             renderStorage,
             directiveSyntax,
@@ -92,7 +94,8 @@ export function useMarkdownEditor(
 
     useLayoutEffect(() => {
         function onToolbarAction({editorMode, id}: {editorMode: MarkdownEditorMode; id: string}) {
-            logger.action({mode: editorMode, source: 'toolbar', action: id});
+            globalLogger.action({mode: editorMode, source: 'toolbar', action: id});
+            editor.logger.action({mode: editorMode, source: 'toolbar', action: id});
         }
 
         editor.on('toolbar-action', onToolbarAction);

--- a/src/core/ExtensionBuilder.test.ts
+++ b/src/core/ExtensionBuilder.test.ts
@@ -1,11 +1,15 @@
 import {Plugin} from 'prosemirror-state';
 
+import {Logger2} from '../logger';
+
 import {ExtensionBuilder} from './ExtensionBuilder';
 import type {ExtensionDeps, ExtensionMarkSpec} from './types/extension';
 
+const logger = new Logger2().nested({env: 'test'});
+
 describe('ExtensionBuilder', () => {
     it('should build empty extension', () => {
-        const ext = new ExtensionBuilder().build();
+        const ext = new ExtensionBuilder(logger).build();
         const deps = {} as ExtensionDeps;
 
         expect(ext.nodes().size).toBe(0);
@@ -16,7 +20,7 @@ describe('ExtensionBuilder', () => {
 
     it('should immediately call added by .use() extension', () => {
         const mockExtension = jest.fn();
-        const builder = new ExtensionBuilder();
+        const builder = new ExtensionBuilder(logger);
         const options = {a: 1, b: 2, c: 3};
 
         builder.use(mockExtension, options);
@@ -26,7 +30,7 @@ describe('ExtensionBuilder', () => {
     });
 
     it('should add nodes', () => {
-        const nodes = new ExtensionBuilder()
+        const nodes = new ExtensionBuilder(logger)
             .addNode('node1', () => ({
                 spec: {},
                 fromMd: {tokenSpec: {type: 'block', name: 'node1'}},
@@ -46,7 +50,7 @@ describe('ExtensionBuilder', () => {
     });
 
     it('should add marks', () => {
-        const marks = new ExtensionBuilder()
+        const marks = new ExtensionBuilder(logger)
             .addMark('mark1', () => ({
                 spec: {},
                 fromMd: {tokenSpec: {type: 'mark', name: 'mark1'}},
@@ -86,7 +90,7 @@ describe('ExtensionBuilder', () => {
             fromMd: {tokenSpec: {type: 'mark', name: 'mark3'}},
             toMd: {open: '', close: ''},
         };
-        const marksOrderedMap = new ExtensionBuilder()
+        const marksOrderedMap = new ExtensionBuilder(logger)
             .addMark('mark3', () => mark3, ExtensionBuilder.Priority.VeryLow)
             .addMark('mark1', () => mark1)
             .addMark('mark0', () => mark0, ExtensionBuilder.Priority.VeryHigh)
@@ -106,7 +110,7 @@ describe('ExtensionBuilder', () => {
     });
 
     it('should add plugins', () => {
-        const plugins = new ExtensionBuilder()
+        const plugins = new ExtensionBuilder(logger)
             .addPlugin(() => new Plugin({}))
             .addPlugin(() => new Plugin({}))
             .build()
@@ -120,7 +124,7 @@ describe('ExtensionBuilder', () => {
         const plugin1 = new Plugin({});
         const plugin2 = new Plugin({});
         const plugin3 = new Plugin({});
-        const plugins = new ExtensionBuilder()
+        const plugins = new ExtensionBuilder(logger)
             .addPlugin(() => plugin3, ExtensionBuilder.Priority.VeryLow)
             .addPlugin(() => plugin1)
             .addPlugin(() => plugin0, ExtensionBuilder.Priority.VeryHigh)
@@ -135,7 +139,7 @@ describe('ExtensionBuilder', () => {
     });
 
     it('should add actions', () => {
-        const actions = new ExtensionBuilder()
+        const actions = new ExtensionBuilder(logger)
             .addAction('action1', () => ({
                 isActive: () => false,
                 isEnable: () => false,
@@ -155,7 +159,7 @@ describe('ExtensionBuilder', () => {
     });
 
     it('should throw error when add nodes with the same names', () => {
-        const builder = new ExtensionBuilder().addNode('node', () => ({
+        const builder = new ExtensionBuilder(logger).addNode('node', () => ({
             spec: {},
             toMd: () => {},
             fromMd: {tokenSpec: {type: 'block', name: 'node'}},
@@ -173,7 +177,7 @@ describe('ExtensionBuilder', () => {
     });
 
     it('should throw error when add marks with the same names', () => {
-        const builder = new ExtensionBuilder().addMark('mark', () => ({
+        const builder = new ExtensionBuilder(logger).addMark('mark', () => ({
             spec: {},
             toMd: {open: '', close: ''},
             fromMd: {tokenSpec: {type: 'mark', name: 'mark'}},
@@ -191,7 +195,7 @@ describe('ExtensionBuilder', () => {
     });
 
     it('should throw error when add actions with the same names', () => {
-        const builder = new ExtensionBuilder().addAction('action', () => ({
+        const builder = new ExtensionBuilder(logger).addAction('action', () => ({
             isActive: () => false,
             isEnable: () => false,
             run() {},

--- a/src/core/ExtensionBuilder.ts
+++ b/src/core/ExtensionBuilder.ts
@@ -4,6 +4,8 @@ import {inputRules} from 'prosemirror-inputrules';
 import {keymap} from 'prosemirror-keymap';
 import type {Plugin} from 'prosemirror-state';
 
+import type {Logger2} from '../logger';
+
 import type {ActionSpec} from './types/actions';
 import type {
     Extension,
@@ -74,6 +76,7 @@ export class ExtensionBuilder {
     readonly Priority = ExtensionBuilder.Priority;
     /* eslint-enable @typescript-eslint/member-ordering */
 
+    readonly #logger: Logger2.ILogger;
     #confMdCbs: {cb: ConfigureMdCallback; params: Required<ConfigureMdParams>}[] = [];
     #nodeSpecs: Record<string, {name: string; cb: AddPmNodeCallback}> = {};
     #markSpecs: Record<string, {name: string; cb: AddPmMarkCallback; priority: number}> = {};
@@ -82,8 +85,13 @@ export class ExtensionBuilder {
 
     readonly context: BuilderContext<WysiwygEditor.Context>;
 
-    constructor(context?: BuilderContext<WysiwygEditor.Context>) {
+    constructor(logger: Logger2.ILogger, context?: BuilderContext<WysiwygEditor.Context>) {
+        this.#logger = logger;
         this.context = context ?? ExtensionBuilder.createContext();
+    }
+
+    get logger(): Logger2.ILogger {
+        return this.#logger;
     }
 
     use(extension: Extension): this;

--- a/src/core/ExtensionsManager.ts
+++ b/src/core/ExtensionsManager.ts
@@ -2,6 +2,8 @@ import MarkdownIt, {type PresetName} from 'markdown-it';
 import type {Schema} from 'prosemirror-model';
 import type {Plugin} from 'prosemirror-state';
 
+import {Logger2} from '../logger';
+
 import {ActionsManager} from './ActionsManager';
 import {ExtensionBuilder} from './ExtensionBuilder';
 import {ParserTokensRegistry} from './ParserTokensRegistry';
@@ -22,6 +24,7 @@ import type {
 import type {MarkViewConstructor, NodeViewConstructor} from './types/node-views';
 
 type ExtensionsManagerParams = {
+    logger?: Logger2.ILogger;
     extensions: Extension;
     options?: ExtensionsManagerOptions;
 };
@@ -38,8 +41,12 @@ type ExtensionsManagerOptions = {
 };
 
 export class ExtensionsManager {
-    static process(extensions: Extension, options: ExtensionsManagerOptions) {
-        return new this({extensions, options}).build();
+    static process(
+        extensions: Extension,
+        options: ExtensionsManagerOptions,
+        logger?: Logger2.ILogger,
+    ) {
+        return new this({extensions, options, logger}).build();
     }
 
     #schemaRegistry;
@@ -65,9 +72,9 @@ export class ExtensionsManager {
     #serializerDynamicModifier?: MarkdownSerializerDynamicModifier;
     #parserDynamicModifier?: MarkdownParserDynamicModifier;
 
-    constructor({extensions, options = {}}: ExtensionsManagerParams) {
+    constructor({extensions, options = {}, logger = new Logger2()}: ExtensionsManagerParams) {
         this.#schemaRegistry = new SchemaSpecRegistry(undefined, options.dynamicModifiers?.schema);
-        this.#parserRegistry = new ParserTokensRegistry();
+        this.#parserRegistry = new ParserTokensRegistry({logger});
         this.#serializerRegistry = new SerializerTokensRegistry();
         if (options.dynamicModifiers) {
             this.#parserDynamicModifier = options.dynamicModifiers?.parser;
@@ -90,7 +97,7 @@ export class ExtensionsManager {
         }
 
         // TODO: add prefilled context
-        this.#builder = new ExtensionBuilder();
+        this.#builder = new ExtensionBuilder(logger);
     }
 
     build() {

--- a/src/core/ParserTokensRegistry.ts
+++ b/src/core/ParserTokensRegistry.ts
@@ -1,12 +1,23 @@
 import type MarkdownIt from 'markdown-it';
 import type {Schema} from 'prosemirror-model';
 
+import type {Logger2} from '../logger';
+
 import {MarkdownParser, type MarkdownParserDynamicModifier} from './markdown/MarkdownParser';
 import type {TransformFn} from './markdown/ProseMirrorTransformer';
 import type {Parser, ParserToken} from './types/parser';
 
+type ParserTokensRegistryOptions = {
+    logger: Logger2.ILogger;
+};
+
 export class ParserTokensRegistry {
     #tokens: Record<string, ParserToken> = {};
+    #logger: Logger2.ILogger;
+
+    constructor(opts: ParserTokensRegistryOptions) {
+        this.#logger = opts.logger;
+    }
 
     addToken(name: string, token: ParserToken) {
         this.#tokens[name] = token;
@@ -19,6 +30,10 @@ export class ParserTokensRegistry {
         pmTransformers: TransformFn[],
         dynamicModifier?: MarkdownParserDynamicModifier,
     ): Parser {
-        return new MarkdownParser(schema, tokenizer, this.#tokens, pmTransformers, dynamicModifier);
+        return new MarkdownParser(schema, tokenizer, this.#tokens, {
+            logger: this.#logger,
+            pmTransformers,
+            dynamicModifier,
+        });
     }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,6 +2,7 @@ export * from './Editor';
 export * from './ExtensionBuilder';
 export * from './ExtensionsManager';
 export {bindActions} from './utils/actions';
+export {getLoggerFromState} from './utils/logger';
 export {trackTransactionMetrics} from './utils/metrics';
 export type {Keymap} from './types/keymap';
 export type {ActionSpec, Action, ActionStorage, CommandWithAttrs} from './types/actions';

--- a/src/core/markdown/Markdown.test.ts
+++ b/src/core/markdown/Markdown.test.ts
@@ -6,6 +6,7 @@ import MarkdownIt from 'markdown-it';
 import * as builder from 'prosemirror-test-builder';
 
 import {createMarkupChecker} from '../../../tests/sameMarkup';
+import {Logger2} from '../../logger';
 import type {Parser} from '../types/parser';
 import type {SerializerNodeToken} from '../types/serializer';
 
@@ -35,7 +36,7 @@ const parser: Parser = new MarkdownParser(
         strong: {type: 'mark', name: 'strong'},
         code_inline: {type: 'mark', name: 'code', noCloseToken: true},
     },
-    [],
+    {logger: new Logger2().nested({env: 'test'}), pmTransformers: []},
 );
 const serializer = new MarkdownSerializer(
     {

--- a/src/core/markdown/MarkdownParser.test.ts
+++ b/src/core/markdown/MarkdownParser.test.ts
@@ -3,6 +3,7 @@ import type Token from 'markdown-it/lib/token';
 import {type Node, Schema} from 'prosemirror-model';
 import {schema as baseSchema, builders, doc, br as hardBreak, p} from 'prosemirror-test-builder';
 
+import {Logger2} from '../../logger';
 import type {Parser} from '../types/parser';
 
 import {MarkdownParser, MarkdownParserDynamicModifier, type TokenAttrs} from './MarkdownParser';
@@ -21,8 +22,11 @@ const createTestParser = (
             paragraph: {type: 'block', name: 'paragraph'},
             softbreak: {type: 'node', name: 'hard_break'},
         },
-        [],
-        dynamicModifier,
+        {
+            logger: new Logger2().nested({env: 'test'}),
+            pmTransformers: [],
+            dynamicModifier,
+        },
     );
 
 function parseWith(parser: Parser) {

--- a/src/core/utils/logger.ts
+++ b/src/core/utils/logger.ts
@@ -1,0 +1,13 @@
+import type {EditorState} from 'prosemirror-state';
+
+import type {Logger2} from '../../logger';
+import {Facet} from '../../utils/facet';
+
+/** @internal */
+export const LoggerFacet = Facet.define<Logger2.ILogger, Logger2.ILogger>({
+    combine: (value) => value[0],
+    static: true,
+});
+
+export const getLoggerFromState = (state: EditorState): Logger2.ILogger =>
+    LoggerFacet.getState(state)!;

--- a/src/core/utils/metrics.ts
+++ b/src/core/utils/metrics.ts
@@ -1,6 +1,6 @@
 import type {Transaction} from 'prosemirror-state';
 
-import {logger} from '../../logger';
+import {type Logger2, globalLogger} from '../../logger';
 
 const METRICS_KEY = 'metrics';
 
@@ -14,9 +14,15 @@ export const trackTransactionMetrics = (
     return tr;
 };
 
-export const logTransactionMetrics = (tr: Transaction) => {
+export const logTransactionMetrics = (tr: Transaction, logger: Logger2.ILogger) => {
     const metrics = tr.getMeta(METRICS_KEY);
     if (metrics) {
+        globalLogger.metrics({
+            component: 'transaction',
+            event: metrics.type,
+            duration: Date.now() - tr.time,
+            meta: metrics.meta,
+        });
         logger.metrics({
             component: 'transaction',
             event: metrics.type,

--- a/src/extensions/behavior/Autocomplete/Autocomplete.test.ts
+++ b/src/extensions/behavior/Autocomplete/Autocomplete.test.ts
@@ -1,4 +1,5 @@
-/* eslint-disable @typescript-eslint/no-loop-func */
+import {Logger2} from '../../../logger';
+
 import {MainHandler, type MainHandlerConfig} from './handler';
 import type {AutocompleteAction, AutocompleteHandler, AutocompleteTrigger} from './types';
 
@@ -12,6 +13,8 @@ const methodsWithAction = new Set<keyof AutocompleteHandler>([
 
 describe('Autocomplete', () => {
     describe('MainHandler', () => {
+        const logger = new Logger2().nested({env: 'test'});
+
         for (const method of methodsWithAction) {
             it(`should call ${method} only on the right handlers`, () => {
                 const handler1: AutocompleteHandler = {[method]: jest.fn(() => false)};
@@ -34,7 +37,7 @@ describe('Autocomplete', () => {
                     {handler: handler2, trigger: trigger2},
                     {handler: handler3, trigger: trigger3},
                 ];
-                const mainHandler = new MainHandler(config);
+                const mainHandler = new MainHandler(config, logger);
 
                 expect(mainHandler[method](action1)).toBe(false);
                 expect(handler1[method]).toBeCalledTimes(1);
@@ -61,7 +64,7 @@ describe('Autocomplete', () => {
                 {handler: handler2, trigger},
                 {handler: handler3, trigger},
             ];
-            const mainHandler = new MainHandler(config);
+            const mainHandler = new MainHandler(config, logger);
 
             mainHandler.onDestroy();
 

--- a/src/extensions/behavior/Autocomplete/handler.ts
+++ b/src/extensions/behavior/Autocomplete/handler.ts
@@ -1,5 +1,5 @@
 import {capitalize, isString} from '../../../lodash';
-import {logger} from '../../../logger';
+import {type Logger2, globalLogger} from '../../../logger';
 
 import type {AutocompleteAction, AutocompleteHandler, AutocompleteItem} from './types';
 
@@ -16,11 +16,12 @@ type MainHandlerLogOptions =
       };
 
 export class MainHandler implements Required<AutocompleteHandler> {
-    private static log(opts: MainHandlerLogOptions) {
+    private static log(logger: Logger2.ILogger, opts: MainHandlerLogOptions) {
         const prefix = '[Autocomplete]';
 
         if (opts.event === 'destroy') {
             logger.log(`${prefix} Destroy`);
+            globalLogger.log(`${prefix} Destroy`);
             return;
         }
 
@@ -35,46 +36,51 @@ export class MainHandler implements Required<AutocompleteHandler> {
         ].join(' ');
 
         logger.log(msg);
+        globalLogger.log(msg);
     }
 
     private readonly config: MainHandlerConfig;
+    private readonly logger: Logger2.ILogger;
 
-    constructor(config: MainHandlerConfig) {
+    constructor(config: MainHandlerConfig, logger: Logger2.ILogger) {
         this.config = config;
+        this.logger = logger.nested({
+            module: 'autocomplete-main-handler',
+        });
     }
 
     onOpen(action: AutocompleteAction): boolean {
         const item = this.getItem(action);
-        MainHandler.log({event: 'open', action, item});
+        MainHandler.log(this.logger, {event: 'open', action, item});
         return item?.handler.onOpen?.(action) ?? false;
     }
 
     onClose(action: AutocompleteAction): boolean {
         const item = this.getItem(action);
-        MainHandler.log({event: 'close', action, item});
+        MainHandler.log(this.logger, {event: 'close', action, item});
         return item?.handler.onClose?.(action) ?? false;
     }
 
     onArrow(action: AutocompleteAction): boolean {
         const item = this.getItem(action);
-        MainHandler.log({event: 'arrow', action, item});
+        MainHandler.log(this.logger, {event: 'arrow', action, item});
         return item?.handler.onArrow?.(action) ?? false;
     }
 
     onEnter(action: AutocompleteAction): boolean {
         const item = this.getItem(action);
-        MainHandler.log({event: 'enter', action, item});
+        MainHandler.log(this.logger, {event: 'enter', action, item});
         return item?.handler.onEnter?.(action) ?? false;
     }
 
     onFilter(action: AutocompleteAction): boolean {
         const item = this.getItem(action);
-        MainHandler.log({event: 'filter', action, item});
+        MainHandler.log(this.logger, {event: 'filter', action, item});
         return item?.handler.onFilter?.(action) ?? false;
     }
 
     onDestroy(): void {
-        MainHandler.log({event: 'destroy'});
+        MainHandler.log(this.logger, {event: 'destroy'});
         for (const item of this.config) {
             item.handler.onDestroy?.();
         }

--- a/src/extensions/behavior/Autocomplete/index.ts
+++ b/src/extensions/behavior/Autocomplete/index.ts
@@ -37,7 +37,7 @@ export const Autocomplete: ExtensionAuto = (builder) => {
             config.push(item);
         }
 
-        const handler = new MainHandler(config);
+        const handler = new MainHandler(config, builder.logger);
         const plugins = autocomplete({
             triggers,
             onOpen: handler.onOpen.bind(handler),

--- a/src/extensions/behavior/Clipboard/clipboard.ts
+++ b/src/extensions/behavior/Clipboard/clipboard.ts
@@ -3,7 +3,7 @@ import {type EditorState, Plugin, type Selection} from 'prosemirror-state';
 import type {EditorView} from 'prosemirror-view';
 
 import {type Parser, type Serializer, trackTransactionMetrics} from '../../../core';
-import {logger} from '../../../logger';
+import {type Logger2, globalLogger} from '../../../logger';
 import '../../../types/spec';
 import {tryCatch} from '../../../utils/helpers';
 import {isNodeSelection, isTextSelection, isWholeSelection} from '../../../utils/selection';
@@ -14,6 +14,7 @@ import {isInsideCode} from './code';
 import {DataTransferType, extractTextContentFromHtml, isIosSafariShare} from './utils';
 
 export type ClipboardPluginOptions = {
+    logger: Logger2.ILogger;
     mdParser: Parser;
     textParser: Parser;
     serializer: Serializer;
@@ -21,6 +22,7 @@ export type ClipboardPluginOptions = {
 };
 
 export const clipboard = ({
+    logger,
     textParser,
     mdParser,
     serializer,
@@ -106,7 +108,11 @@ export const clipboard = ({
                                 );
                                 isPasteHandled = true;
                             } else {
-                                logger.error(res.error);
+                                globalLogger.error(res.error);
+                                logger.error(res.error, {
+                                    module: 'clipboard',
+                                    event: 'paste',
+                                });
                                 console.error(res.error);
                             }
                         } else return false; // default html pasting
@@ -159,7 +165,11 @@ export const clipboard = ({
                                 );
                                 isPasteHandled = true;
                             } else {
-                                logger.error(res.error);
+                                globalLogger.error(res.error);
+                                logger.error(res.error, {
+                                    module: 'clipboard',
+                                    event: 'paste',
+                                });
                                 console.error(res.error);
                             }
                         }

--- a/src/extensions/behavior/Clipboard/index.ts
+++ b/src/extensions/behavior/Clipboard/index.ts
@@ -11,6 +11,7 @@ export const Clipboard: ExtensionAuto<ClipboardOptions> = (builder, opts) => {
     builder.addPlugin(
         (deps) =>
             clipboard({
+                logger: builder.logger,
                 mdParser: deps.markupParser,
                 textParser: deps.textParser,
                 serializer: deps.serializer,

--- a/src/extensions/behavior/CommandMenu/handler.ts
+++ b/src/extensions/behavior/CommandMenu/handler.ts
@@ -1,10 +1,10 @@
 import type {EditorView} from 'prosemirror-view';
 
-import {logger} from '../../..//logger';
-import {AutocompletePopupCloser} from '../../..//utils/autocomplete-popup';
-import {ArrayCarousel} from '../../..//utils/carousel';
 import type {ActionStorage} from '../../../core';
 import {isFunction} from '../../../lodash';
+import {type Logger2, globalLogger} from '../../../logger';
+import {AutocompletePopupCloser} from '../../../utils/autocomplete-popup';
+import {ArrayCarousel} from '../../../utils/carousel';
 import {
     type AutocompleteAction,
     AutocompleteActionKind,
@@ -25,12 +25,14 @@ declare module 'prosemirror-model' {
 }
 
 export type CommandHandlerParams = {
+    logger: Logger2.ILogger;
     actions: Config;
     storage: ActionStorage;
     nodesIgnoreList?: readonly string[];
 };
 
 export class CommandHandler implements AutocompleteHandler {
+    readonly #logger: Logger2.ILogger;
     readonly #actions: readonly CommandAction[];
     readonly #actionStorage: ActionStorage;
     readonly #nodesIgnoreList: readonly string[];
@@ -45,7 +47,8 @@ export class CommandHandler implements AutocompleteHandler {
     #menuProps?: CommandMenuComponentProps;
     #menuRenderItem?: RendererItem;
 
-    constructor({actions, storage, nodesIgnoreList = []}: CommandHandlerParams) {
+    constructor({logger, actions, storage, nodesIgnoreList = []}: CommandHandlerParams) {
+        this.#logger = logger;
         this.#actions = actions;
         this.#actionStorage = storage;
         this.#nodesIgnoreList = nodesIgnoreList;
@@ -164,7 +167,8 @@ export class CommandHandler implements AutocompleteHandler {
         action.exec(this.#actionStorage);
         view.focus();
 
-        logger.action({mode: 'wysiwyg', source: 'command-menu', action: action.id});
+        globalLogger.action({mode: 'wysiwyg', source: 'command-menu', action: action.id});
+        this.#logger.action({source: 'command-menu', action: action.id});
     }
 
     private filterActions(): boolean {

--- a/src/extensions/behavior/CommandMenu/index.ts
+++ b/src/extensions/behavior/CommandMenu/index.ts
@@ -1,7 +1,7 @@
 import type {ExtensionAuto} from '../../../core';
 import {DeflistNode, TableNode} from '../../../extensions/markdown';
 import {CheckboxNode, CutNode, TabsNode, YfmNoteNode} from '../../../extensions/yfm';
-import {logger} from '../../../logger';
+import {type Logger2, globalLogger} from '../../../logger';
 import {Autocomplete, type AutocompleteItemFn} from '../Autocomplete';
 
 import {DecoClassName} from './const';
@@ -14,7 +14,7 @@ export type CommandMenuOptions = {
 };
 
 const getCommandMenuAutocompleteItem =
-    (opts: CommandMenuOptions): AutocompleteItemFn =>
+    (opts: CommandMenuOptions, logger: Logger2.ILogger): AutocompleteItemFn =>
     ({actions}) => ({
         trigger: {
             name: 'command',
@@ -24,6 +24,7 @@ const getCommandMenuAutocompleteItem =
             decorationAttrs: {class: DecoClassName},
         },
         handler: new CommandHandler({
+            logger,
             storage: actions,
             actions: opts.actions,
             // TODO: add commandMenu=false flag to specs:
@@ -41,11 +42,16 @@ const getCommandMenuAutocompleteItem =
 
 export const CommandMenu: ExtensionAuto<CommandMenuOptions> = (builder, opts) => {
     if (!Array.isArray(opts.actions) || opts.actions.length === 0) {
-        logger.info("[CommandMenu extension]: Skip because 'actions' is not an array or is empty");
+        globalLogger.log(
+            "[CommandMenu extension]: Skip because 'actions' is not an array or is empty",
+        );
+        builder.logger.log(
+            "[CommandMenu extension]: Skip because 'actions' is not an array or is empty",
+        );
         return;
     }
     if (!builder.context.has('autocomplete')) {
         builder.use(Autocomplete);
     }
-    builder.context.get('autocomplete')!.add(getCommandMenuAutocompleteItem(opts));
+    builder.context.get('autocomplete')!.add(getCommandMenuAutocompleteItem(opts, builder.logger));
 };

--- a/src/extensions/behavior/SelectionContext/index.ts
+++ b/src/extensions/behavior/SelectionContext/index.ts
@@ -9,6 +9,7 @@ import {
 import type {EditorProps, EditorView} from 'prosemirror-view';
 
 import type {ActionStorage, ExtensionAuto} from '../../../core';
+import type {Logger2} from '../../../logger';
 import {isCodeBlock} from '../../../utils/nodes';
 
 import {type ContextConfig, TooltipView} from './tooltip';
@@ -24,7 +25,9 @@ export type SelectionContextOptions = {
 
 export const SelectionContext: ExtensionAuto<SelectionContextOptions> = (builder, {config}) => {
     if (Array.isArray(config) && config.length > 0) {
-        builder.addPlugin(({actions}) => new Plugin(new SelectionTooltip(actions, config)));
+        builder.addPlugin(
+            ({actions}) => new Plugin(new SelectionTooltip(actions, config, builder.logger)),
+        );
     }
 };
 
@@ -38,8 +41,8 @@ class SelectionTooltip implements PluginSpec<unknown> {
 
     private _isMousePressed = false;
 
-    constructor(actions: ActionStorage, menuConfig: ContextConfig) {
-        this.tooltip = new TooltipView(actions, menuConfig);
+    constructor(actions: ActionStorage, menuConfig: ContextConfig, logger: Logger2.ILogger) {
+        this.tooltip = new TooltipView(actions, menuConfig, logger);
     }
 
     get props(): EditorProps {

--- a/src/extensions/behavior/SelectionContext/tooltip.tsx
+++ b/src/extensions/behavior/SelectionContext/tooltip.tsx
@@ -5,7 +5,7 @@ import type {EditorView} from 'prosemirror-view';
 
 import type {ActionStorage} from '../../../core';
 import {isFunction} from '../../../lodash';
-import {logger} from '../../../logger';
+import {type Logger2, globalLogger} from '../../../logger';
 import {ErrorLoggerBoundary} from '../../../react-utils/ErrorBoundary';
 import {Toolbar} from '../../../toolbar';
 import type {
@@ -49,6 +49,7 @@ export type ContextConfig = ContextGroupData[];
 export class TooltipView {
     #isTooltipOpen = false;
 
+    private logger: Logger2.ILogger;
     private actions: ActionStorage;
     private menuConfig: ContextConfig;
 
@@ -56,7 +57,8 @@ export class TooltipView {
     private baseProps: SelectionTooltipBaseProps = {show: false, poppupProps: {}};
     private _tooltipRenderItem: RendererItem | null = null;
 
-    constructor(actions: ActionStorage, menuConfig: ContextConfig) {
+    constructor(actions: ActionStorage, menuConfig: ContextConfig, logger: Logger2.ILogger) {
+        this.logger = logger;
         this.actions = actions;
         this.menuConfig = menuConfig;
     }
@@ -96,7 +98,10 @@ export class TooltipView {
             focus: () => this.view.focus(),
             data: this.getFilteredConfig(),
             editor: this.actions,
-            onClick: (id) => logger.action({mode: 'wysiwyg', source: 'context-menu', action: id}),
+            onClick: (id) => {
+                globalLogger.action({mode: 'wysiwyg', source: 'context-menu', action: id});
+                this.logger.action({source: 'context-menu', action: id});
+            },
         };
     }
 

--- a/src/extensions/behavior/utils/upload.ts
+++ b/src/extensions/behavior/utils/upload.ts
@@ -1,6 +1,8 @@
 import type {Node} from 'prosemirror-model';
 import type {EditorView} from 'prosemirror-view';
 
+import {getLoggerFromState} from '../../../core';
+import type {Logger2} from '../../../logger';
 import {
     type FileUploadHandler,
     type UploadSuccessItem,
@@ -12,6 +14,7 @@ export abstract class FilesBatchUploadProcess {
     protected readonly view;
     protected readonly files;
     protected readonly uploadHandler;
+    protected readonly logger: Logger2.ILogger;
 
     protected skeletonDescriptor?: WidgetDescriptor;
 
@@ -19,6 +22,7 @@ export abstract class FilesBatchUploadProcess {
         this.view = view;
         this.files = files;
         this.uploadHandler = uploadHandler;
+        this.logger = getLoggerFromState(view.state);
     }
 
     async run() {

--- a/src/extensions/markdown/Breaks/index.ts
+++ b/src/extensions/markdown/Breaks/index.ts
@@ -3,7 +3,7 @@ import type {Node, NodeType} from 'prosemirror-model';
 import {TextSelection} from 'prosemirror-state';
 
 import type {ExtensionAuto, Keymap} from '../../../core';
-import {logger} from '../../../logger';
+import {globalLogger} from '../../../logger';
 import {isMac} from '../../../utils/platform';
 import {isTextSelection} from '../../../utils/selection';
 import {pType} from '../../base/BaseSchema/BaseSchemaSpecs';
@@ -27,7 +27,10 @@ export const Breaks: ExtensionAuto<BreaksOptions> = (builder, opts) => {
         preferredBreak = builder.context.get('breaks') ? 'soft' : 'hard';
     } else {
         preferredBreak = opts.preferredBreak ?? 'hard';
-        logger.info(
+        globalLogger.info(
+            "[Breaks extension]: Parameter 'breaks' is not defined in context; value from options is used",
+        );
+        builder.logger.log(
             "[Breaks extension]: Parameter 'breaks' is not defined in context; value from options is used",
         );
     }

--- a/src/extensions/markdown/CodeBlock/CodeBlockHighlight/CodeBlockHighlight.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlockHighlight/CodeBlockHighlight.ts
@@ -11,7 +11,7 @@ import {Decoration, DecorationSet} from 'prosemirror-view';
 
 import type {ExtensionAuto} from '../../../../core';
 import {capitalize} from '../../../../lodash';
-import {logger} from '../../../../logger';
+import {globalLogger} from '../../../../logger';
 import {CodeBlockNodeAttr, codeBlockNodeName, codeBlockType} from '../CodeBlockSpecs';
 
 import {codeLangSelectTooltipViewCreator} from './TooltipPlugin';
@@ -45,7 +45,8 @@ export const CodeBlockHighlight: ExtensionAuto<CodeBlockHighlightOptions> = (bui
         langs = {...all, ...opts.langs};
         lowlight = create(langs);
     } catch (e) {
-        logger.info('Skip code_block highlighting');
+        globalLogger.info('Skip code_block highlighting');
+        builder.logger.log('Skip code_block highlighting');
         return;
     }
 

--- a/src/extensions/markdown/Html/index.ts
+++ b/src/extensions/markdown/Html/index.ts
@@ -1,5 +1,5 @@
 import type {ExtensionAuto} from '../../../core';
-import {logger} from '../../../logger';
+import {globalLogger} from '../../../logger';
 
 import {HtmlNode} from './const';
 import {parserTokens} from './parser';
@@ -10,7 +10,8 @@ export {HtmlAttr, HtmlNode} from './const';
 
 export const Html: ExtensionAuto = (builder) => {
     if (builder.context.has('html') && builder.context.get('html') === false) {
-        logger.info('[HTML extension]: Skip extension, because HTML disabled via context');
+        globalLogger.info('[HTML extension]: Skip extension, because HTML disabled via context');
+        builder.logger.log('[HTML extension]: Skip extension, because HTML disabled via context');
         return;
     }
 

--- a/src/extensions/yfm/ImgSize/ImagePaste/upload.ts
+++ b/src/extensions/yfm/ImgSize/ImagePaste/upload.ts
@@ -1,7 +1,7 @@
 import type {Node} from 'prosemirror-model';
 import type {EditorView} from 'prosemirror-view';
 
-import {logger} from '../../../../logger';
+import {type Logger2, globalLogger} from '../../../../logger';
 import {
     type FileUploadHandler,
     type UploadSuccessItem,
@@ -30,16 +30,20 @@ export class ImagesUploadProcess extends FilesBatchUploadProcess {
         super(view, files, uploadHandler);
 
         this.initPosition = position;
-        this.createImage = createImageNode(imageType(this.view.state.schema), opts);
+        this.createImage = createImageNode(imageType(this.view.state.schema), opts, this.logger);
         this.enableNewImageSizeCalculation = opts.enableNewImageSizeCalculation;
     }
 
     protected async createSkeleton() {
         return new ImageSkeletonDescriptor(
             this.initPosition,
-            await getSkeletonSize(this.files, {
-                enableNewImageSizeCalculation: this.enableNewImageSizeCalculation,
-            }),
+            await getSkeletonSize(
+                this.files,
+                {
+                    enableNewImageSizeCalculation: this.enableNewImageSizeCalculation,
+                },
+                this.logger,
+            ),
         );
     }
 
@@ -50,18 +54,20 @@ export class ImagesUploadProcess extends FilesBatchUploadProcess {
 
 async function getSkeletonSize(
     files: readonly File[],
-    opts?: {enableNewImageSizeCalculation?: boolean},
+    opts: {enableNewImageSizeCalculation?: boolean},
+    logger: Logger2.ILogger,
 ) {
     const skeletonSize = {width: '300', height: '200'};
     if (files.length === 1) {
         try {
             const size = await loadImage(files[0]).then(
-                opts?.enableNewImageSizeCalculation ? calcSkeletonSizeNew : calcSkeletonSize,
+                opts.enableNewImageSizeCalculation ? calcSkeletonSizeNew : calcSkeletonSize,
             );
             skeletonSize.width = String(size.width);
             skeletonSize.height = String(size.height);
         } catch (err) {
-            logger.error(err);
+            globalLogger.error(err);
+            logger.error({error: err});
         }
     }
     return skeletonSize;

--- a/src/extensions/yfm/ImgSize/utils.ts
+++ b/src/extensions/yfm/ImgSize/utils.ts
@@ -1,6 +1,6 @@
 import type {Node, NodeType} from 'prosemirror-model';
 
-import {logger} from '../../../logger';
+import {type Logger2, globalLogger} from '../../../logger';
 import {type UploadSuccessItem, getProportionalSize} from '../../../utils';
 import {imageNodeName} from '../../markdown';
 import {ImgSizeAttr} from '../../specs';
@@ -17,7 +17,7 @@ export type CreateImageNodeOptions = {
 };
 
 export const createImageNode =
-    (imgType: NodeType, opts: CreateImageNodeOptions) =>
+    (imgType: NodeType, opts: CreateImageNodeOptions, logger: Logger2.ILogger) =>
     async ({result, file}: UploadSuccessItem) => {
         const attrs: Record<string, string> = {
             [ImgSizeAttr.Src]: result.url,
@@ -30,7 +30,8 @@ export const createImageNode =
                 );
                 Object.assign(attrs, sizes);
             } catch (err) {
-                logger.error(err);
+                globalLogger.error(err);
+                logger.error({error: err});
             }
         }
         return imgType.create(attrs);

--- a/src/extensions/yfm/YfmFile/YfmFilePaste/index.ts
+++ b/src/extensions/yfm/YfmFile/YfmFilePaste/index.ts
@@ -114,9 +114,13 @@ class YfmFilesPasteUploadProcess extends YfmFilesUploadProcessBase {
 
         const {schema} = this.view.state;
         if (imageType(schema)) {
-            this.createImage = createImageNode(imageType(schema), {
-                needDimensions: opts.needToSetDimensionsForUploadedImages,
-            });
+            this.createImage = createImageNode(
+                imageType(schema),
+                {
+                    needDimensions: opts.needToSetDimensionsForUploadedImages,
+                },
+                this.logger,
+            );
         }
     }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,20 +1,176 @@
+import {type Listener, type Receiver, SafeEventEmitter} from './utils/event-emitter';
+
+type MsgObj = {
+    msg: string;
+    [key: string]: unknown;
+};
+
+type ErrObj = {
+    error: any;
+    [key: string]: unknown;
+};
+
+type EventObj = {
+    event: string;
+    [key: string]: unknown;
+};
+
+// MAJOR: rename Logger2 to Logger (namespace and class)
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Logger2 {
+    export type LogData = MsgObj;
+    export type WarnData = MsgObj;
+    export type ErrorData = ErrObj;
+    export type ActionData = MdEditorLogger.ActionData;
+    export type MetricsData = MdEditorLogger.MetricsData;
+    export type EventData = EventObj;
+
+    export type ReceiverDataMap = {
+        log: LogData;
+        warn: WarnData;
+        error: ErrorData;
+        event: EventData;
+        action: ActionData;
+        metrics: MetricsData;
+    };
+
+    export interface LogReceiver extends Receiver<ReceiverDataMap> {}
+
+    export interface LogEmitter {
+        /** Log a regular message */
+        log(msg: string, ...data: object[]): void;
+        /** Log a warning message */
+        warn(msg: string, ...data: object[]): void;
+        /** Log an error */
+        error(err: string | Error | unknown, ...data: object[]): void;
+        /** Log an event triggered in editor. For example, changing mode, pasting, or otherwise */
+        event(data: Logger2.EventData): void;
+        /** Log the action called in editor and its source (from toolbar, or hotkeys, etc.) */
+        action(data: Logger2.ActionData): void;
+        /** Log metric data, such as parsing or execution time */
+        metrics(data: Logger2.MetricsData): void;
+    }
+
+    export interface ILogger extends Logger2.LogEmitter, Logger2.LogReceiver {
+        /** Create nested logger with bound parameters */
+        nested(params: object): ILogger;
+    }
+}
+
+export class Logger2 implements Logger2.ILogger {
+    readonly #emitter = new SafeEventEmitter<Logger2.ReceiverDataMap>();
+
+    log(msg: string, ...data: object[]): void {
+        const obj: object = Object.assign({}, ...data);
+        const logData = Object.assign(obj, {msg});
+        this.#emitter.emit('log', logData);
+    }
+
+    warn(msg: string, ...data: object[]): void {
+        const obj: object = Object.assign({}, ...data);
+        const warnData = Object.assign(obj, {msg});
+        this.#emitter.emit('warn', warnData);
+    }
+
+    error(err: string | Error | unknown, ...data: object[]): void {
+        const error = typeof err === 'string' ? Error(err) : err;
+        const obj: object = Object.assign({}, ...data);
+        const errorData = Object.assign(obj, {error});
+        this.#emitter.emit('error', errorData);
+    }
+
+    action(data: Logger2.ActionData): void {
+        this.#emitter.emit('action', data);
+    }
+
+    metrics(data: Logger2.MetricsData): void {
+        this.#emitter.emit('metrics', data);
+    }
+
+    event(data: Logger2.EventData): void {
+        this.#emitter.emit('event', data);
+    }
+
+    nested(params: object): Logger2.ILogger {
+        const self = this;
+        const paramsKey = Symbol();
+
+        const logger: Logger2.ILogger & {[paramsKey]: object} = {
+            [paramsKey]: params,
+            log(msg, ...data) {
+                if (self.#emitter.countOf('log')) self.log(msg, this[paramsKey], ...data);
+            },
+            warn(msg, ...data) {
+                if (self.#emitter.countOf('warn')) self.warn(msg, this[paramsKey], ...data);
+            },
+            error(err, ...data) {
+                if (self.#emitter.countOf('error')) self.error(err, this[paramsKey], ...data);
+            },
+            action(data) {
+                if (self.#emitter.countOf('action')) self.action({...this[paramsKey], ...data});
+            },
+            metrics(data) {
+                if (self.#emitter.countOf('metrics')) self.metrics({...this[paramsKey], ...data});
+            },
+            event(data) {
+                if (self.#emitter.countOf('event')) self.event({...this[paramsKey], ...data});
+            },
+            nested(nestedParams) {
+                return {
+                    ...this,
+                    [paramsKey]: {
+                        ...this[paramsKey],
+                        ...nestedParams,
+                    },
+                };
+            },
+            on: self.on.bind(self),
+            off: self.off.bind(self),
+        };
+
+        return logger;
+    }
+
+    on<K extends keyof Logger2.ReceiverDataMap>(
+        type: K,
+        listener: Listener<Logger2.ReceiverDataMap[K]>,
+    ): void {
+        this.#emitter.on(type, listener);
+    }
+
+    off<K extends keyof Logger2.ReceiverDataMap>(
+        type: K,
+        listener: Listener<Logger2.ReceiverDataMap[K]>,
+    ): void {
+        this.#emitter.off(type, listener);
+    }
+}
+
+// MAJOR: remove old logger implementation
+
 const noop = () => {};
 
 declare global {
+    /** @deprecated */
     namespace MdEditorLogger {
+        /** @deprecated */
         type MetricsData = {
             component: string;
             event: string;
             duration?: number;
             meta?: Record<string, any>;
+            [key: string]: any;
         };
 
+        /** @deprecated */
         interface ActionData {
             action: string;
             source: string;
             [key: string]: any;
         }
 
+        /** @deprecated */
         interface Logger {
             log(...data: any[]): void;
             info(...data: any[]): void;
@@ -24,10 +180,12 @@ declare global {
             action(data: ActionData): void;
         }
 
+        /** @deprecated */
         interface Settings extends Partial<Logger> {}
     }
 }
 
+/** @deprecated */
 class Logger implements MdEditorLogger.Logger {
     #logger: MdEditorLogger.Logger = this.createLogger({});
 
@@ -76,4 +234,11 @@ class Logger implements MdEditorLogger.Logger {
     }
 }
 
+/** @deprecated */
 export const logger = new Logger();
+/**
+ * Alias for global singleton logger instance
+ *
+ * @deprecated
+ */
+export const globalLogger = logger;

--- a/src/markup/codemirror/logger-facet.ts
+++ b/src/markup/codemirror/logger-facet.ts
@@ -1,0 +1,8 @@
+import {Facet} from '@codemirror/state';
+
+import type {Logger2} from '../../logger';
+
+export const LoggerFacet = Facet.define<Logger2.ILogger, Logger2.ILogger>({
+    combine: (value) => value[0],
+    static: true,
+});

--- a/src/utils/event-emitter.ts
+++ b/src/utils/event-emitter.ts
@@ -33,6 +33,10 @@ export class EventEmitter<T extends object = UnkObj> implements Emitter<T>, Rece
     emit<K extends keyof T>(type: K, value: T[K]): void {
         this._listeners.get(type)?.forEach((listener) => listener(value));
     }
+
+    countOf<K extends keyof T>(type: K): number {
+        return this._listeners.get(type)?.length || 0;
+    }
 }
 
 export class SafeEventEmitter<T extends object = UnkObj> extends EventEmitter<T> {

--- a/src/utils/facet.ts
+++ b/src/utils/facet.ts
@@ -1,0 +1,46 @@
+// Partial realization of Facet from CodeMirror, but for ProseMirror
+
+import {type EditorState, Plugin, PluginKey} from 'prosemirror-state';
+
+import {uniqueId} from '../lodash';
+
+/** @internal @unstable */
+export type FacetConfig<Input, Output> = {
+    combine: (value: readonly Input[]) => Output;
+    static: true;
+    name?: string;
+};
+
+/** @internal @unstable */
+export class Facet<Input, Output = readonly Input[]> {
+    static define<Input, Output = readonly Input[]>(
+        config: FacetConfig<Input, Output>,
+    ): Facet<Input, Output> {
+        return new this(config);
+    }
+
+    private readonly _combine;
+    private readonly _key: PluginKey<Output>;
+
+    private constructor(config: FacetConfig<Input, Output>) {
+        this._combine = config.combine;
+        this._key = new PluginKey(
+            `Facet${config.static ? '_static' : ''}:${config.name || ''}:${uniqueId()}`,
+        );
+    }
+
+    of(value: Input): Plugin<Output> {
+        const output = this._combine([value]);
+        return new Plugin<Output>({
+            key: this._key,
+            state: {
+                init: () => output,
+                apply: () => output,
+            },
+        });
+    }
+
+    getState(state: EditorState): Output | undefined {
+        return this._key.getState(state);
+    }
+}

--- a/src/utils/keymap.ts
+++ b/src/utils/keymap.ts
@@ -1,11 +1,17 @@
 import type {Command} from 'prosemirror-state';
 
-import {logger} from '../logger';
+import {getLoggerFromState} from '../core';
+import {globalLogger} from '../logger';
 
 export function withLogAction(action: string, command: Command): Command {
     return (...args) => {
         const res = command(...args);
-        if (res) logger.action({action, source: 'keymap'});
+        if (res) {
+            const [state] = args;
+            const logger = getLoggerFromState(state);
+            logger.action({action, source: 'keymap'});
+            globalLogger.action({action, source: 'keymap', mode: 'wysiwyg'});
+        }
         return res;
     };
 }


### PR DESCRIPTION
Problems of old logger:
- global logger instance
  - there is no inheritance/nesting of logs
  - it is not possible to split logs between different instances of the editor
- only one log consumer
  - adding new consumer through `logger.setLogger` always override previous consumer

New logger:
- one per editor instance
- can be passed from outside
- support nesting
- event-based system
  - can add multiple subscribers to each log event

An alias named `globalLogger` has been added for old logger, both (`logger` and `globalLogger`) have been deprecated.

New logger is named `Logger2`. New instance can be created using `new Logger2()`. Nested logger can be created by calling `logger.nested({})`. Example: `new Logger2().nested({env: 'test'})`. Parameters passed to `.nested()` call will be added to all logs emitted by nested logger.