### PR TITLE
fix(gpt): added "onClose" props in plugin for  markup mode

### DIFF
--- a/demo/stories/gpt/gptWidgetOptions.tsx
+++ b/demo/stories/gpt/gptWidgetOptions.tsx
@@ -58,6 +58,9 @@ export const gptWidgetProps = (
         onTryAgain: async ({markup, customPrompt, promptData}) => {
             return gptRequestHandler({markup, customPrompt, promptData});
         },
+        onClose: () => {
+            console.log('close');
+        },
         onLike: async () => {},
         onDislike: async () => {},
         onApplyResult: (markup) => {

--- a/src/extensions/additional/GPT/MarkupGpt/plugin.ts
+++ b/src/extensions/additional/GPT/MarkupGpt/plugin.ts
@@ -135,7 +135,11 @@ export function mGptPlugin<
                 return renderPopup(this._anchor as HTMLElement, {
                     ...gptProps,
                     disablePromptPresets: this.disablePromptPresets,
-                    onClose: () => hideMarkupGpt(this._view),
+                    onClose: () => {
+                        hideMarkupGpt(this._view);
+
+                        gptProps.onClose?.();
+                    },
                     markup: this.markup,
                     onApplyResult: (changedMarkup) => this._onApplyResult(changedMarkup),
                 });


### PR DESCRIPTION
they sent the problem that the onClose method does not work in the plugin in markup mode, it turned out that it was not used in the plugin for markup mode.