### PR TITLE
fix(Lists): unify indent and outdent for staircase selections

### DIFF
--- a/packages/editor/src/extensions/markdown/Lists/README.md
+++ b/packages/editor/src/extensions/markdown/Lists/README.md
@@ -1,0 +1,34 @@
+# Lists Selection Planner
+
+This extension handles multi-item list indent and outdent through a shared block planner.
+The planner does not move every selected row independently. Instead, it:
+
+1. Collects the selected `list_item` nodes touched by the current selection.
+2. Expands nested tails when the selected structure implies additional descendant items.
+3. Groups the expanded items into contiguous sibling blocks per list level.
+4. Executes those blocks in a direction-specific order for `sink` and `lift`.
+
+## Covered Cases
+
+1. A single selected list item.
+2. A flat sibling group on one list level.
+3. A downward staircase selection into deeper nested items.
+4. An upward staircase selection from nested items back to outer siblings.
+5. A mixed multi-level selection that requires planner expansion and regrouping.
+6. A multi-block command that stays in one transaction and preserves selection on undo.
+
+## Algorithm
+
+```mermaid
+flowchart TD
+    A[Selection] --> B[Collect selected list items]
+    B --> C[Expand nested tails when descendants are implied]
+    C --> D[Group contiguous siblings per list level]
+    D --> E[Sort blocks for sink or lift]
+    E --> F[Resolve block range through transaction mapping]
+    F --> G{Direction}
+    G -- sink --> H[Compute effective sink end]
+    H --> I[Lift trailing nested items outside the move]
+    I --> J[Sink the planned block]
+    G -- lift --> K[Lift the planned block]
+```

--- a/packages/editor/src/extensions/markdown/Lists/actions.ts
+++ b/packages/editor/src/extensions/markdown/Lists/actions.ts
@@ -1,8 +1,6 @@
-import {liftListItem} from 'prosemirror-schema-list';
-
 import type {ActionSpec, ExtensionDeps} from '../../../core';
 
-import {sinkOnlySelectedListItem, toList} from './commands';
+import {liftSelectedListItems, sinkSelectedListItems, toList} from './commands';
 import {ListNode} from './const';
 import {blType, isIntoListOfType, liType, olType} from './utils';
 
@@ -27,15 +25,15 @@ export const actions = {
 
     liftListItem: ({schema}: ExtensionDeps): ActionSpec => {
         return {
-            isEnable: liftListItem(liType(schema)),
-            run: liftListItem(liType(schema)),
+            isEnable: liftSelectedListItems(liType(schema)),
+            run: liftSelectedListItems(liType(schema)),
         };
     },
 
     sinkListItem: ({schema}: ExtensionDeps): ActionSpec => {
         return {
-            isEnable: sinkOnlySelectedListItem(liType(schema)),
-            run: sinkOnlySelectedListItem(liType(schema)),
+            isEnable: sinkSelectedListItems(liType(schema)),
+            run: sinkSelectedListItems(liType(schema)),
         };
     },
 };

--- a/packages/editor/src/extensions/markdown/Lists/commands.test.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.test.ts
@@ -14,16 +14,31 @@ import {
     sinkOnlySelectedListItem,
 } from 'src/extensions/markdown/Lists/commands';
 
+type TaggedNode = Node & {
+    tag: {
+        a: number | null | undefined;
+        b: number | null | undefined;
+    };
+};
+
 function selFor(docNode: Node) {
-    const a = (docNode as any).tag.a,
-        b = (docNode as any).tag.b;
-    if (a !== null) {
-        const $a = docNode.resolve(a);
-        if ($a.parent.inlineContent)
-            return new TextSelection($a, b !== null ? docNode.resolve(b) : undefined);
-        else return new NodeSelection($a);
+    const taggedNode = docNode as TaggedNode;
+    const {a, b} = taggedNode.tag;
+
+    if (a === null || a === undefined) {
+        return Selection.atStart(docNode);
     }
-    return Selection.atStart(docNode);
+
+    const $a = docNode.resolve(a);
+
+    if ($a.parent.inlineContent) {
+        return new TextSelection(
+            $a,
+            b !== null && b !== undefined ? docNode.resolve(b) : undefined,
+        );
+    }
+
+    return new NodeSelection($a);
 }
 
 function apply(docNode: Node, command: Command, result: Node | null) {
@@ -31,8 +46,11 @@ function apply(docNode: Node, command: Command, result: Node | null) {
     // eslint-disable-next-line no-return-assign
     command(state, (tr) => (state = state.apply(tr)));
     ist(state.doc, result || docNode, eq);
-    // eslint-disable-next-line no-eq-null
-    if (result && (result as any).tag.a != null) ist(state.selection, selFor(result), eq);
+
+    const taggedResult = result as TaggedNode | null;
+    if (taggedResult && taggedResult.tag.a !== null && taggedResult.tag.a !== undefined) {
+        ist(state.selection, selFor(taggedResult), eq);
+    }
 }
 
 describe('sinkOnlySelectedListItem', () => {

--- a/packages/editor/src/extensions/markdown/Lists/commands.test.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.test.ts
@@ -10,6 +10,7 @@ import {
     TextSelection,
 } from 'prosemirror-state';
 import {doc, eq, li, p, schema, ul} from 'prosemirror-test-builder';
+
 import {
     getSelectedListBlocks,
     liftSelectedListItems,
@@ -64,7 +65,11 @@ function apply(docNode: Node, command: Command, result: Node | null) {
 
     ist(state.doc, result || docNode, eq);
 
-    if (result && (result as TaggedNode).tag.a !== null) {
+    if (
+        result &&
+        (result as TaggedNode).tag.a !== null &&
+        (result as TaggedNode).tag.a !== undefined
+    ) {
         ist(state.selection, selFor(result), eq);
     }
 }

--- a/packages/editor/src/extensions/markdown/Lists/commands.test.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.test.ts
@@ -1,60 +1,182 @@
 import ist from 'ist';
+import {history, undo} from 'prosemirror-history';
 import type {Node} from 'prosemirror-model';
 import {
     type Command,
     EditorState,
     NodeSelection,
+    type Plugin,
     Selection,
     TextSelection,
 } from 'prosemirror-state';
 import {doc, eq, li, p, schema, ul} from 'prosemirror-test-builder';
-
 import {
+    getSelectedListBlocks,
     liftSelectedListItems,
-    sinkOnlySelectedListItem,
+    sinkSelectedListItems,
 } from 'src/extensions/markdown/Lists/commands';
 
 type TaggedNode = Node & {
     tag: {
-        a: number | null | undefined;
-        b: number | null | undefined;
+        a: number | null;
+        b: number | null;
     };
 };
 
 function selFor(docNode: Node) {
     const taggedNode = docNode as TaggedNode;
-    const {a, b} = taggedNode.tag;
+    const a = taggedNode.tag.a;
+    const b = taggedNode.tag.b;
 
-    if (a === null || a === undefined) {
+    if (a === null) {
         return Selection.atStart(docNode);
     }
 
     const $a = docNode.resolve(a);
 
     if ($a.parent.inlineContent) {
-        return new TextSelection(
-            $a,
-            b !== null && b !== undefined ? docNode.resolve(b) : undefined,
-        );
+        const $b = b === null ? undefined : docNode.resolve(b);
+
+        return new TextSelection($a, $b);
     }
 
     return new NodeSelection($a);
 }
 
+function createState(docNode: Node, plugins: Plugin[] = []) {
+    return EditorState.create({doc: docNode, selection: selFor(docNode), plugins});
+}
+
+function runCommand(docNode: Node, command: Command, plugins: Plugin[] = []) {
+    let state = createState(docNode, plugins);
+    let dispatchCount = 0;
+
+    const handled = command(state, (tr) => {
+        dispatchCount += 1;
+        state = state.apply(tr);
+    });
+
+    return {dispatchCount, handled, state};
+}
+
 function apply(docNode: Node, command: Command, result: Node | null) {
-    let state = EditorState.create({doc: docNode, selection: selFor(docNode)});
-    // eslint-disable-next-line no-return-assign
-    command(state, (tr) => (state = state.apply(tr)));
+    const {state} = runCommand(docNode, command);
+
     ist(state.doc, result || docNode, eq);
 
-    const taggedResult = result as TaggedNode | null;
-    if (taggedResult && taggedResult.tag.a !== null && taggedResult.tag.a !== undefined) {
-        ist(state.selection, selFor(taggedResult), eq);
+    if (result && (result as TaggedNode).tag.a !== null) {
+        ist(state.selection, selFor(result), eq);
     }
 }
 
-describe('sinkOnlySelectedListItem', () => {
-    const sink = sinkOnlySelectedListItem(schema.nodes.list_item);
+function getBlockTexts(docNode: Node) {
+    const state = createState(docNode);
+
+    return getSelectedListBlocks(state.selection, schema.nodes.list_item).map((block) => {
+        const range = docNode
+            .resolve(block.from)
+            .blockRange(
+                docNode.resolve(block.to),
+                (node) =>
+                    node.childCount > 0 &&
+                    node.firstChild !== null &&
+                    node.firstChild.type === schema.nodes.list_item,
+            );
+
+        if (!range) {
+            throw new Error('Expected a list block range');
+        }
+
+        const texts: string[] = [];
+
+        for (let index = range.startIndex; index < range.endIndex; index++) {
+            const item = range.parent.child(index);
+            texts.push(item.firstChild?.textContent ?? item.textContent);
+        }
+
+        return texts;
+    });
+}
+
+describe('getSelectedListBlocks', () => {
+    it('collects a simple selected list item', () => {
+        expect(getBlockTexts(doc(ul(li(p('11')), li(p('2<a><b>2')), li(p('33')))))).toEqual([
+            ['22'],
+        ]);
+    });
+
+    it('collects downward staircase selections as separate list-level blocks', () => {
+        expect(
+            getBlockTexts(
+                doc(
+                    ul(
+                        li(p('aa')),
+                        li(
+                            p('b<a>b'),
+                            ul(
+                                li(p('c<b>c')),
+                                li(p('dd'), ul(li(p('ee')), li(p('ss')))),
+                                li(p('zz')),
+                                li(p('ww')),
+                            ),
+                        ),
+                        li(p('pp')),
+                        li(p('hh')),
+                    ),
+                ),
+            ),
+        ).toEqual([['bb'], ['cc']]);
+    });
+
+    it('collects reverse staircase selections from inner to outer items', () => {
+        expect(
+            getBlockTexts(
+                doc(
+                    ul(
+                        li(p('aa')),
+                        li(
+                            p('bb'),
+                            ul(
+                                li(p('cc')),
+                                li(p('dd'), ul(li(p('ee')), li(p('s<a>s')))),
+                                li(p('z<b>z')),
+                                li(p('ww')),
+                            ),
+                        ),
+                        li(p('pp')),
+                        li(p('hh')),
+                    ),
+                ),
+            ),
+        ).toEqual([['ss'], ['zz']]);
+    });
+
+    it('groups mixed multi-level selections into contiguous sibling runs', () => {
+        expect(
+            getBlockTexts(
+                doc(
+                    ul(
+                        li(p('aa')),
+                        li(
+                            p('b<a>b'),
+                            ul(
+                                li(p('cc')),
+                                li(p('dd'), ul(li(p('e<b>e')), li(p('ss')))),
+                                li(p('zz')),
+                                li(p('ww')),
+                            ),
+                        ),
+                        li(p('pp')),
+                        li(p('hh')),
+                    ),
+                ),
+            ),
+        ).toEqual([['bb'], ['cc', 'dd'], ['ee', 'ss']]);
+    });
+});
+
+describe('sinkSelectedListItems', () => {
+    const sink = sinkSelectedListItems(schema.nodes.list_item);
 
     it('can wrap a simple item in a list', () =>
         apply(
@@ -181,7 +303,7 @@ describe('sinkOnlySelectedListItem', () => {
             ),
         ));
 
-    it('sinks nested list items with an upward staircase selection', () =>
+    it('sinks reverse staircase selections from the innermost item outward', () =>
         apply(
             doc(
                 ul(
@@ -206,7 +328,8 @@ describe('sinkOnlySelectedListItem', () => {
                     li(
                         p('bb'),
                         ul(
-                            li(p('cc'), ul(li(p('dd'), ul(li(p('ee')), li(p('ss')))), li(p('zz')))),
+                            li(p('cc')),
+                            li(p('dd'), ul(li(p('ee'), ul(li(p('ss')))), li(p('zz')))),
                             li(p('ww')),
                         ),
                     ),
@@ -269,7 +392,7 @@ describe('liftSelectedListItems', () => {
             doc(ul(li(p('one')), li(p('two')))),
         ));
 
-    it('lifts reverse staircase selections with standard list-item semantics', () =>
+    it('keeps the original selection when lifting reverse staircase blocks', () =>
         apply(
             doc(
                 ul(
@@ -291,11 +414,45 @@ describe('liftSelectedListItems', () => {
             doc(
                 ul(
                     li(p('aa')),
-                    li(p('bb'), ul(li(p('cc')), li(p('dd'), ul(li(p('ee')))), li(p('ss')))),
-                    li(p('zz'), ul(li(p('ww')))),
+                    li(p('bb'), ul(li(p('cc')), li(p('dd'), ul(li(p('ee')))), li(p('s<a>s')))),
+                    li(p('z<b>z'), ul(li(p('ww')))),
                     li(p('pp')),
                     li(p('hh')),
                 ),
             ),
         ));
+
+    it('undoes a multi-block lift in a single history step', () => {
+        const docNode = doc(
+            ul(
+                li(p('aa')),
+                li(
+                    p('bb'),
+                    ul(
+                        li(p('cc')),
+                        li(p('dd'), ul(li(p('ee')), li(p('s<a>s')))),
+                        li(p('z<b>z')),
+                        li(p('ww')),
+                    ),
+                ),
+                li(p('pp')),
+                li(p('hh')),
+            ),
+        );
+
+        let state = createState(docNode, [history()]);
+
+        lift(state, (tr) => {
+            state = state.apply(tr);
+        });
+
+        expect(
+            undo(state, (tr) => {
+                state = state.apply(tr);
+            }),
+        ).toBe(true);
+
+        ist(state.doc, docNode, eq);
+        ist(state.selection, selFor(docNode), eq);
+    });
 });

--- a/packages/editor/src/extensions/markdown/Lists/commands.test.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.test.ts
@@ -255,6 +255,13 @@ describe('sinkOnlySelectedListItem', () => {
 describe('liftSelectedListItems', () => {
     const lift = liftSelectedListItems(schema.nodes.list_item);
 
+    it('lifts a top-level list item into a paragraph', () =>
+        apply(
+            doc(ul(li(p('first')), li(p('s<a><b>econd'))), p('text')),
+            lift,
+            doc(ul(li(p('first'))), p('second'), p('text')),
+        ));
+
     it('lifts a nested list item out by one level', () =>
         apply(
             doc(ul(li(p('one'), ul(li(p('t<a><b>wo')))))),

--- a/packages/editor/src/extensions/markdown/Lists/commands.test.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.test.ts
@@ -12,8 +12,8 @@ import {
 import {doc, eq, li, p, schema, ul} from 'prosemirror-test-builder';
 
 import {
-    getSelectedListBlocks,
     liftSelectedListItems,
+    planSelectedListBlocks,
     sinkSelectedListItems,
 } from 'src/extensions/markdown/Lists/commands';
 
@@ -74,10 +74,10 @@ function apply(docNode: Node, command: Command, result: Node | null) {
     }
 }
 
-function getBlockTexts(docNode: Node) {
+function getPlannedBlockTexts(docNode: Node) {
     const state = createState(docNode);
 
-    return getSelectedListBlocks(state.selection, schema.nodes.list_item).map((block) => {
+    return planSelectedListBlocks(state.selection, schema.nodes.list_item).blocks.map((block) => {
         const range = docNode
             .resolve(block.from)
             .blockRange(
@@ -103,16 +103,22 @@ function getBlockTexts(docNode: Node) {
     });
 }
 
-describe('getSelectedListBlocks', () => {
-    it('collects a simple selected list item', () => {
-        expect(getBlockTexts(doc(ul(li(p('11')), li(p('2<a><b>2')), li(p('33')))))).toEqual([
+describe('planSelectedListBlocks', () => {
+    it('plans a single selected item as one block', () => {
+        expect(getPlannedBlockTexts(doc(ul(li(p('11')), li(p('2<a><b>2')), li(p('33')))))).toEqual([
             ['22'],
         ]);
     });
 
-    it('collects downward staircase selections as separate list-level blocks', () => {
+    it('plans a flat sibling group as one contiguous block', () => {
         expect(
-            getBlockTexts(
+            getPlannedBlockTexts(doc(ul(li(p('aa')), li(p('b<a>b')), li(p('c<b>c')), li(p('dd'))))),
+        ).toEqual([['bb', 'cc']]);
+    });
+
+    it('plans downward staircase selections as separate list-level blocks', () => {
+        expect(
+            getPlannedBlockTexts(
                 doc(
                     ul(
                         li(p('aa')),
@@ -133,9 +139,9 @@ describe('getSelectedListBlocks', () => {
         ).toEqual([['bb'], ['cc']]);
     });
 
-    it('collects reverse staircase selections from inner to outer items', () => {
+    it('plans upward staircase selections from inner items back to outer siblings', () => {
         expect(
-            getBlockTexts(
+            getPlannedBlockTexts(
                 doc(
                     ul(
                         li(p('aa')),
@@ -156,9 +162,9 @@ describe('getSelectedListBlocks', () => {
         ).toEqual([['ss'], ['zz']]);
     });
 
-    it('groups mixed multi-level selections into contiguous sibling runs', () => {
+    it('plans mixed multi-level selections by expanding nested tails into sibling runs', () => {
         expect(
-            getBlockTexts(
+            getPlannedBlockTexts(
                 doc(
                     ul(
                         li(p('aa')),
@@ -427,7 +433,7 @@ describe('liftSelectedListItems', () => {
             ),
         ));
 
-    it('undoes a multi-block lift in a single history step', () => {
+    it('keeps a multi-block lift in one history step with stable selection on undo', () => {
         const docNode = doc(
             ul(
                 li(p('aa')),

--- a/packages/editor/src/extensions/markdown/Lists/commands.test.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.test.ts
@@ -9,25 +9,28 @@ import {
 } from 'prosemirror-state';
 import {doc, eq, li, p, schema, ul} from 'prosemirror-test-builder';
 
-import {sinkOnlySelectedListItem} from 'src/extensions/markdown/Lists/commands';
+import {
+    liftSelectedListItems,
+    sinkOnlySelectedListItem,
+} from 'src/extensions/markdown/Lists/commands';
 
-function selFor(doc: Node) {
-    const a = (doc as any).tag.a,
-        b = (doc as any).tag.b;
+function selFor(docNode: Node) {
+    const a = (docNode as any).tag.a,
+        b = (docNode as any).tag.b;
     if (a !== null) {
-        const $a = doc.resolve(a);
+        const $a = docNode.resolve(a);
         if ($a.parent.inlineContent)
-            return new TextSelection($a, b !== null ? doc.resolve(b) : undefined);
+            return new TextSelection($a, b !== null ? docNode.resolve(b) : undefined);
         else return new NodeSelection($a);
     }
-    return Selection.atStart(doc);
+    return Selection.atStart(docNode);
 }
 
-function apply(doc: Node, command: Command, result: Node | null) {
-    let state = EditorState.create({doc, selection: selFor(doc)});
+function apply(docNode: Node, command: Command, result: Node | null) {
+    let state = EditorState.create({doc: docNode, selection: selFor(docNode)});
     // eslint-disable-next-line no-return-assign
     command(state, (tr) => (state = state.apply(tr)));
-    ist(state.doc, result || doc, eq);
+    ist(state.doc, result || docNode, eq);
     // eslint-disable-next-line no-eq-null
     if (result && (result as any).tag.a != null) ist(state.selection, selFor(result), eq);
 }
@@ -160,8 +163,6 @@ describe('sinkOnlySelectedListItem', () => {
             ),
         ));
 
-    // expected result should be the same as
-    // sinks nested list items into a deeper hierarchy when selection spans multiple items
     it('sinks nested list items with an upward staircase selection', () =>
         apply(
             doc(
@@ -226,6 +227,47 @@ describe('sinkOnlySelectedListItem', () => {
                             li(p('ww')),
                         ),
                     ),
+                    li(p('pp')),
+                    li(p('hh')),
+                ),
+            ),
+        ));
+});
+
+describe('liftSelectedListItems', () => {
+    const lift = liftSelectedListItems(schema.nodes.list_item);
+
+    it('lifts a nested list item out by one level', () =>
+        apply(
+            doc(ul(li(p('one'), ul(li(p('t<a><b>wo')))))),
+            lift,
+            doc(ul(li(p('one')), li(p('two')))),
+        ));
+
+    it('lifts reverse staircase selections with standard list-item semantics', () =>
+        apply(
+            doc(
+                ul(
+                    li(p('aa')),
+                    li(
+                        p('bb'),
+                        ul(
+                            li(p('cc')),
+                            li(p('dd'), ul(li(p('ee')), li(p('s<a>s')))),
+                            li(p('z<b>z')),
+                            li(p('ww')),
+                        ),
+                    ),
+                    li(p('pp')),
+                    li(p('hh')),
+                ),
+            ),
+            lift,
+            doc(
+                ul(
+                    li(p('aa')),
+                    li(p('bb'), ul(li(p('cc')), li(p('dd'), ul(li(p('ee')))), li(p('ss')))),
+                    li(p('zz'), ul(li(p('ww')))),
                     li(p('pp')),
                     li(p('hh')),
                 ),

--- a/packages/editor/src/extensions/markdown/Lists/commands.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.ts
@@ -304,6 +304,12 @@ function getLiftTransaction(state: EditorState, itemType: NodeType): Transaction
 
 export function liftSelectedListItems(itemType: NodeType): Command {
     return (state, dispatch) => {
+        const selectedItems = collectSelectedListItems(state.selection, itemType);
+
+        if (selectedItems.length <= 1) {
+            return pmLiftListItem(itemType)(state, dispatch);
+        }
+
         const blocks = getSelectedListBlocks(state.selection, itemType);
 
         if (blocks.length === 0) {

--- a/packages/editor/src/extensions/markdown/Lists/commands.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.ts
@@ -60,7 +60,7 @@ export type ListBlock = {
     to: number;
 };
 
-const isListBlockParent = (node: Node, itemType: NodeType) =>
+const isListNodeForItemType = (node: Node, itemType: NodeType) =>
     node.childCount > 0 && node.firstChild !== null && node.firstChild.type === itemType;
 
 function findClosestListItem(
@@ -122,25 +122,152 @@ function collectSelectedListItems(selection: Selection, itemType: NodeType): Sel
     return Array.from(items.values()).sort((left, right) => left.pos - right.pos);
 }
 
+function createSelectedListItem(
+    doc: Node,
+    itemPos: number,
+    itemType: NodeType,
+): SelectedListItem | null {
+    const itemNode = doc.nodeAt(itemPos);
+
+    if (!itemNode || itemNode.type !== itemType) {
+        return null;
+    }
+
+    const $pos = doc.resolve(itemPos + 1);
+
+    for (let depth = $pos.depth; depth > 0; depth--) {
+        if ($pos.node(depth).type !== itemType || $pos.before(depth) !== itemPos) {
+            continue;
+        }
+
+        return {
+            depth,
+            from: itemPos + 1,
+            index: $pos.index(depth - 1),
+            parentListPos: $pos.before(depth - 1),
+            pos: itemPos,
+            to: itemPos + itemNode.nodeSize - 1,
+        };
+    }
+
+    return null;
+}
+
+function findNestedList(item: SelectedListItem, doc: Node, itemType: NodeType) {
+    const itemNode = doc.nodeAt(item.pos);
+
+    if (!itemNode) {
+        return null;
+    }
+
+    let childPos = item.pos + 1;
+
+    for (let index = 0; index < itemNode.childCount; index++) {
+        const child = itemNode.child(index);
+
+        if (isListNodeForItemType(child, itemType)) {
+            return {listNode: child, listPos: childPos};
+        }
+
+        childPos += child.nodeSize;
+    }
+
+    return null;
+}
+
+function expandSelectedListItems(
+    selection: Selection,
+    itemType: NodeType,
+    selectedItems: SelectedListItem[],
+): SelectedListItem[] {
+    const {doc} = selection.$from;
+    const itemsByPos = new Map(selectedItems.map((item) => [item.pos, item]));
+    let changed = true;
+
+    while (changed) {
+        changed = false;
+
+        const currentItems = Array.from(itemsByPos.values()).sort(
+            (left, right) => left.pos - right.pos,
+        );
+        const groupedItems = new Map<number, SelectedListItem[]>();
+
+        for (const item of currentItems) {
+            const siblingGroup = groupedItems.get(item.parentListPos) ?? [];
+            siblingGroup.push(item);
+            groupedItems.set(item.parentListPos, siblingGroup);
+        }
+
+        for (const siblings of groupedItems.values()) {
+            siblings.sort((left, right) => left.index - right.index);
+
+            for (let siblingIndex = 1; siblingIndex < siblings.length; siblingIndex++) {
+                const sibling = siblings[siblingIndex];
+                const nestedList = findNestedList(sibling, doc, itemType);
+
+                if (!nestedList) {
+                    continue;
+                }
+
+                const selectedChildren = currentItems
+                    .filter((item) => item.parentListPos === nestedList.listPos)
+                    .sort((left, right) => left.index - right.index);
+
+                if (selectedChildren.length === 0) {
+                    continue;
+                }
+
+                let childPos = nestedList.listPos + 1;
+
+                for (
+                    let childIndex = 0;
+                    childIndex < nestedList.listNode.childCount;
+                    childIndex++
+                ) {
+                    const childNode = nestedList.listNode.child(childIndex);
+
+                    if (childIndex >= selectedChildren[0].index && !itemsByPos.has(childPos)) {
+                        const childItem = createSelectedListItem(doc, childPos, itemType);
+
+                        if (childItem) {
+                            itemsByPos.set(childPos, childItem);
+                            changed = true;
+                        }
+                    }
+
+                    childPos += childNode.nodeSize;
+                }
+            }
+        }
+    }
+
+    return Array.from(itemsByPos.values()).sort((left, right) => left.pos - right.pos);
+}
+
 export function getSelectedListBlocks(selection: Selection, itemType: NodeType): ListBlock[] {
     const groupedItems = new Map<number, SelectedListItem[]>();
+    const items = expandSelectedListItems(
+        selection,
+        itemType,
+        collectSelectedListItems(selection, itemType),
+    );
 
-    for (const item of collectSelectedListItems(selection, itemType)) {
-        const items = groupedItems.get(item.parentListPos) ?? [];
-        items.push(item);
-        groupedItems.set(item.parentListPos, items);
+    for (const item of items) {
+        const siblingGroup = groupedItems.get(item.parentListPos) ?? [];
+        siblingGroup.push(item);
+        groupedItems.set(item.parentListPos, siblingGroup);
     }
 
     const blocks: ListBlock[] = [];
 
-    for (const items of groupedItems.values()) {
-        items.sort((left, right) => left.index - right.index);
+    for (const siblingGroup of groupedItems.values()) {
+        siblingGroup.sort((left, right) => left.index - right.index);
 
-        let blockStart = items[0];
-        let previous = items[0];
+        let blockStart = siblingGroup[0];
+        let previous = siblingGroup[0];
 
-        for (let index = 1; index < items.length; index++) {
-            const current = items[index];
+        for (let index = 1; index < siblingGroup.length; index++) {
+            const current = siblingGroup[index];
 
             if (current.index !== previous.index + 1) {
                 blocks.push({
@@ -173,29 +300,128 @@ function resolveListBlockRange(
 ): NodeRange | null {
     const mappedFrom = tr.mapping.map(block.from, 1);
     const mappedTo = tr.mapping.map(block.to, -1);
+    const mappedParentListPos = tr.mapping.map(block.parentListPos, 1);
+    const mappedToInside = Math.max(mappedTo - 1, mappedFrom);
 
     if (mappedFrom >= mappedTo) {
         return null;
     }
 
-    const $from = tr.doc.resolve(mappedFrom);
-    const $to = tr.doc.resolve(mappedTo);
+    const $parentList = tr.doc.resolve(mappedParentListPos);
+    const parentList = $parentList.nodeAfter;
 
-    return $from.blockRange($to, (node) => isListBlockParent(node, itemType));
+    if (!parentList || !isListNodeForItemType(parentList, itemType)) {
+        return null;
+    }
+
+    let childPos = mappedParentListPos + 1;
+    let rangeFromPos: number | null = null;
+    let rangeToPos: number | null = null;
+
+    for (let index = 0; index < parentList.childCount; index++) {
+        const child = parentList.child(index);
+        const childEnd = childPos + child.nodeSize;
+
+        if (rangeFromPos === null && mappedFrom >= childPos && mappedFrom < childEnd) {
+            rangeFromPos = childPos;
+        }
+
+        if (mappedToInside >= childPos && mappedToInside < childEnd) {
+            rangeToPos = childEnd - 1;
+            break;
+        }
+
+        childPos = childEnd;
+    }
+
+    if (rangeFromPos === null || rangeToPos === null) {
+        return null;
+    }
+
+    return new NodeRange(
+        tr.doc.resolve(rangeFromPos + 1),
+        tr.doc.resolve(rangeToPos),
+        block.depth - 1,
+    );
 }
 
 function canSinkListBlock(range: NodeRange, itemType: NodeType) {
     return range.startIndex > 0 && range.parent.child(range.startIndex - 1).type === itemType;
 }
 
-function sinkListBlock(tr: Transaction, range: NodeRange, itemType: NodeType) {
+function liftTrailingNestedItems(tr: Transaction, range: NodeRange, effectiveEnd: number) {
+    const start = tr.mapping.map(range.start, 1);
+    let currentEnd = tr.mapping.map(range.end, -1) - 1;
+
+    while (currentEnd > start) {
+        const $candidateBlockEnd = tr.doc.resolve(currentEnd);
+        const candidateBlockStartPos = $candidateBlockEnd.before($candidateBlockEnd.depth);
+        const $candidateBlockStart = tr.doc.resolve(candidateBlockStartPos);
+        const candidateBlockRange = $candidateBlockStart.blockRange($candidateBlockEnd);
+
+        if (candidateBlockRange?.start) {
+            const $rangeStart = tr.doc.resolve(candidateBlockRange.start);
+            const shouldLift =
+                candidateBlockRange.start > effectiveEnd && isListNode($rangeStart.parent);
+
+            if (shouldLift) {
+                currentEnd = candidateBlockRange.start;
+
+                const targetDepth = liftTarget(candidateBlockRange);
+
+                if (targetDepth !== null) {
+                    tr.lift(candidateBlockRange, targetDepth);
+                }
+            }
+        }
+
+        currentEnd--;
+    }
+}
+
+function getEffectiveSinkEnd(
+    tr: Transaction,
+    block: ListBlock,
+    blocks: ListBlock[],
+    selectionEnd: number,
+) {
+    let effectiveEnd = tr.mapping.map(Math.min(selectionEnd, block.to), -1);
+
+    for (const nestedBlock of blocks) {
+        if (
+            nestedBlock.depth > block.depth &&
+            nestedBlock.from >= block.from &&
+            nestedBlock.to <= block.to
+        ) {
+            effectiveEnd = Math.max(effectiveEnd, tr.mapping.map(nestedBlock.to, -1));
+        }
+    }
+
+    return effectiveEnd;
+}
+
+function sinkListBlock(
+    tr: Transaction,
+    block: ListBlock,
+    range: NodeRange,
+    itemType: NodeType,
+    effectiveEnd: number,
+) {
     if (!canSinkListBlock(range, itemType)) {
         return false;
     }
 
-    const before = range.start;
-    const after = range.end;
-    const {parent, startIndex} = range;
+    liftTrailingNestedItems(tr, range, effectiveEnd);
+
+    const mappedRange = resolveListBlockRange(tr, block, itemType);
+
+    if (!mappedRange || !canSinkListBlock(mappedRange, itemType)) {
+        return false;
+    }
+
+    const before = mappedRange.start;
+    const after = mappedRange.end;
+    const {parent, startIndex} = mappedRange;
     const nodeBefore = parent.child(startIndex - 1);
     const nestedBefore = nodeBefore.lastChild && nodeBefore.lastChild.type === parent.type;
     const inner = Fragment.from(nestedBefore ? itemType.create() : null);
@@ -335,6 +561,10 @@ function liftListBlock(tr: Transaction, range: NodeRange, itemType: NodeType) {
 
 function sortListBlocks(blocks: ListBlock[], direction: MoveDirection) {
     return [...blocks].sort((left, right) => {
+        if (direction === 'right' && left.from !== right.from) {
+            return right.from - left.from;
+        }
+
         if (left.depth !== right.depth) {
             return direction === 'right' ? right.depth - left.depth : left.depth - right.depth;
         }
@@ -370,7 +600,13 @@ function moveSelectedListBlocks(itemType: NodeType, direction: MoveDirection): C
 
             moved =
                 (direction === 'right'
-                    ? sinkListBlock(tr, range, itemType)
+                    ? sinkListBlock(
+                          tr,
+                          block,
+                          range,
+                          itemType,
+                          getEffectiveSinkEnd(tr, block, blocks, selection.to),
+                      )
                     : liftListBlock(tr, range, itemType)) || moved;
         }
 

--- a/packages/editor/src/extensions/markdown/Lists/commands.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.ts
@@ -1,8 +1,14 @@
 import {liftEmptyBlock} from 'prosemirror-commands';
-import {Fragment, type NodeRange, type NodeType, Slice} from 'prosemirror-model';
-import {wrapInList} from 'prosemirror-schema-list';
-import type {Command, Transaction} from 'prosemirror-state';
-import {ReplaceAroundStep, liftTarget} from 'prosemirror-transform';
+import {Fragment, type Node, type NodeRange, type NodeType, Slice} from 'prosemirror-model';
+import {liftListItem as pmLiftListItem, wrapInList} from 'prosemirror-schema-list';
+import {
+    type Command,
+    type EditorState,
+    type Selection,
+    TextSelection,
+    type Transaction,
+} from 'prosemirror-state';
+import {Mapping, ReplaceAroundStep, liftTarget} from 'prosemirror-transform';
 
 import {joinPreviousBlock} from '../../../commands/join';
 import {get$CursorAtBlockStart} from '../../../utils/selection';
@@ -81,7 +87,10 @@ export function sinkOnlySelectedListItem(itemType: NodeType): Command {
         const {$from, $to} = selection;
         const selectionRange = $from.blockRange(
             $to,
-            (node) => node.childCount > 0 && node.firstChild!.type === itemType,
+            (node) =>
+                node.childCount > 0 &&
+                node.firstChild !== null &&
+                node.firstChild.type === itemType,
         );
         if (!selectionRange) {
             return false;
@@ -98,7 +107,7 @@ export function sinkOnlySelectedListItem(itemType: NodeType): Command {
         }
 
         if (dispatch) {
-            // lifts following list items sequentially to prepare correct nesting structure
+            // Lifts following list items sequentially to prepare the correct nesting structure.
             let currentEnd = end - 1;
             while (currentEnd > start) {
                 const selectionEnd = tr.mapping.map($to.pos);
@@ -126,7 +135,6 @@ export function sinkOnlySelectedListItem(itemType: NodeType): Command {
                 currentEnd--;
             }
 
-            // sinks the selected list item deeper into the list hierarchy
             sink(tr, selectionRange, itemType);
 
             dispatch(tr.scrollIntoView());
@@ -134,4 +142,220 @@ export function sinkOnlySelectedListItem(itemType: NodeType): Command {
         }
         return true;
     };
+}
+
+type SelectedListItem = {
+    depth: number;
+    from: number;
+    index: number;
+    parentListPos: number;
+    pos: number;
+    to: number;
+};
+
+type ListBlock = {
+    depth: number;
+    from: number;
+    parentListPos: number;
+    to: number;
+};
+
+function isListBlockParent(node: Node, itemType: NodeType) {
+    return node.childCount > 0 && node.firstChild !== null && node.firstChild.type === itemType;
+}
+
+function findClosestListItem(selection: Selection, pos: number, itemType: NodeType) {
+    const $pos = selection.$from.doc.resolve(pos);
+
+    for (let depth = $pos.depth; depth > 0; depth--) {
+        if ($pos.node(depth).type !== itemType) {
+            continue;
+        }
+
+        const itemPos = $pos.before(depth);
+        const itemNode = $pos.node(depth);
+
+        return {
+            depth,
+            from: itemPos + 1,
+            index: $pos.index(depth - 1),
+            parentListPos: $pos.before(depth - 1),
+            pos: itemPos,
+            to: itemPos + itemNode.nodeSize - 1,
+        };
+    }
+
+    return null;
+}
+
+function collectSelectedListItems(selection: Selection, itemType: NodeType): SelectedListItem[] {
+    const items = new Map<number, SelectedListItem>();
+    const {from, to} = selection;
+    const {doc} = selection.$from;
+
+    const addItemAt = (pos: number) => {
+        const item = findClosestListItem(selection, pos, itemType);
+
+        if (item) {
+            items.set(item.pos, item);
+        }
+    };
+
+    addItemAt(from);
+    addItemAt(to);
+
+    if (!selection.empty) {
+        doc.nodesBetween(from, to, (node: Node, pos: number) => {
+            if (node.isText || node.isLeaf) {
+                const samplePos = Math.max(pos + 1, from);
+
+                if (samplePos <= to) {
+                    addItemAt(samplePos);
+                }
+            }
+        });
+    }
+
+    return Array.from(items.values()).sort((left, right) => left.pos - right.pos);
+}
+
+function getSelectedListBlocks(selection: Selection, itemType: NodeType): ListBlock[] {
+    const groupedItems = new Map<number, SelectedListItem[]>();
+
+    for (const item of collectSelectedListItems(selection, itemType)) {
+        const items = groupedItems.get(item.parentListPos) ?? [];
+        items.push(item);
+        groupedItems.set(item.parentListPos, items);
+    }
+
+    const blocks: ListBlock[] = [];
+
+    for (const items of groupedItems.values()) {
+        items.sort((left, right) => left.index - right.index);
+
+        let blockStart = items[0];
+        let previous = items[0];
+
+        for (let index = 1; index < items.length; index++) {
+            const current = items[index];
+
+            if (current.index !== previous.index + 1) {
+                blocks.push({
+                    depth: blockStart.depth,
+                    from: blockStart.from,
+                    parentListPos: blockStart.parentListPos,
+                    to: previous.to,
+                });
+                blockStart = current;
+            }
+
+            previous = current;
+        }
+
+        blocks.push({
+            depth: blockStart.depth,
+            from: blockStart.from,
+            parentListPos: blockStart.parentListPos,
+            to: previous.to,
+        });
+    }
+
+    return blocks.sort((left, right) => {
+        if (left.depth !== right.depth) {
+            return right.depth - left.depth;
+        }
+
+        return right.from - left.from;
+    });
+}
+
+function resolveListBlockRange(
+    doc: Node,
+    mapping: Mapping,
+    block: ListBlock,
+    itemType: NodeType,
+): NodeRange | null {
+    const mappedFrom = mapping.map(block.from, 1);
+    const mappedTo = mapping.map(block.to, -1);
+
+    if (mappedFrom >= mappedTo) {
+        return null;
+    }
+
+    const $from = doc.resolve(mappedFrom);
+    const $to = doc.resolve(mappedTo);
+
+    return $from.blockRange($to, (node) => isListBlockParent(node, itemType));
+}
+
+function getLiftSelectionFromRange(doc: Node, range: NodeRange) {
+    return TextSelection.between(doc.resolve(range.start), doc.resolve(range.end - 1));
+}
+
+function getLiftTransaction(state: EditorState, itemType: NodeType): Transaction | null {
+    let liftedTr: Transaction | null = null;
+
+    pmLiftListItem(itemType)(state, (tr) => {
+        liftedTr = tr;
+    });
+
+    return liftedTr;
+}
+
+export function liftSelectedListItems(itemType: NodeType): Command {
+    return (state, dispatch) => {
+        const blocks = getSelectedListBlocks(state.selection, itemType);
+
+        if (blocks.length === 0) {
+            return false;
+        }
+
+        if (!dispatch) {
+            return blocks.some((block) => {
+                const range = resolveListBlockRange(state.doc, new Mapping(), block, itemType);
+
+                if (!range) {
+                    return false;
+                }
+
+                const tempState = state.apply(
+                    state.tr.setSelection(getLiftSelectionFromRange(state.doc, range)),
+                );
+                return pmLiftListItem(itemType)(tempState);
+            });
+        }
+
+        let nextState = state;
+        const mapping = new Mapping();
+        let moved = false;
+
+        for (const block of blocks) {
+            const range = resolveListBlockRange(nextState.doc, mapping, block, itemType);
+
+            if (!range) {
+                continue;
+            }
+
+            const tempState = nextState.apply(
+                nextState.tr.setSelection(getLiftSelectionFromRange(nextState.doc, range)),
+            );
+
+            const liftedTr = getLiftTransaction(tempState, itemType);
+
+            if (!liftedTr) {
+                continue;
+            }
+
+            mapping.appendMapping(liftedTr.mapping);
+            nextState = nextState.apply(liftedTr);
+            moved = true;
+            dispatch(liftedTr.scrollIntoView());
+        }
+
+        return moved;
+    };
+}
+
+export function sinkSelectedListItems(itemType: NodeType): Command {
+    return sinkOnlySelectedListItem(itemType);
 }

--- a/packages/editor/src/extensions/markdown/Lists/commands.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.ts
@@ -1,14 +1,8 @@
 import {liftEmptyBlock} from 'prosemirror-commands';
-import {Fragment, type Node, type NodeRange, type NodeType, Slice} from 'prosemirror-model';
-import {liftListItem as pmLiftListItem, wrapInList} from 'prosemirror-schema-list';
-import {
-    type Command,
-    type EditorState,
-    type Selection,
-    TextSelection,
-    type Transaction,
-} from 'prosemirror-state';
-import {Mapping, ReplaceAroundStep, liftTarget} from 'prosemirror-transform';
+import {Fragment, type Node, NodeRange, type NodeType, Slice} from 'prosemirror-model';
+import {wrapInList} from 'prosemirror-schema-list';
+import type {Command, Selection, Transaction} from 'prosemirror-state';
+import {ReplaceAroundStep, canJoin, liftTarget} from 'prosemirror-transform';
 
 import {joinPreviousBlock} from '../../../commands/join';
 import {get$CursorAtBlockStart} from '../../../utils/selection';
@@ -48,101 +42,7 @@ export function liftEmptyListItem(itemType: NodeType): Command {
     };
 }
 
-/*
-    Simplified `sinkListItem` from `prosemirror-schema-list` without `state`/`dispatch`,
-    sinks list items deeper.
- */
-const sink = (tr: Transaction, range: NodeRange, itemType: NodeType) => {
-    const before = tr.mapping.map(range.start);
-    const after = tr.mapping.map(range.end);
-    const startIndex = tr.mapping.map(range.startIndex);
-
-    const parent = range.parent;
-    const nodeBefore = parent.child(startIndex - 1);
-
-    const nestedBefore = nodeBefore.lastChild && nodeBefore.lastChild.type === parent.type;
-    const inner = Fragment.from(nestedBefore ? itemType.create() : null);
-    const slice = new Slice(
-        Fragment.from(itemType.create(null, Fragment.from(parent.type.create(null, inner)))),
-        nestedBefore ? 3 : 1,
-        0,
-    );
-
-    tr.step(
-        new ReplaceAroundStep(
-            before - (nestedBefore ? 3 : 1),
-            after,
-            before,
-            after,
-            slice,
-            1,
-            true,
-        ),
-    );
-    return true;
-};
-
-export function sinkOnlySelectedListItem(itemType: NodeType): Command {
-    return ({tr, selection}, dispatch) => {
-        const {$from, $to} = selection;
-        const selectionRange = $from.blockRange(
-            $to,
-            (node) =>
-                node.childCount > 0 &&
-                node.firstChild !== null &&
-                node.firstChild.type === itemType,
-        );
-        if (!selectionRange) {
-            return false;
-        }
-
-        const {startIndex, parent, start, end} = selectionRange;
-        if (startIndex === 0) {
-            return false;
-        }
-
-        const nodeBefore = parent.child(startIndex - 1);
-        if (nodeBefore.type !== itemType) {
-            return false;
-        }
-
-        if (dispatch) {
-            // Lifts following list items sequentially to prepare the correct nesting structure.
-            let currentEnd = end - 1;
-            while (currentEnd > start) {
-                const selectionEnd = tr.mapping.map($to.pos);
-
-                const $candidateBlockEnd = tr.doc.resolve(currentEnd);
-                const candidateBlockStartPos = $candidateBlockEnd.before($candidateBlockEnd.depth);
-                const $candidateBlockStart = tr.doc.resolve(candidateBlockStartPos);
-                const candidateBlockRange = $candidateBlockStart.blockRange($candidateBlockEnd);
-
-                if (candidateBlockRange?.start) {
-                    const $rangeStart = tr.doc.resolve(candidateBlockRange.start);
-                    const shouldLift =
-                        candidateBlockRange.start > selectionEnd && isListNode($rangeStart.parent);
-
-                    if (shouldLift) {
-                        currentEnd = candidateBlockRange.start;
-
-                        const targetDepth = liftTarget(candidateBlockRange);
-                        if (targetDepth !== null) {
-                            tr.lift(candidateBlockRange, targetDepth);
-                        }
-                    }
-                }
-
-                currentEnd--;
-            }
-
-            sink(tr, selectionRange, itemType);
-
-            dispatch(tr.scrollIntoView());
-            return true;
-        }
-        return true;
-    };
-}
+type MoveDirection = 'left' | 'right';
 
 type SelectedListItem = {
     depth: number;
@@ -153,18 +53,21 @@ type SelectedListItem = {
     to: number;
 };
 
-type ListBlock = {
+export type ListBlock = {
     depth: number;
     from: number;
     parentListPos: number;
     to: number;
 };
 
-function isListBlockParent(node: Node, itemType: NodeType) {
-    return node.childCount > 0 && node.firstChild !== null && node.firstChild.type === itemType;
-}
+const isListBlockParent = (node: Node, itemType: NodeType) =>
+    node.childCount > 0 && node.firstChild !== null && node.firstChild.type === itemType;
 
-function findClosestListItem(selection: Selection, pos: number, itemType: NodeType) {
+function findClosestListItem(
+    selection: Selection,
+    pos: number,
+    itemType: NodeType,
+): SelectedListItem | null {
     const $pos = selection.$from.doc.resolve(pos);
 
     for (let depth = $pos.depth; depth > 0; depth--) {
@@ -219,7 +122,7 @@ function collectSelectedListItems(selection: Selection, itemType: NodeType): Sel
     return Array.from(items.values()).sort((left, right) => left.pos - right.pos);
 }
 
-function getSelectedListBlocks(selection: Selection, itemType: NodeType): ListBlock[] {
+export function getSelectedListBlocks(selection: Selection, itemType: NodeType): ListBlock[] {
     const groupedItems = new Map<number, SelectedListItem[]>();
 
     for (const item of collectSelectedListItems(selection, itemType)) {
@@ -260,57 +163,189 @@ function getSelectedListBlocks(selection: Selection, itemType: NodeType): ListBl
         });
     }
 
-    return blocks.sort((left, right) => {
+    return blocks.sort((left, right) => left.from - right.from);
+}
+
+function resolveListBlockRange(
+    tr: Transaction,
+    block: ListBlock,
+    itemType: NodeType,
+): NodeRange | null {
+    const mappedFrom = tr.mapping.map(block.from, 1);
+    const mappedTo = tr.mapping.map(block.to, -1);
+
+    if (mappedFrom >= mappedTo) {
+        return null;
+    }
+
+    const $from = tr.doc.resolve(mappedFrom);
+    const $to = tr.doc.resolve(mappedTo);
+
+    return $from.blockRange($to, (node) => isListBlockParent(node, itemType));
+}
+
+function canSinkListBlock(range: NodeRange, itemType: NodeType) {
+    return range.startIndex > 0 && range.parent.child(range.startIndex - 1).type === itemType;
+}
+
+function sinkListBlock(tr: Transaction, range: NodeRange, itemType: NodeType) {
+    if (!canSinkListBlock(range, itemType)) {
+        return false;
+    }
+
+    const before = range.start;
+    const after = range.end;
+    const {parent, startIndex} = range;
+    const nodeBefore = parent.child(startIndex - 1);
+    const nestedBefore = nodeBefore.lastChild && nodeBefore.lastChild.type === parent.type;
+    const inner = Fragment.from(nestedBefore ? itemType.create() : null);
+    const slice = new Slice(
+        Fragment.from(itemType.create(null, Fragment.from(parent.type.create(null, inner)))),
+        nestedBefore ? 3 : 1,
+        0,
+    );
+
+    tr.step(
+        new ReplaceAroundStep(
+            before - (nestedBefore ? 3 : 1),
+            after,
+            before,
+            after,
+            slice,
+            1,
+            true,
+        ),
+    );
+
+    return true;
+}
+
+function liftToOuterList(tr: Transaction, itemType: NodeType, range: NodeRange) {
+    let currentRange = range;
+    const end = range.end;
+    const endOfList = currentRange.$to.end(currentRange.depth);
+
+    if (end < endOfList) {
+        tr.step(
+            new ReplaceAroundStep(
+                end - 1,
+                endOfList,
+                end,
+                endOfList,
+                new Slice(Fragment.from(itemType.create(null, currentRange.parent.copy())), 1, 0),
+                1,
+                true,
+            ),
+        );
+
+        currentRange = new NodeRange(
+            tr.doc.resolve(currentRange.$from.pos),
+            tr.doc.resolve(endOfList),
+            currentRange.depth,
+        );
+    }
+
+    const target = liftTarget(currentRange);
+
+    if (target === null) {
+        return false;
+    }
+
+    tr.lift(currentRange, target);
+
+    const $after = tr.doc.resolve(tr.mapping.map(end, -1) - 1);
+    const {nodeBefore, nodeAfter} = $after;
+
+    if (
+        nodeBefore &&
+        nodeAfter &&
+        canJoin(tr.doc, $after.pos) &&
+        nodeBefore.type === nodeAfter.type
+    ) {
+        tr.join($after.pos);
+    }
+
+    return true;
+}
+
+function liftOutOfList(tr: Transaction, range: NodeRange) {
+    const list = range.parent;
+
+    for (let pos = range.end, index = range.endIndex - 1; index > range.startIndex; index--) {
+        pos -= list.child(index).nodeSize;
+        tr.delete(pos - 1, pos + 1);
+    }
+
+    const $start = tr.doc.resolve(range.start);
+    const item = $start.nodeAfter;
+
+    if (!item) {
+        return false;
+    }
+
+    if (tr.mapping.map(range.end) !== range.start + item.nodeSize) {
+        return false;
+    }
+
+    const atStart = range.startIndex === 0;
+    const atEnd = range.endIndex === list.childCount;
+    const parent = $start.node(-1);
+    const indexBefore = $start.index(-1);
+
+    if (
+        !parent.canReplace(
+            indexBefore + (atStart ? 0 : 1),
+            indexBefore + 1,
+            item.content.append(atEnd ? Fragment.empty : Fragment.from(list)),
+        )
+    ) {
+        return false;
+    }
+
+    const start = $start.pos;
+    const end = start + item.nodeSize;
+
+    tr.step(
+        new ReplaceAroundStep(
+            start - (atStart ? 1 : 0),
+            end + (atEnd ? 1 : 0),
+            start + 1,
+            end - 1,
+            new Slice(
+                (atStart ? Fragment.empty : Fragment.from(list.copy(Fragment.empty))).append(
+                    atEnd ? Fragment.empty : Fragment.from(list.copy(Fragment.empty)),
+                ),
+                atStart ? 0 : 1,
+                atEnd ? 0 : 1,
+            ),
+            atStart ? 0 : 1,
+        ),
+    );
+
+    return true;
+}
+
+function liftListBlock(tr: Transaction, range: NodeRange, itemType: NodeType) {
+    if (range.$from.node(range.depth - 1).type === itemType) {
+        return liftToOuterList(tr, itemType, range);
+    }
+
+    return liftOutOfList(tr, range);
+}
+
+function sortListBlocks(blocks: ListBlock[], direction: MoveDirection) {
+    return [...blocks].sort((left, right) => {
         if (left.depth !== right.depth) {
-            return right.depth - left.depth;
+            return direction === 'right' ? right.depth - left.depth : left.depth - right.depth;
         }
 
         return right.from - left.from;
     });
 }
 
-function resolveListBlockRange(
-    doc: Node,
-    mapping: Mapping,
-    block: ListBlock,
-    itemType: NodeType,
-): NodeRange | null {
-    const mappedFrom = mapping.map(block.from, 1);
-    const mappedTo = mapping.map(block.to, -1);
-
-    if (mappedFrom >= mappedTo) {
-        return null;
-    }
-
-    const $from = doc.resolve(mappedFrom);
-    const $to = doc.resolve(mappedTo);
-
-    return $from.blockRange($to, (node) => isListBlockParent(node, itemType));
-}
-
-function getLiftSelectionFromRange(doc: Node, range: NodeRange) {
-    return TextSelection.between(doc.resolve(range.start), doc.resolve(range.end - 1));
-}
-
-function getLiftTransaction(state: EditorState, itemType: NodeType): Transaction | null {
-    let liftedTr: Transaction | null = null;
-
-    pmLiftListItem(itemType)(state, (tr) => {
-        liftedTr = tr;
-    });
-
-    return liftedTr;
-}
-
-export function liftSelectedListItems(itemType: NodeType): Command {
-    return (state, dispatch) => {
-        const selectedItems = collectSelectedListItems(state.selection, itemType);
-
-        if (selectedItems.length <= 1) {
-            return pmLiftListItem(itemType)(state, dispatch);
-        }
-
-        const blocks = getSelectedListBlocks(state.selection, itemType);
+function moveSelectedListBlocks(itemType: NodeType, direction: MoveDirection): Command {
+    return ({selection, tr}, dispatch) => {
+        const blocks = sortListBlocks(getSelectedListBlocks(selection, itemType), direction);
 
         if (blocks.length === 0) {
             return false;
@@ -318,50 +353,42 @@ export function liftSelectedListItems(itemType: NodeType): Command {
 
         if (!dispatch) {
             return blocks.some((block) => {
-                const range = resolveListBlockRange(state.doc, new Mapping(), block, itemType);
+                const range = resolveListBlockRange(tr, block, itemType);
 
-                if (!range) {
-                    return false;
-                }
-
-                const tempState = state.apply(
-                    state.tr.setSelection(getLiftSelectionFromRange(state.doc, range)),
-                );
-                return pmLiftListItem(itemType)(tempState);
+                return range && (direction === 'left' || canSinkListBlock(range, itemType));
             });
         }
 
-        let nextState = state;
-        const mapping = new Mapping();
         let moved = false;
 
         for (const block of blocks) {
-            const range = resolveListBlockRange(nextState.doc, mapping, block, itemType);
+            const range = resolveListBlockRange(tr, block, itemType);
 
             if (!range) {
                 continue;
             }
 
-            const tempState = nextState.apply(
-                nextState.tr.setSelection(getLiftSelectionFromRange(nextState.doc, range)),
-            );
-
-            const liftedTr = getLiftTransaction(tempState, itemType);
-
-            if (!liftedTr) {
-                continue;
-            }
-
-            mapping.appendMapping(liftedTr.mapping);
-            nextState = nextState.apply(liftedTr);
-            moved = true;
-            dispatch(liftedTr.scrollIntoView());
+            moved =
+                (direction === 'right'
+                    ? sinkListBlock(tr, range, itemType)
+                    : liftListBlock(tr, range, itemType)) || moved;
         }
 
-        return moved;
+        if (!moved) {
+            return false;
+        }
+
+        dispatch(tr.scrollIntoView());
+        return true;
     };
 }
 
 export function sinkSelectedListItems(itemType: NodeType): Command {
-    return sinkOnlySelectedListItem(itemType);
+    return moveSelectedListBlocks(itemType, 'right');
 }
+
+export function liftSelectedListItems(itemType: NodeType): Command {
+    return moveSelectedListBlocks(itemType, 'left');
+}
+
+export const sinkOnlySelectedListItem = sinkSelectedListItems;

--- a/packages/editor/src/extensions/markdown/Lists/commands.ts
+++ b/packages/editor/src/extensions/markdown/Lists/commands.ts
@@ -44,7 +44,7 @@ export function liftEmptyListItem(itemType: NodeType): Command {
 
 type MoveDirection = 'left' | 'right';
 
-type SelectedListItem = {
+export type ListSelectionItem = {
     depth: number;
     from: number;
     index: number;
@@ -60,15 +60,22 @@ export type ListBlock = {
     to: number;
 };
 
+export type ListSelectionPlan = {
+    blocks: ListBlock[];
+    expandedItems: ListSelectionItem[];
+    explicitItems: ListSelectionItem[];
+};
+
+type PlannedListBlockMove = {
+    block: ListBlock;
+    direction: MoveDirection;
+};
+
 const isListNodeForItemType = (node: Node, itemType: NodeType) =>
     node.childCount > 0 && node.firstChild !== null && node.firstChild.type === itemType;
 
-function findClosestListItem(
-    selection: Selection,
-    pos: number,
-    itemType: NodeType,
-): SelectedListItem | null {
-    const $pos = selection.$from.doc.resolve(pos);
+function findClosestListItem(doc: Node, pos: number, itemType: NodeType): ListSelectionItem | null {
+    const $pos = doc.resolve(pos);
 
     for (let depth = $pos.depth; depth > 0; depth--) {
         if ($pos.node(depth).type !== itemType) {
@@ -91,13 +98,13 @@ function findClosestListItem(
     return null;
 }
 
-function collectSelectedListItems(selection: Selection, itemType: NodeType): SelectedListItem[] {
-    const items = new Map<number, SelectedListItem>();
+function collectSelectedListItems(selection: Selection, itemType: NodeType): ListSelectionItem[] {
+    const items = new Map<number, ListSelectionItem>();
     const {from, to} = selection;
     const {doc} = selection.$from;
 
     const addItemAt = (pos: number) => {
-        const item = findClosestListItem(selection, pos, itemType);
+        const item = findClosestListItem(doc, pos, itemType);
 
         if (item) {
             items.set(item.pos, item);
@@ -122,11 +129,11 @@ function collectSelectedListItems(selection: Selection, itemType: NodeType): Sel
     return Array.from(items.values()).sort((left, right) => left.pos - right.pos);
 }
 
-function createSelectedListItem(
+function createListSelectionItem(
     doc: Node,
     itemPos: number,
     itemType: NodeType,
-): SelectedListItem | null {
+): ListSelectionItem | null {
     const itemNode = doc.nodeAt(itemPos);
 
     if (!itemNode || itemNode.type !== itemType) {
@@ -153,7 +160,7 @@ function createSelectedListItem(
     return null;
 }
 
-function findNestedList(item: SelectedListItem, doc: Node, itemType: NodeType) {
+function findNestedList(item: ListSelectionItem, doc: Node, itemType: NodeType) {
     const itemNode = doc.nodeAt(item.pos);
 
     if (!itemNode) {
@@ -175,13 +182,41 @@ function findNestedList(item: SelectedListItem, doc: Node, itemType: NodeType) {
     return null;
 }
 
+function expandNestedTailSelection(
+    doc: Node,
+    itemType: NodeType,
+    itemsByPos: Map<number, ListSelectionItem>,
+    nestedList: NonNullable<ReturnType<typeof findNestedList>>,
+    selectedChildren: ListSelectionItem[],
+) {
+    let changed = false;
+    let childPos = nestedList.listPos + 1;
+
+    for (let childIndex = 0; childIndex < nestedList.listNode.childCount; childIndex++) {
+        const childNode = nestedList.listNode.child(childIndex);
+
+        if (childIndex >= selectedChildren[0].index && !itemsByPos.has(childPos)) {
+            const childItem = createListSelectionItem(doc, childPos, itemType);
+
+            if (childItem) {
+                itemsByPos.set(childPos, childItem);
+                changed = true;
+            }
+        }
+
+        childPos += childNode.nodeSize;
+    }
+
+    return changed;
+}
+
 function expandSelectedListItems(
     selection: Selection,
     itemType: NodeType,
-    selectedItems: SelectedListItem[],
-): SelectedListItem[] {
+    explicitItems: ListSelectionItem[],
+): ListSelectionItem[] {
     const {doc} = selection.$from;
-    const itemsByPos = new Map(selectedItems.map((item) => [item.pos, item]));
+    const itemsByPos = new Map(explicitItems.map((item) => [item.pos, item]));
     let changed = true;
 
     while (changed) {
@@ -190,15 +225,15 @@ function expandSelectedListItems(
         const currentItems = Array.from(itemsByPos.values()).sort(
             (left, right) => left.pos - right.pos,
         );
-        const groupedItems = new Map<number, SelectedListItem[]>();
+        const itemsByParentList = new Map<number, ListSelectionItem[]>();
 
         for (const item of currentItems) {
-            const siblingGroup = groupedItems.get(item.parentListPos) ?? [];
+            const siblingGroup = itemsByParentList.get(item.parentListPos) ?? [];
             siblingGroup.push(item);
-            groupedItems.set(item.parentListPos, siblingGroup);
+            itemsByParentList.set(item.parentListPos, siblingGroup);
         }
 
-        for (const siblings of groupedItems.values()) {
+        for (const siblings of itemsByParentList.values()) {
             siblings.sort((left, right) => left.index - right.index);
 
             for (let siblingIndex = 1; siblingIndex < siblings.length; siblingIndex++) {
@@ -217,26 +252,14 @@ function expandSelectedListItems(
                     continue;
                 }
 
-                let childPos = nestedList.listPos + 1;
-
-                for (
-                    let childIndex = 0;
-                    childIndex < nestedList.listNode.childCount;
-                    childIndex++
-                ) {
-                    const childNode = nestedList.listNode.child(childIndex);
-
-                    if (childIndex >= selectedChildren[0].index && !itemsByPos.has(childPos)) {
-                        const childItem = createSelectedListItem(doc, childPos, itemType);
-
-                        if (childItem) {
-                            itemsByPos.set(childPos, childItem);
-                            changed = true;
-                        }
-                    }
-
-                    childPos += childNode.nodeSize;
-                }
+                changed =
+                    expandNestedTailSelection(
+                        doc,
+                        itemType,
+                        itemsByPos,
+                        nestedList,
+                        selectedChildren,
+                    ) || changed;
             }
         }
     }
@@ -244,23 +267,18 @@ function expandSelectedListItems(
     return Array.from(itemsByPos.values()).sort((left, right) => left.pos - right.pos);
 }
 
-export function getSelectedListBlocks(selection: Selection, itemType: NodeType): ListBlock[] {
-    const groupedItems = new Map<number, SelectedListItem[]>();
-    const items = expandSelectedListItems(
-        selection,
-        itemType,
-        collectSelectedListItems(selection, itemType),
-    );
+function groupSelectedListItemsIntoBlocks(items: ListSelectionItem[]): ListBlock[] {
+    const itemsByParentList = new Map<number, ListSelectionItem[]>();
 
     for (const item of items) {
-        const siblingGroup = groupedItems.get(item.parentListPos) ?? [];
+        const siblingGroup = itemsByParentList.get(item.parentListPos) ?? [];
         siblingGroup.push(item);
-        groupedItems.set(item.parentListPos, siblingGroup);
+        itemsByParentList.set(item.parentListPos, siblingGroup);
     }
 
     const blocks: ListBlock[] = [];
 
-    for (const siblingGroup of groupedItems.values()) {
+    for (const siblingGroup of itemsByParentList.values()) {
         siblingGroup.sort((left, right) => left.index - right.index);
 
         let blockStart = siblingGroup[0];
@@ -291,6 +309,48 @@ export function getSelectedListBlocks(selection: Selection, itemType: NodeType):
     }
 
     return blocks.sort((left, right) => left.from - right.from);
+}
+
+export function planSelectedListBlocks(
+    selection: Selection,
+    itemType: NodeType,
+): ListSelectionPlan {
+    const explicitItems = collectSelectedListItems(selection, itemType);
+    const expandedItems = expandSelectedListItems(selection, itemType, explicitItems);
+
+    return {
+        blocks: groupSelectedListItemsIntoBlocks(expandedItems),
+        expandedItems,
+        explicitItems,
+    };
+}
+
+export function getSelectedListBlocks(selection: Selection, itemType: NodeType): ListBlock[] {
+    return planSelectedListBlocks(selection, itemType).blocks;
+}
+
+function sortListBlocks(blocks: ListBlock[], direction: MoveDirection) {
+    return [...blocks].sort((left, right) => {
+        if (direction === 'right' && left.from !== right.from) {
+            return right.from - left.from;
+        }
+
+        if (left.depth !== right.depth) {
+            return direction === 'right' ? right.depth - left.depth : left.depth - right.depth;
+        }
+
+        return right.from - left.from;
+    });
+}
+
+function createPlannedListBlockMoves(
+    selection: Selection,
+    itemType: NodeType,
+    direction: MoveDirection,
+): PlannedListBlockMove[] {
+    const {blocks} = planSelectedListBlocks(selection, itemType);
+
+    return sortListBlocks(blocks, direction).map((block) => ({block, direction}));
 }
 
 function resolveListBlockRange(
@@ -382,12 +442,12 @@ function liftTrailingNestedItems(tr: Transaction, range: NodeRange, effectiveEnd
 function getEffectiveSinkEnd(
     tr: Transaction,
     block: ListBlock,
-    blocks: ListBlock[],
+    plannedBlocks: ListBlock[],
     selectionEnd: number,
 ) {
     let effectiveEnd = tr.mapping.map(Math.min(selectionEnd, block.to), -1);
 
-    for (const nestedBlock of blocks) {
+    for (const nestedBlock of plannedBlocks) {
         if (
             nestedBlock.depth > block.depth &&
             nestedBlock.from >= block.from &&
@@ -559,55 +619,57 @@ function liftListBlock(tr: Transaction, range: NodeRange, itemType: NodeType) {
     return liftOutOfList(tr, range);
 }
 
-function sortListBlocks(blocks: ListBlock[], direction: MoveDirection) {
-    return [...blocks].sort((left, right) => {
-        if (direction === 'right' && left.from !== right.from) {
-            return right.from - left.from;
-        }
+function applyPlannedListBlockMove(
+    tr: Transaction,
+    move: PlannedListBlockMove,
+    allMoves: PlannedListBlockMove[],
+    itemType: NodeType,
+    selectionEnd: number,
+) {
+    const range = resolveListBlockRange(tr, move.block, itemType);
 
-        if (left.depth !== right.depth) {
-            return direction === 'right' ? right.depth - left.depth : left.depth - right.depth;
-        }
+    if (!range) {
+        return false;
+    }
 
-        return right.from - left.from;
-    });
+    if (move.direction === 'right') {
+        return sinkListBlock(
+            tr,
+            move.block,
+            range,
+            itemType,
+            getEffectiveSinkEnd(
+                tr,
+                move.block,
+                allMoves.map(({block}) => block),
+                selectionEnd,
+            ),
+        );
+    }
+
+    return liftListBlock(tr, range, itemType);
 }
 
 function moveSelectedListBlocks(itemType: NodeType, direction: MoveDirection): Command {
     return ({selection, tr}, dispatch) => {
-        const blocks = sortListBlocks(getSelectedListBlocks(selection, itemType), direction);
+        const moves = createPlannedListBlockMoves(selection, itemType, direction);
 
-        if (blocks.length === 0) {
+        if (moves.length === 0) {
             return false;
         }
 
         if (!dispatch) {
-            return blocks.some((block) => {
+            return moves.some(({block, direction: moveDirection}) => {
                 const range = resolveListBlockRange(tr, block, itemType);
 
-                return range && (direction === 'left' || canSinkListBlock(range, itemType));
+                return range && (moveDirection === 'left' || canSinkListBlock(range, itemType));
             });
         }
 
         let moved = false;
 
-        for (const block of blocks) {
-            const range = resolveListBlockRange(tr, block, itemType);
-
-            if (!range) {
-                continue;
-            }
-
-            moved =
-                (direction === 'right'
-                    ? sinkListBlock(
-                          tr,
-                          block,
-                          range,
-                          itemType,
-                          getEffectiveSinkEnd(tr, block, blocks, selection.to),
-                      )
-                    : liftListBlock(tr, range, itemType)) || moved;
+        for (const move of moves) {
+            moved = applyPlannedListBlockMove(tr, move, moves, itemType, selection.to) || moved;
         }
 
         if (!moved) {

--- a/packages/editor/src/extensions/markdown/Lists/index.ts
+++ b/packages/editor/src/extensions/markdown/Lists/index.ts
@@ -1,11 +1,17 @@
-import {liftListItem, splitListItem} from 'prosemirror-schema-list';
+import {splitListItem} from 'prosemirror-schema-list';
 
 import type {Action, ExtensionAuto, Keymap} from '../../../core';
 import {withLogAction} from '../../../utils/keymap';
 
 import {ListsSpecs, blType, liType, olType} from './ListsSpecs';
 import {actions} from './actions';
-import {joinPrevList, liftEmptyListItem, sinkOnlySelectedListItem, toList} from './commands';
+import {
+    joinPrevList,
+    liftEmptyListItem,
+    liftSelectedListItems,
+    sinkSelectedListItems,
+    toList,
+} from './commands';
 import {ListAction} from './const';
 import {ListsInputRulesExtension, type ListsInputRulesOptions} from './inputrules';
 import {collapseListsPlugin} from './plugins/CollapseListsPlugin';
@@ -29,12 +35,12 @@ export const Lists: ExtensionAuto<ListsOptions> = (builder, opts) => {
         if (olKey) bindings[olKey] = withLogAction('orderedList', toList(olType(schema)));
 
         return {
-            Tab: sinkOnlySelectedListItem(liType(schema)),
-            'Shift-Tab': liftListItem(liType(schema)),
+            Tab: sinkSelectedListItems(liType(schema)),
+            'Shift-Tab': liftSelectedListItems(liType(schema)),
             Backspace: liftEmptyListItem(liType(schema)),
 
-            'Mod-[': liftListItem(liType(schema)),
-            'Mod-]': sinkOnlySelectedListItem(liType(schema)),
+            'Mod-[': liftSelectedListItems(liType(schema)),
+            'Mod-]': sinkSelectedListItems(liType(schema)),
 
             ...bindings,
         };


### PR DESCRIPTION
This PR reworks list indentation around a shared block planner for complex multi-item list selections.

Instead of treating the whole selection as a single `blockRange`, the new logic plans contiguous sibling blocks per list level and applies the same model to both `Tab` / `Mod-]` and `Shift-Tab` / `Mod-[`.

The planner is now described and tested around six explicit cases:
1. A single selected list item.
2. A flat sibling group on one list level.
3. A downward staircase selection into deeper nested items.
4. An upward staircase selection from nested items back to outer siblings.
5. A mixed multi-level selection that requires planner expansion and regrouping.
6. A multi-block command that stays in one transaction and preserves selection on undo.

Behaviorally, this PR keeps block-based movement semantics:
- the unit of movement is a contiguous sibling block, not an independently moved row;
- the planner may expand the selected structure when nested tails are implied by the current selection;
- indent and outdent share the same planning model and differ only in execution.

The test suite now covers the planner directly, and the `Lists` folder includes a short README with an algorithm diagram for future maintenance.
