### PR TITLE
fix: get actual range when selecting item in suggests (command menu, emoji suggest)

### DIFF
--- a/src/extensions/behavior/Autocomplete/index.ts
+++ b/src/extensions/behavior/Autocomplete/index.ts
@@ -1,4 +1,4 @@
-import autocomplete from 'prosemirror-autocomplete';
+import {autocomplete} from 'prosemirror-autocomplete';
 import {Plugin} from 'prosemirror-state';
 
 import type {ExtensionAuto, ExtensionDeps} from '../../../core';
@@ -8,6 +8,7 @@ import {MainHandler} from './handler';
 import type {AutocompleteItem, AutocompleteTrigger} from './types';
 
 export {openAutocomplete, closeAutocomplete} from 'prosemirror-autocomplete';
+export {getAutocompleteState} from './utils';
 export const AutocompleteDecoClassName = 'autocomplete';
 
 export type AutocompleteItemFn = (deps: ExtensionDeps) => AutocompleteItem;

--- a/src/extensions/behavior/Autocomplete/types.ts
+++ b/src/extensions/behavior/Autocomplete/types.ts
@@ -3,6 +3,7 @@ import type {Options, Trigger} from 'prosemirror-autocomplete';
 export type {
     FromTo,
     AutocompleteAction,
+    AutocompleteState,
     Trigger as AutocompleteTrigger,
 } from 'prosemirror-autocomplete';
 

--- a/src/extensions/behavior/Autocomplete/utils.ts
+++ b/src/extensions/behavior/Autocomplete/utils.ts
@@ -1,0 +1,9 @@
+import {pluginKey} from 'prosemirror-autocomplete';
+
+import type {EditorState} from '#pm/state';
+
+import type {AutocompleteState} from './types';
+
+export function getAutocompleteState(state: EditorState): AutocompleteState | null {
+    return pluginKey.getState(state) || null;
+}

--- a/src/extensions/behavior/CommandMenu/handler.ts
+++ b/src/extensions/behavior/CommandMenu/handler.ts
@@ -9,8 +9,8 @@ import {
     type AutocompleteAction,
     AutocompleteActionKind,
     type AutocompleteHandler,
-    type FromTo,
     closeAutocomplete,
+    getAutocompleteState,
 } from '../Autocomplete';
 import {type RendererItem, getReactRendererFromState} from '../ReactRenderer';
 
@@ -40,7 +40,6 @@ export class CommandHandler implements AutocompleteHandler {
 
     #view?: EditorView;
     #anchor: Element | null = null;
-    #range?: FromTo;
     #filterText?: string;
     #popupCloser?: AutocompletePopupCloser;
 
@@ -155,13 +154,16 @@ export class CommandHandler implements AutocompleteHandler {
     }
 
     private select() {
-        if (!this.#view || !this.#range) return;
+        if (!this.#view) return;
 
         const action = this.#filteredActionsCarousel?.currentItem;
         if (!action) return;
 
+        const autocompleteState = getAutocompleteState(this.#view.state);
+        if (!autocompleteState || !autocompleteState.active) return;
+
         const view = this.#view;
-        const range = this.#range;
+        const {range} = autocompleteState;
 
         view.dispatch(view.state.tr.deleteRange(range.from, range.to).scrollIntoView());
         action.exec(this.#actionStorage);
@@ -223,14 +225,12 @@ export class CommandHandler implements AutocompleteHandler {
         this.#view?.focus();
     };
 
-    private updateState({view, range}: AutocompleteAction) {
+    private updateState({view}: AutocompleteAction) {
         this.#view = view;
-        this.#range = range;
     }
 
     private clear() {
         this.#view = undefined;
-        this.#range = undefined;
         this.#anchor = null;
         this.#filterText = undefined;
         this.#filteredActionsCarousel = undefined;

--- a/src/extensions/behavior/index.ts
+++ b/src/extensions/behavior/index.ts
@@ -13,6 +13,7 @@ import {Selection} from './Selection';
 import {SelectionContext, type SelectionContextOptions} from './SelectionContext';
 import {WidgetDecoration} from './WidgetDecoration';
 
+export * from './Autocomplete';
 export * from './ClicksOnEdges';
 export * from './Clipboard';
 export * from './CommandMenu';


### PR DESCRIPTION
In collaborative editing, when the first user opens suggest and the second user edits the document to the point where suggest opened, the suggest handler contains an outdated range of the start and end points of the suggestion

This PR fixes this: suggest handlers now always get the actual range from the autocomplete state when an element is selected