### PR TITLE
build: support import aliases

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,8 @@
+import {resolve} from 'node:path';
 import webpack from 'webpack';
 import type {StorybookConfig} from '@storybook/react-webpack5';
 import pkg from '../package.json';
+import tsConfig from '../tsconfig.json';
 
 const config: StorybookConfig = {
     framework: {
@@ -25,6 +27,16 @@ const config: StorybookConfig = {
                 __VERSION__: `'${pkg.version}-storybook'`,
             }),
         );
+
+        config.resolve ||= {};
+        config.resolve.alias ||= {};
+
+        const baseUrl = resolve(__dirname, '..', tsConfig.compilerOptions.baseUrl);
+        const paths = tsConfig.compilerOptions.paths;
+
+        for (const alias in paths) {
+            config.resolve.alias[alias] = resolve(baseUrl, paths[alias][0])
+        }
 
         return config;
     },

--- a/demo/components/PMSelection.tsx
+++ b/demo/components/PMSelection.tsx
@@ -1,15 +1,15 @@
 import {useLayoutEffect} from 'react';
 
-import type {EditorView} from 'prosemirror-view';
 import {useEffectOnce, useUpdate} from 'react-use';
 
+import type {EditorView} from '#pm/view';
 import {
     type ClassNameProps,
     type MarkdownEditorInstance,
     isNodeSelection,
     isTextSelection,
     isWholeSelection,
-} from '../../src';
+} from 'src/index';
 
 export type WysiwygSelectionProps = ClassNameProps & {
     editor: MarkdownEditorInstance;

--- a/demo/components/Playground.tsx
+++ b/demo/components/Playground.tsx
@@ -3,6 +3,13 @@ import {type CSSProperties, memo, useCallback, useEffect, useMemo, useState} fro
 import {defaultOptions} from '@diplodoc/transform/lib/sanitize';
 import {Button, DropdownMenu} from '@gravity-ui/uikit';
 
+import type {ToolbarActionData} from 'src/bundle/Editor';
+import type {Extension} from 'src/cm/state';
+import {FoldingHeading} from 'src/extensions/additional/FoldingHeading';
+import {Math} from 'src/extensions/additional/Math';
+import {Mermaid} from 'src/extensions/additional/Mermaid';
+import {YfmHtmlBlock} from 'src/extensions/additional/YfmHtmlBlock';
+import {getSanitizeYfmHtmlBlock} from 'src/extensions/additional/YfmHtmlBlock/utils';
 import {
     type DirectiveSyntaxValue,
     type FileUploadHandler,
@@ -19,16 +26,10 @@ import {
     logger,
     useMarkdownEditor,
     wysiwygToolbarConfigs,
-} from '../../src';
-import type {ToolbarActionData} from '../../src/bundle/Editor';
-import type {Extension} from '../../src/cm/state';
-import {FoldingHeading} from '../../src/extensions/additional/FoldingHeading';
-import {Math} from '../../src/extensions/additional/Math';
-import {Mermaid} from '../../src/extensions/additional/Mermaid';
-import {YfmHtmlBlock} from '../../src/extensions/additional/YfmHtmlBlock';
-import {getSanitizeYfmHtmlBlock} from '../../src/extensions/additional/YfmHtmlBlock/utils';
-import type {CodeEditor} from '../../src/markup';
-import type {ToolbarsPreset} from '../../src/modules/toolbars/types';
+} from 'src/index';
+import type {CodeEditor} from 'src/markup';
+import type {ToolbarsPreset} from 'src/modules/toolbars/types';
+
 import {getPlugins} from '../defaults/md-plugins';
 import {useLogs} from '../hooks/useLogs';
 import useYfmHtmlBlockStyles from '../hooks/useYfmHtmlBlockStyles';

--- a/demo/components/PlaygroundLayout.tsx
+++ b/demo/components/PlaygroundLayout.tsx
@@ -2,8 +2,9 @@ import {StrictMode, useEffect} from 'react';
 
 import {useUpdate} from 'react-use';
 
-import type {MarkdownEditorInstance} from '../../src';
-import {VERSION} from '../../src/version';
+import type {MarkdownEditorInstance} from 'src/index';
+import {VERSION} from 'src/version';
+
 import {useMarkdownEditorValue} from '../hooks/useMarkdownEditorValue';
 import {block} from '../utils/cn';
 

--- a/demo/components/ProseMirrorDevTools.tsx
+++ b/demo/components/ProseMirrorDevTools.tsx
@@ -1,10 +1,10 @@
 import {useEffect, useLayoutEffect} from 'react';
 
 import {applyDevTools, removeDevTools} from 'prosemirror-dev-toolkit';
-import type {EditorView} from 'prosemirror-view';
 import {useEffectOnce, useUpdate} from 'react-use';
 
-import type {MarkdownEditorInstance} from '../../src';
+import type {EditorView} from '#pm/view';
+import type {MarkdownEditorInstance} from 'src/index';
 
 export type WysiwygDevToolsProps = {
     editor: MarkdownEditorInstance;

--- a/demo/components/SplitModePreview.tsx
+++ b/demo/components/SplitModePreview.tsx
@@ -4,12 +4,13 @@ import transform from '@diplodoc/transform';
 import {useThemeValue} from '@gravity-ui/uikit';
 import type MarkdownIt from 'markdown-it';
 
-import {type MarkupString, colorClassName} from '../../src';
-import {debounce} from '../../src/lodash';
-import {YfmStaticView} from '../../src/view/components/YfmHtml';
-import {withLatex} from '../../src/view/hocs/withLatex';
-import {type MermaidConfig, withMermaid} from '../../src/view/hocs/withMermaid';
-import {withYfmHtmlBlock} from '../../src/view/hocs/withYfmHtml';
+import {type MarkupString, colorClassName} from 'src/index';
+import {debounce} from 'src/lodash';
+import {YfmStaticView} from 'src/view/components/YfmHtml';
+import {withLatex} from 'src/view/hocs/withLatex';
+import {type MermaidConfig, withMermaid} from 'src/view/hocs/withMermaid';
+import {withYfmHtmlBlock} from 'src/view/hocs/withYfmHtml';
+
 import {LATEX_RUNTIME, MERMAID_RUNTIME, YFM_HTML_BLOCK_RUNTIME} from '../defaults/md-plugins';
 import useYfmHtmlBlockStyles from '../hooks/useYfmHtmlBlockStyles';
 

--- a/demo/defaults/md-plugins.ts
+++ b/demo/defaults/md-plugins.ts
@@ -19,13 +19,13 @@ import yfmTable from '@diplodoc/transform/lib/plugins/table';
 import video from '@diplodoc/transform/lib/plugins/video';
 import type {PluginWithParams} from 'markdown-it/lib';
 
-import type {RenderPreviewParams} from '../../src';
-import {emojiDefs} from '../../src/bundle/emoji';
-import color from '../../src/markdown-it/color';
-import {bare as emoji} from '../../src/markdown-it/emoji';
-import ins from '../../src/markdown-it/ins';
-import mark from '../../src/markdown-it/mark';
-import sub from '../../src/markdown-it/sub';
+import {emojiDefs} from 'src/bundle/emoji';
+import type {RenderPreviewParams} from 'src/index';
+import color from 'src/markdown-it/color';
+import {bare as emoji} from 'src/markdown-it/emoji';
+import ins from 'src/markdown-it/ins';
+import mark from 'src/markdown-it/mark';
+import sub from 'src/markdown-it/sub';
 
 export const LATEX_RUNTIME = 'extension:latex';
 export const MERMAID_RUNTIME = 'extension:mermaid';

--- a/demo/hocs/withLang.tsx
+++ b/demo/hocs/withLang.tsx
@@ -1,7 +1,7 @@
 import {configure} from '@gravity-ui/uikit';
 import type {Decorator} from '@storybook/react';
 
-import {configure as configureYfmEditor} from '../../src';
+import {configure as configureYfmEditor} from 'src/index';
 
 import '@gravity-ui/uikit/styles/styles.scss';
 

--- a/demo/hooks/useLogs.ts
+++ b/demo/hooks/useLogs.ts
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 
-import type {Logger2} from '../../src';
+import type {Logger2} from 'src/index';
 
 export function useLogs(logger: Logger2.LogReceiver) {
     useMemo(() => {

--- a/demo/hooks/useMarkdownEditorValue.ts
+++ b/demo/hooks/useMarkdownEditorValue.ts
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'react';
 
-import {type MarkdownEditorInstance, type MarkupString, useDebounce} from '../../src';
+import {type MarkdownEditorInstance, type MarkupString, useDebounce} from 'src/index';
 
 export function useMarkdownEditorValue(editor: MarkdownEditorInstance, delay = 500): MarkupString {
     const [value, setValue] = useState(() => editor.getValue());

--- a/demo/hooks/useYfmHtmlBlockStyles.ts
+++ b/demo/hooks/useYfmHtmlBlockStyles.ts
@@ -3,7 +3,7 @@ import {useEffect, useState} from 'react';
 import type {IHTMLIFrameElementConfig} from '@diplodoc/html-extension/runtime';
 import {useThemeValue} from '@gravity-ui/uikit';
 
-import {getYfmHtmlBlockCssVariables} from '../../src/view/hocs/withYfmHtml/utils';
+import {getYfmHtmlBlockCssVariables} from 'src/view/hocs/withYfmHtml/utils';
 
 const variablesMapping = {
     colorBackground: '--g-color-base-background',

--- a/demo/stories/css-variables/CSSVariables.tsx
+++ b/demo/stories/css-variables/CSSVariables.tsx
@@ -1,6 +1,7 @@
 import {memo} from 'react';
 
-import {MarkdownEditorView, useMarkdownEditor} from '../../../src';
+import {MarkdownEditorView, useMarkdownEditor} from 'src/index';
+
 import {PlaygroundLayout} from '../../components/PlaygroundLayout';
 import {markup} from '../../defaults/content';
 

--- a/demo/stories/editor-in-editor/EditorInEditor.tsx
+++ b/demo/stories/editor-in-editor/EditorInEditor.tsx
@@ -1,6 +1,7 @@
 import {useEffect} from 'react';
 
-import {BaseNode, MarkdownEditorView, useMarkdownEditor} from '../../../src';
+import {BaseNode, MarkdownEditorView, useMarkdownEditor} from 'src/index';
+
 import {PlaygroundLayout} from '../../components/PlaygroundLayout';
 
 import {

--- a/demo/stories/editor-in-editor/EditorInEditorExtension/index.tsx
+++ b/demo/stories/editor-in-editor/EditorInEditorExtension/index.tsx
@@ -1,9 +1,9 @@
-import type {Node} from 'prosemirror-model';
-import type {EditorView, NodeView} from 'prosemirror-view';
 import {createPortal} from 'react-dom';
 
-import {type ExtensionAuto, getReactRendererFromState} from '../../../../src';
-import {MarkdownEditorView, useMarkdownEditor} from '../../../../src/bundle';
+import type {Node} from '#pm/model';
+import type {EditorView, NodeView} from '#pm/view';
+import {MarkdownEditorView, useMarkdownEditor} from 'src/bundle';
+import {type ExtensionAuto, getReactRendererFromState} from 'src/index';
 
 import './index.scss';
 

--- a/demo/stories/escape-config/EscapeConfig.tsx
+++ b/demo/stories/escape-config/EscapeConfig.tsx
@@ -1,4 +1,5 @@
-import {MarkdownEditorView, useMarkdownEditor} from '../../../src';
+import {MarkdownEditorView, useMarkdownEditor} from 'src/index';
+
 import {PlaygroundLayout} from '../../components/PlaygroundLayout';
 import {markup} from '../../defaults/content';
 

--- a/demo/stories/examples/img-custom-form/ImageCustomForm.tsx
+++ b/demo/stories/examples/img-custom-form/ImageCustomForm.tsx
@@ -3,7 +3,8 @@ import {memo} from 'react';
 import {FilePlus} from '@gravity-ui/icons';
 import {Button, FilePreview, Icon, useFileInput} from '@gravity-ui/uikit';
 
-import {type ImgSizeOptions, MarkdownEditorView, useMarkdownEditor} from '../../../../src';
+import {type ImgSizeOptions, MarkdownEditorView, useMarkdownEditor} from 'src/index';
+
 import {PlaygroundLayout} from '../../../components/PlaygroundLayout';
 import {randomDelay} from '../../../utils/delay';
 

--- a/demo/stories/experiments/empty-row/EmptyRows.tsx
+++ b/demo/stories/experiments/empty-row/EmptyRows.tsx
@@ -1,6 +1,7 @@
 import {memo, useCallback, useLayoutEffect, useState} from 'react';
 
-import {MarkdownEditorView, type RenderPreview, useMarkdownEditor} from '../../../../src';
+import {MarkdownEditorView, type RenderPreview, useMarkdownEditor} from 'src/index';
+
 import {PlaygroundLayout} from '../../../components/PlaygroundLayout';
 import {SplitModePreview} from '../../../components/SplitModePreview';
 import {plugins} from '../../../defaults/md-plugins';

--- a/demo/stories/experiments/store-raw/StoreRawMarkup.tsx
+++ b/demo/stories/experiments/store-raw/StoreRawMarkup.tsx
@@ -1,6 +1,7 @@
 import {memo, useCallback, useLayoutEffect, useState} from 'react';
 
-import {MarkdownEditorView, type RenderPreview, useMarkdownEditor} from '../../../../src';
+import {MarkdownEditorView, type RenderPreview, useMarkdownEditor} from 'src/index';
+
 import {PlaygroundLayout} from '../../../components/PlaygroundLayout';
 import {SplitModePreview} from '../../../components/SplitModePreview';
 import {plugins} from '../../../defaults/md-plugins';

--- a/demo/stories/ghost/Ghost.tsx
+++ b/demo/stories/ghost/Ghost.tsx
@@ -1,6 +1,6 @@
-import cloneDeep from 'lodash/cloneDeep';
+import {MarkdownEditorView, markupToolbarConfigs, useMarkdownEditor} from 'src/index';
+import {cloneDeep} from 'src/lodash';
 
-import {MarkdownEditorView, markupToolbarConfigs, useMarkdownEditor} from '../../../src';
 import {PlaygroundLayout} from '../../components/PlaygroundLayout';
 import {useLogs} from '../../hooks/useLogs';
 

--- a/demo/stories/ghost/ghostExtension/commands.ts
+++ b/demo/stories/ghost/ghostExtension/commands.ts
@@ -1,4 +1,4 @@
-import type {EditorView} from '../../../../src/cm/view';
+import type {EditorView} from '#cm/view';
 
 import {HideGhostPopupEffect, ShowGhostPopupEffect} from './effects';
 

--- a/demo/stories/ghost/ghostExtension/effects.ts
+++ b/demo/stories/ghost/ghostExtension/effects.ts
@@ -1,4 +1,4 @@
-import {StateEffect} from '../../../../src/cm/state';
+import {StateEffect} from '#cm/state';
 
 export const ShowGhostPopupEffect = StateEffect.define();
 export const HideGhostPopupEffect = StateEffect.define();

--- a/demo/stories/ghost/ghostExtension/plugin.ts
+++ b/demo/stories/ghost/ghostExtension/plugin.ts
@@ -1,4 +1,3 @@
-import {ReactRendererFacet} from '../../../../src';
 import {
     Decoration,
     type DecorationSet,
@@ -7,7 +6,8 @@ import {
     ViewPlugin,
     type ViewUpdate,
     WidgetType,
-} from '../../../../src/cm/view';
+} from '#cm/view';
+import {ReactRendererFacet} from 'src/index';
 
 import {hideGhostPopup} from './commands';
 import {HideGhostPopupEffect, ShowGhostPopupEffect} from './effects';

--- a/demo/stories/ghost/ghostExtension/toolbar.ts
+++ b/demo/stories/ghost/ghostExtension/toolbar.ts
@@ -1,6 +1,6 @@
 import {Ghost} from '@gravity-ui/icons';
 
-import {type MToolbarSingleItemData, ToolbarDataType} from '../../../../src';
+import {type MToolbarSingleItemData, ToolbarDataType} from 'src/index';
 
 import {showGhostPopup} from './commands';
 

--- a/demo/stories/gpt/GPT.tsx
+++ b/demo/stories/gpt/GPT.tsx
@@ -1,7 +1,5 @@
 import {memo, useState} from 'react';
 
-import cloneDeep from 'lodash/cloneDeep';
-
 import {
     MarkdownEditorView,
     gptExtension,
@@ -11,7 +9,9 @@ import {
     useMarkdownEditor,
     wGptItemData,
     wysiwygToolbarConfigs,
-} from '../../../src';
+} from 'src/index';
+import {cloneDeep} from 'src/lodash';
+
 import {PlaygroundLayout} from '../../components/PlaygroundLayout';
 import {useLogs} from '../../hooks/useLogs';
 

--- a/demo/stories/gpt/gptWidgetOptions.tsx
+++ b/demo/stories/gpt/gptWidgetOptions.tsx
@@ -1,4 +1,4 @@
-import type {GptWidgetOptions} from '../../../src';
+import type {GptWidgetOptions} from 'src/index';
 
 const gptRequestHandler = async ({
     markup,

--- a/demo/stories/presets/Preset.tsx
+++ b/demo/stories/presets/Preset.tsx
@@ -7,11 +7,11 @@ import {
     type MarkupString,
     type RenderPreview,
     useMarkdownEditor,
-} from '../../../src';
-import type {ToolbarsPreset} from '../../../src/modules/toolbars/types';
-import type {FileUploadHandler} from '../../../src/utils/upload';
-import {VERSION} from '../../../src/version';
-// ---
+} from 'src/index';
+import type {ToolbarsPreset} from 'src/modules/toolbars/types';
+import type {FileUploadHandler} from 'src/utils/upload';
+import {VERSION} from 'src/version';
+
 import {WysiwygSelection} from '../../components/PMSelection';
 import {WysiwygDevTools} from '../../components/ProseMirrorDevTools';
 import {SplitModePreview} from '../../components/SplitModePreview';

--- a/demo/stories/presets/Presets.stories.tsx
+++ b/demo/stories/presets/Presets.stories.tsx
@@ -1,7 +1,7 @@
 import type {StoryObj} from '@storybook/react';
 
-import {ActionName as Action} from '../../../src/bundle/config/action-names';
-import {ToolbarName as Toolbar} from '../../../src/modules/toolbars/constants';
+import {ActionName as Action} from 'src/bundle/config/action-names';
+import {ToolbarName as Toolbar} from 'src/modules/toolbars/constants';
 import {
     boldItemView,
     boldItemWysiwyg,
@@ -16,7 +16,7 @@ import {
     undoItemMarkup,
     undoItemView,
     undoItemWysiwyg,
-} from '../../../src/modules/toolbars/items';
+} from 'src/modules/toolbars/items';
 
 import {Preset as component} from './Preset';
 

--- a/demo/stories/remember-mode/RememberMode.tsx
+++ b/demo/stories/remember-mode/RememberMode.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
 
-import type {MarkdownEditorMode} from '../../../src/bundle';
+import type {MarkdownEditorMode} from 'src/bundle';
+
 import {PlaygroundMini} from '../../components/PlaygroundMini';
 
 import {markup} from './content';

--- a/demo/utils/location.ts
+++ b/demo/utils/location.ts
@@ -1,4 +1,4 @@
-import {debounce} from '../../src/lodash';
+import {debounce} from 'src/lodash';
 
 const QKEY = 'markup';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@diplodoc/tabs-extension": "^3.5.1",
         "@diplodoc/transform": "^4.43.0",
         "@gravity-ui/eslint-config": "3.3.0",
-        "@gravity-ui/gulp-utils": "1.0.1",
+        "@gravity-ui/gulp-utils": "1.0.3",
         "@gravity-ui/prettier-config": "1.1.0",
         "@gravity-ui/stylelint-config": "4.0.1",
         "@gravity-ui/tsconfig": "1.0.0",
@@ -3382,9 +3382,9 @@
       }
     },
     "node_modules/@gravity-ui/gulp-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gravity-ui/gulp-utils/-/gulp-utils-1.0.1.tgz",
-      "integrity": "sha512-jdBcRcPFPeQIZCdJjpKDX+lDmGufNzkY00La6u80b0siy9sDzXP8Uh8IGj1Y5ykKeT7Ui21M0JcqxCEbmCZrNA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gravity-ui/gulp-utils/-/gulp-utils-1.0.3.tgz",
+      "integrity": "sha512-0TfFGUMsjU8gCBjTD1OuRR9E44AoHHEBxhnrXXaaOREdCtrtAA63hHsoC+MiMnackC885w0ixIcVQOFFkpQidQ==",
       "dev": true,
       "dependencies": {
         "plugin-error": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "@diplodoc/tabs-extension": "^3.5.1",
     "@diplodoc/transform": "^4.43.0",
     "@gravity-ui/eslint-config": "3.3.0",
-    "@gravity-ui/gulp-utils": "1.0.1",
+    "@gravity-ui/gulp-utils": "1.0.3",
     "@gravity-ui/prettier-config": "1.1.0",
     "@gravity-ui/stylelint-config": "4.0.1",
     "@gravity-ui/tsconfig": "1.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,10 @@
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "paths": {
+      "#core": ["./src/core"],
+      "#cm/*": ["./src/cm/*"],
+      "#pm/*": ["./src/pm/*"],
+      "src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*", "demo/**/*", "tests/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
+    "paths": {
+    }
   },
   "include": ["src/**/*", "demo/**/*", "tests/**/*"],
   "exclude": ["build"]


### PR DESCRIPTION
Now we can use import aliases in our code:

```
// similarly for other prosemirror packages, re-exported from `src/pm/*`
import 'prosemirror-view' --> import '#pm/view'

// similarly for other codemirror packages, re-exported from `src/cm/*`
import '@codemirror/view' --> import '#cm/view'

import '../../../core' --> import '#core'

// similarly for all imports from src/
import '../../../lodash' --> import 'src/lodash'
```

`#` is required for entries from package "imports", so I suggest using this prefix for aliases similar to those from package "exports"