### PR TITLE
feat: export Math extension

### DIFF
--- a/src/extensions/additional/index.ts
+++ b/src/extensions/additional/index.ts
@@ -1,1 +1,2 @@
 export * from './GPT';
+export * from './Math';


### PR DESCRIPTION
To import Math extension like GPT extension directly from `@gravity-ui/markdown-editor`

`import { Math } from '@gravity-ui/markdown-editor';`