### PR TITLE
test: support import aliases

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
+const {pathsToModuleNameMapper} = require('ts-jest');
+const {compilerOptions} = require('./tsconfig.json');
+
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 // eslint-disable-next-line no-undef
 module.exports = {
@@ -6,6 +9,7 @@ module.exports = {
     testPathIgnorePatterns: ['spec.js', 'spec.ts'],
     setupFilesAfterEnv: ['<rootDir>tests/setup.ts'],
     moduleNameMapper: {
+        ...pathsToModuleNameMapper(compilerOptions.paths, {prefix: '<rootDir>/'}),
         '\\.(css|less|scss|sss|styl)$': '<rootDir>/node_modules/jest-css-modules',
         '.+\\.(svg|png|jpg)$': 'identity-obj-proxy',
     },


### PR DESCRIPTION
## Description

Added aliases to `tsconfig.json` in [#656](https://github.com/gravity-ui/markdown-editor/pull/656/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0), requiring matching updates in `jest.config.js`. Used `pathsToModuleNameMapper` to sync aliases (`#core`, `#cm/*`, etc.) for Jest, fixing test failures.