### PR TITLE
fix(YfmNote): improved note removal on Backspace

### DIFF
--- a/src/extensions/yfm/YfmNote/commands.test.ts
+++ b/src/extensions/yfm/YfmNote/commands.test.ts
@@ -19,11 +19,19 @@ const schema = new Schema({
     },
 });
 
-const {doc, paragraph: p, yfm_note: note, yfm_note_title: noteTitle} = builders(schema);
+const {
+    doc,
+    paragraph: p,
+    yfm_note: note,
+    yfm_note_title: noteTitle,
+    yfm_note_content: noteContent,
+} = builders(schema);
 
 describe('YfmNote commands', () => {
     it('removeNote: should replace note with its content', () => {
-        const pmDoc = doc(note(noteTitle('note title'), p('note content in paragraph')));
+        const pmDoc = doc(
+            note(noteTitle('note title'), noteContent(p('note content in paragraph'))),
+        );
         const view = new EditorView(null, {
             state: EditorState.create({
                 schema,
@@ -38,12 +46,14 @@ describe('YfmNote commands', () => {
     });
 
     it("backToNoteTitle: should move cursor to the end of note's title", () => {
-        const pmDoc = doc(note(noteTitle('note title'), p('note content in paragraph')));
+        const pmDoc = doc(
+            note(noteTitle('note title'), noteContent(p('note content in paragraph'))),
+        );
         const view = new EditorView(null, {
             state: EditorState.create({
                 schema,
                 doc: pmDoc,
-                selection: TextSelection.create(pmDoc, 14),
+                selection: TextSelection.create(pmDoc, 15),
             }),
         });
         const res = backToNoteTitle(view.state, view.dispatch, view);

--- a/src/extensions/yfm/YfmNote/commands.ts
+++ b/src/extensions/yfm/YfmNote/commands.ts
@@ -82,10 +82,12 @@ export const removeNote: Command = (state, dispatch, view) => {
         if (dispatch) {
             const noteTitleNode = $cursor.parent;
             const noteNode = $cursor.node(-1);
-            const content = noteNode.content.replaceChild(
-                0,
-                pType(schema).create(null, noteTitleNode.content),
+
+            const noteContentNode = noteNode.lastChild!;
+            const content = Fragment.from(pType(schema).create(null, noteTitleNode.content)).append(
+                noteContentNode.content,
             );
+
             const from = $cursor.before(-1);
             const to = from + noteNode.nodeSize;
             const tr = state.tr.replaceWith(from, to, content);
@@ -107,18 +109,22 @@ export const backToNoteTitle: Command = (state, dispatch, view) => {
     if (!$cursor) return false;
     if (
         !isSameNodeType($cursor.parent, pType(schema)) ||
-        !isSameNodeType($cursor.node(-1), noteType(schema))
+        !isSameNodeType($cursor.node(-1), noteContentType(schema)) ||
+        !isSameNodeType($cursor.node(-2), noteType(schema))
     ) {
         return false;
     }
-    const noteNode = $cursor.node(-1);
-    if ($cursor.parent !== noteNode.maybeChild(1)) return false;
+
+    const noteNode = $cursor.node(-2);
+    const noteContentNode = $cursor.node(-1);
+    if ($cursor.parent !== noteContentNode.firstChild) return false;
+
     if (view?.endOfTextblock('backward', state)) {
         if (dispatch) {
             const noteTitleNode = noteNode.firstChild!;
             dispatch(
                 state.tr.setSelection(
-                    TextSelection.create(state.doc, $cursor.before(-1) + noteTitleNode.nodeSize),
+                    TextSelection.create(state.doc, $cursor.before(-2) + noteTitleNode.nodeSize),
                 ),
             );
         }


### PR DESCRIPTION
Due to the appearance of the noteContent container in the yfm_note structure, when deleting via Backspace, an extra wrapper used to remain; now we insert the contents of this container directly instead, without an additional level.

If the note body was empty, Backspace did nothing - now, with empty content, the cursor goes to the end of the heading.