### PR TITLE
feat(YfmHtmlBlock): added compatibility for sanitize named export

### DIFF
--- a/src/extensions/additional/YfmHtmlBlock/utils.ts
+++ b/src/extensions/additional/YfmHtmlBlock/utils.ts
@@ -18,9 +18,8 @@ const sanitizeAll = () => {
 };
 const getSanitizeFunction = (): SanitizeFn => {
     const module = sanitizeModule as SanitizeModule;
-    return 'sanitize' in module && module.sanitize
-        ? module.sanitize
-        : module.default ?? sanitizeAll;
+    const sanitize = 'sanitize' in module && module.sanitize ? module.sanitize : module.default;
+    return sanitize instanceof Function ? sanitize : sanitizeAll;
 };
 
 // MAJOR: use `import {sanitize} from '@diplodoc/transform/lib/sanitize.js'`

--- a/src/extensions/additional/YfmHtmlBlock/utils.ts
+++ b/src/extensions/additional/YfmHtmlBlock/utils.ts
@@ -1,4 +1,30 @@
-import diplodocSanitize, {type SanitizeOptions} from '@diplodoc/transform/lib/sanitize.js';
+import type {SanitizeOptions} from '@diplodoc/transform/lib/sanitize.js';
+import * as sanitizeModule from '@diplodoc/transform/lib/sanitize.js';
+
+type SanitizeFn = (
+    html: string,
+    options?: SanitizeOptions,
+    additionalOptions?: SanitizeOptions,
+) => string;
+
+interface SanitizeModule {
+    sanitize?: SanitizeFn;
+    default?: SanitizeFn;
+}
+
+const sanitizeAll = () => {
+    console.warn('[YfmHtmlBlock]: sanitize function not found');
+    return '';
+};
+const getSanitizeFunction = (): SanitizeFn => {
+    const module = sanitizeModule as SanitizeModule;
+    return 'sanitize' in module && module.sanitize
+        ? module.sanitize
+        : module.default ?? sanitizeAll;
+};
+
+// MAJOR: use `import {sanitize} from '@diplodoc/transform/lib/sanitize.js'`
+const diplodocSanitize = getSanitizeFunction();
 
 // yfmHtmlBlock additional css properties white list
 const getYfmHtmlBlockWhiteList = () => {

--- a/src/extensions/markdown/Lists/plugins/CollapseListsPlugin.ts
+++ b/src/extensions/markdown/Lists/plugins/CollapseListsPlugin.ts
@@ -1,5 +1,6 @@
 import {Fragment, type Node} from 'prosemirror-model';
 import {Plugin, TextSelection, type Transaction} from 'prosemirror-state';
+// @ts-ignore // TODO: fix cjs build
 import {findChildren, hasParentNode} from 'prosemirror-utils';
 
 import {getChildrenOfNode} from '../../../../utils';
@@ -36,7 +37,8 @@ export function collapseEmptyListItems(
     nodes: ReturnType<typeof findChildren>,
 ): number {
     const stepsCountBefore = tr.steps.length;
-    nodes.reverse().forEach((list) => {
+    // TODO: fix cjs build
+    nodes.reverse().forEach((list: {node: Node; pos: number}) => {
         const listNode = list.node;
         const listPos = list.pos;
         const childrenOfList = getChildrenOfNode(listNode).reverse();


### PR DESCRIPTION
Fixed issues with default sanitize import in ESM projects by supporting sanitize named export, keeping default import for compatibility. See https://github.com/diplodoc-platform/transform/releases/tag/v4.47.4