### PR TITLE
fix(Lists): fixed toolbar button activation for sink list item

### DIFF
--- a/src/extensions/markdown/Lists/commands.ts
+++ b/src/extensions/markdown/Lists/commands.ts
@@ -115,6 +115,6 @@ export function sinkOnlySelectedListItem(itemType: NodeType): Command {
             dispatch(tr.scrollIntoView());
             return true;
         }
-        return false;
+        return true;
     };
 }


### PR DESCRIPTION
Previously, the `sinkOnlySelectedListItem` command returned false without dispatch, causing toolbar buttons like `sinkListItem` to be incorrectly disabled even when the action could be applied. Changed the return value to true, ensuring that toolbar buttons correctly reflect the availability of the sink action based on the document state.
