### PR TITLE
fix(GPT extension): fixed opened gpt in safari brouse

### DIFF
--- a/src/extensions/additional/GPT/MarkupGpt/popup.tsx
+++ b/src/extensions/additional/GPT/MarkupGpt/popup.tsx
@@ -21,8 +21,10 @@ export function renderPopup<
             className={cnGptPopup()}
             open
             strategy="absolute"
-            onOpenChange={(open) => {
-                if (!open) props.onClose();
+            onOpenChange={(_open, _event, reason) => {
+                if (reason === 'outside-press' || reason === 'escape-key') {
+                    props.onClose();
+                }
             }}
             anchorElement={anchor}
             placement={gptPopupPlacement}

--- a/src/extensions/additional/GPT/plugin.ts
+++ b/src/extensions/additional/GPT/plugin.ts
@@ -35,6 +35,8 @@ export const gptWidgetPlugin = <
                 const meta = tr.getMeta(key) as GptWidgetMeta | undefined;
                 const paramsGpt = params;
 
+                if (!meta) return decos;
+
                 paramsGpt.disablePromptPresets = false;
 
                 if (meta?.action === 'show') {


### PR DESCRIPTION
Here is the corrected text:

I managed to fix the extension, I realized what the problem was.
There are two points there:

Safari browser losing focus when opening a popup, which caused the close function on the popup to trigger, causing the popup to close.

The problem was still in the plugin in WYSIWYG mode. In Safari browser for some reason after triggering the update function, where there is this.rerender(), gptWidgetPlugin state -> init was also triggered, but this is only in Safari browser. And since the meta data was empty, the selection was set to 0 0 by default, so after the update was triggered again and compared the current selection with the previous one and since they were different, it just closed the popup. I added logic to the plugin where it returns the current state when the meta is empty, and removed the code in update that was responsible for closing the popup. Why close it in update when the plugin component does it. But maybe I could have broken something, I poked around the main cases, everything seems fine, can you look at the cases too?

Translated with DeepL.com (free version)