### PR TITLE
fix: resolved log func via named import to avoid default mismatch

### DIFF
--- a/src/extensions/markdown/Superscript/SuperscriptSpecs/index.ts
+++ b/src/extensions/markdown/Superscript/SuperscriptSpecs/index.ts
@@ -1,4 +1,4 @@
-import log from '@diplodoc/transform/lib/log.js';
+import {log} from '@diplodoc/transform/lib/log.js';
 import sup from '@diplodoc/transform/lib/plugins/sup.js';
 
 import type {ExtensionAuto} from '../../../../core';

--- a/src/extensions/yfm/ImgSize/ImgSizeSpecs/index.ts
+++ b/src/extensions/yfm/ImgSize/ImgSizeSpecs/index.ts
@@ -1,4 +1,4 @@
-import log from '@diplodoc/transform/lib/log.js';
+import {log} from '@diplodoc/transform/lib/log.js';
 import imsize from '@diplodoc/transform/lib/plugins/imsize/index.js';
 import isNumber from 'is-number';
 import type {NodeSpec} from 'prosemirror-model';

--- a/src/extensions/yfm/Monospace/MonospaceSpecs/index.ts
+++ b/src/extensions/yfm/Monospace/MonospaceSpecs/index.ts
@@ -1,4 +1,4 @@
-import log from '@diplodoc/transform/lib/log.js';
+import {log} from '@diplodoc/transform/lib/log.js';
 import yfmPlugin from '@diplodoc/transform/lib/plugins/monospace.js';
 
 import type {ExtensionAuto} from '../../../../core';

--- a/src/extensions/yfm/Video/VideoSpecs/index.ts
+++ b/src/extensions/yfm/Video/VideoSpecs/index.ts
@@ -1,4 +1,4 @@
-import log from '@diplodoc/transform/lib/log.js';
+import {log} from '@diplodoc/transform/lib/log.js';
 
 import type {ExtensionAuto} from '../../../../core';
 

--- a/src/extensions/yfm/YfmNote/YfmNoteSpecs/index.ts
+++ b/src/extensions/yfm/YfmNote/YfmNoteSpecs/index.ts
@@ -1,4 +1,4 @@
-import log from '@diplodoc/transform/lib/log.js';
+import {log} from '@diplodoc/transform/lib/log.js';
 import yfmPlugin from '@diplodoc/transform/lib/plugins/notes/index.js';
 import type {NodeSpec} from 'prosemirror-model';
 

--- a/src/extensions/yfm/YfmTable/YfmTableSpecs/index.ts
+++ b/src/extensions/yfm/YfmTable/YfmTableSpecs/index.ts
@@ -1,4 +1,4 @@
-import log from '@diplodoc/transform/lib/log.js';
+import {log} from '@diplodoc/transform/lib/log.js';
 import yfmTable from '@diplodoc/transform/lib/plugins/table/index.js';
 
 import type {ExtensionWithOptions} from '../../../../core';


### PR DESCRIPTION
Used named import instead of default to fix log func issues in ESM environments.

like in https://github.com/gravity-ui/markdown-editor/pull/668