### PR TITLE
fix(CodeBlock): resolved async import loading for CodeBlockHighlight

### DIFF
--- a/src/extensions/markdown/CodeBlock/CodeBlockHighlight/CodeBlockHighlight.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlockHighlight/CodeBlockHighlight.ts
@@ -66,8 +66,8 @@ export const CodeBlockHighlight: ExtensionAuto<CodeBlockHighlightOptions> = (bui
             key,
             state: {
                 init: (_, state) => {
-                    loadModules().then((success) => {
-                        modulesLoaded = success;
+                    loadModules().then(() => {
+                        modulesLoaded = true;
 
                         for (const lang of Object.keys(langs)) {
                             const defs = langs[lang](hljs);
@@ -85,7 +85,9 @@ export const CodeBlockHighlight: ExtensionAuto<CodeBlockHighlightOptions> = (bui
                     return getDecorations(state.doc);
                 },
                 apply: (tr, decos, oldState, newState) => {
-                    if (!modulesLoaded) return DecorationSet.empty;
+                    if (!modulesLoaded) {
+                        return DecorationSet.empty;
+                    }
 
                     if (tr.docChanged) {
                         const oldNodeName = oldState.selection.$head.parent.type.name;

--- a/src/extensions/markdown/CodeBlock/CodeBlockHighlight/CodeBlockHighlight.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlockHighlight/CodeBlockHighlight.ts
@@ -37,42 +37,56 @@ export const CodeBlockHighlight: ExtensionAuto<CodeBlockHighlightOptions> = (bui
     let lowlight: Lowlight;
     let hljs: typeof HLJS;
 
-    try {
-        hljs = require('highlight.js/lib/core');
-        const low = require('lowlight');
-        const all: HighlightLangMap = low.all;
-        const create: typeof createLowlight = low.createLowlight;
-        langs = {...all, ...opts.langs};
-        lowlight = create(langs);
-    } catch (e) {
-        globalLogger.info('Skip code_block highlighting');
-        builder.logger.log('Skip code_block highlighting');
-        return;
-    }
+    const loadModules = async () => {
+        try {
+            hljs = (await import('highlight.js/lib/core')).default;
+            const low = await import('lowlight');
+
+            const all: HighlightLangMap = low.all;
+            const create: typeof createLowlight = low.createLowlight;
+            langs = {...all, ...opts.langs};
+            lowlight = create(langs);
+            return true;
+        } catch (e) {
+            globalLogger.info('Skip code_block highlighting');
+            builder.logger.log('Skip code_block highlighting');
+            return false;
+        }
+    };
 
     builder.addPlugin(() => {
+        let modulesLoaded = false;
+
         const selectItems: LangSelectItem[] = [];
         const mapping: Record<string, string> = {};
-        for (const lang of Object.keys(langs)) {
-            const defs = langs[lang](hljs);
-            selectItems.push({
-                value: lang,
-                content: defs.name || capitalize(lang),
-            });
-            if (defs.aliases) {
-                for (const alias of defs.aliases) {
-                    mapping[alias] = lang;
-                }
-            }
-        }
 
         // TODO: add TAB key handler
         // TODO: Remove constant selection of block
         return new Plugin<DecorationSet>({
             key,
             state: {
-                init: (_, state) => getDecorations(state.doc),
+                init: (_, state) => {
+                    loadModules().then((success) => {
+                        modulesLoaded = success;
+
+                        for (const lang of Object.keys(langs)) {
+                            const defs = langs[lang](hljs);
+                            selectItems.push({
+                                value: lang,
+                                content: defs.name || capitalize(lang),
+                            });
+                            if (defs.aliases) {
+                                for (const alias of defs.aliases) {
+                                    mapping[alias] = lang;
+                                }
+                            }
+                        }
+                    });
+                    return getDecorations(state.doc);
+                },
                 apply: (tr, decos, oldState, newState) => {
+                    if (!modulesLoaded) return DecorationSet.empty;
+
                     if (tr.docChanged) {
                         const oldNodeName = oldState.selection.$head.parent.type.name;
                         const newNodeName = newState.selection.$head.parent.type.name;
@@ -167,6 +181,10 @@ export const CodeBlockHighlight: ExtensionAuto<CodeBlockHighlightOptions> = (bui
 
     function getDecorations(doc: Node) {
         const decos: Decoration[] = [];
+
+        if (!lowlight) {
+            return DecorationSet.empty;
+        }
 
         for (const {node, pos} of findChildrenByType(doc, codeBlockType(doc.type.schema), true)) {
             let from = pos + 1;


### PR DESCRIPTION
Upgrading to v15 broke `require` in `CodeBlockHighlight` for `highlight.js` and `lowlight` (ESM) with `ReferenceError: require is not defined`. This PR switches to `async import` for proper loading of optional deps while keeping ProseMirror sync API compatibility.