### PR TITLE
feat(core, color): added support for custom escape characters

### DIFF
--- a/src/core/ExtensionsManager.ts
+++ b/src/core/ExtensionsManager.ts
@@ -129,7 +129,7 @@ export class ExtensionsManager {
         this.#spec.marks().forEach(this.processMark);
     }
 
-    private processNode = (name: string, {spec, fromMd, toMd: toMd, view}: ExtensionNodeSpec) => {
+    private processNode = (name: string, {spec, fromMd, toMd, view}: ExtensionNodeSpec) => {
         this.#schemaRegistry.addNode(name, spec);
 
         this.#parserRegistry.addToken(fromMd.tokenName || name, fromMd.tokenSpec);

--- a/src/extensions/yfm/Color/ColorSpecs/index.ts
+++ b/src/extensions/yfm/Color/ColorSpecs/index.ts
@@ -87,10 +87,14 @@ export const ColorSpecs: ExtensionAuto<ColorSpecsOptions> = (builder, opts) => {
                 },
             },
             toMd: {
-                open: (_state, mark) => {
+                open: (state, mark) => {
+                    state.escapeCharacters = ['(', ')'];
                     return `{${mark.attrs[colorMarkName]}}(`;
                 },
-                close: ')',
+                close: (state) => {
+                    state.escapeCharacters = undefined;
+                    return `)`;
+                },
                 mixable: true,
                 expelEnclosingWhitespace: true,
             },


### PR DESCRIPTION
The `esc()` method now checks `state.escapeCharacters`, if defined, and includes its characters in the escape regex.  
This allows context-specific escaping — for example, in the `color` mark, to escape parentheses in user input without interfering with the markup syntax.