### PR TITLE
fix(bundle): dont pass invalid props to dom in ToolbarColors component

### DIFF
--- a/demo/components/Playground.tsx
+++ b/demo/components/Playground.tsx
@@ -56,6 +56,7 @@ const wCommandMenuConfig = wysiwygToolbarConfigs.wCommandMenuConfig.concat(
 );
 
 export type PlaygroundProps = {
+    mobile?: boolean;
     initial?: MarkupString;
     allowHTML?: boolean;
     settingsVisible?: boolean | SettingItems[];
@@ -107,6 +108,7 @@ logger.setLogger({
 
 export const Playground = memo<PlaygroundProps>((props) => {
     const {
+        mobile,
         initial,
         initialEditor,
         initialSplitModeEnabled,
@@ -174,6 +176,7 @@ export const Playground = memo<PlaygroundProps>((props) => {
     const mdEditor = useMarkdownEditor(
         {
             logger,
+            mobile,
             preset: 'full',
             wysiwygConfig: {
                 placeholderOptions: placeholderOptions,
@@ -261,6 +264,7 @@ export const Playground = memo<PlaygroundProps>((props) => {
             },
         },
         [
+            mobile,
             allowHTML,
             linkify,
             linkifyTlds,

--- a/demo/components/PlaygroundMini.tsx
+++ b/demo/components/PlaygroundMini.tsx
@@ -6,6 +6,7 @@ import {Playground, type PlaygroundProps} from './Playground';
 
 export type PlaygroundMiniProps = Pick<
     PlaygroundProps,
+    | 'mobile'
     | 'initialEditor'
     | 'settingsVisible'
     | 'breaks'

--- a/demo/defaults/args.ts
+++ b/demo/defaults/args.ts
@@ -5,6 +5,7 @@ import type {PlaygroundMiniProps} from '../components/PlaygroundMini';
 export const args: Meta<PlaygroundMiniProps>['args'] = {
     initialEditor: 'wysiwyg',
     settingsVisible: true,
+    mobile: false,
     allowHTML: true,
     breaks: true,
     linkify: true,

--- a/demo/stories/playground/Playground.stories.tsx
+++ b/demo/stories/playground/Playground.stories.tsx
@@ -6,6 +6,7 @@ import {getInitialMd} from '../../utils/getInitialMd';
 
 export const Story: StoryObj<typeof component> = {
     args: {
+        mobile: false,
         disableMarkdownItAttrs: true,
     },
 };

--- a/src/bundle/toolbar/ToolbarButtonWithPopupMenu.tsx
+++ b/src/bundle/toolbar/ToolbarButtonWithPopupMenu.tsx
@@ -31,20 +31,20 @@ export type MenuItem = {
     ignoreActive?: boolean;
 };
 
-export type ToolbarButtonWithPopupMenuProps = Omit<
-    ToolbarBaseProps<never> &
-        Pick<PopupProps, 'disablePortal'> & {
-            icon: ToolbarIconData;
-            iconClassName?: string;
-            chevronIconClassName?: string;
-            title: string | (() => string);
-            menuItems: MenuItem[];
-            /** @default 'classic' */
-            _selectionType?: 'classic' | 'light';
-            qaMenu?: string;
-        },
-    'editor'
->;
+export type ToolbarButtonWithPopupMenuProps = Pick<
+    ToolbarBaseProps<never>,
+    'className' | 'focus' | 'onClick' | 'qa'
+> &
+    Pick<PopupProps, 'disablePortal'> & {
+        icon: ToolbarIconData;
+        iconClassName?: string;
+        chevronIconClassName?: string;
+        title: string | (() => string);
+        menuItems: MenuItem[];
+        /** @default 'classic' */
+        _selectionType?: 'classic' | 'light';
+        qaMenu?: string;
+    };
 
 export const ToolbarButtonWithPopupMenu: React.FC<ToolbarButtonWithPopupMenuProps> = ({
     disablePortal,

--- a/src/bundle/toolbar/custom/ToolbarColors.tsx
+++ b/src/bundle/toolbar/custom/ToolbarColors.tsx
@@ -76,7 +76,10 @@ export const ToolbarColors: React.FC<ToolbarColorsProps> = (props) => {
 
     return (
         <ToolbarButtonWithPopupMenu
-            {...props}
+            qa={props.qa}
+            focus={props.focus}
+            onClick={props.onClick}
+            className={props.className}
             qaMenu="g-md-toolbar-menu"
             title={i18n('colorify')}
             menuItems={items}


### PR DESCRIPTION
Fixed warnings:
```
react-dom.development.js:86 Warning: Invalid value for prop `exec` on <button> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://reactjs.org/link/attribute-behavior 
    at button
    at Button (http://localhost:8888/vendors-node_modules_gravity-ui_uikit_build_esm_index_js-node_modules_gravity-ui_uikit_build_-7fc4e1.iframe.bundle.js:11741:13)
    at Tooltip (http://localhost:8888/vendors-node_modules_gravity-ui_uikit_build_esm_index_js-node_modules_gravity-ui_uikit_build_-7fc4e1.iframe.bundle.js:24083:20)
    at ActionTooltip (http://localhost:8888/vendors-node_modules_gravity-ui_uikit_build_esm_index_js-node_modules_gravity-ui_uikit_build_-7fc4e1.iframe.bundle.js:9986:26)
    at ToolbarButtonWithPopupMenu (http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:4542:3)
    at ToolbarColors (http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:4800:5)
    at WToolbarColors (http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:5452:3)
    at div
    at ToolbarButtonGroup (http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:40751:3)
    at div
    at Toolbar (http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:40476:3)
    at div
    at div
    at FlexToolbar (http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:40309:68)
    at div
    at ToolbarView (http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:1595:3)
    at div
    at http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:1747:5
    at div
    at http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:862:3
    at div
    at ErrorBoundary (http://localhost:8888/vendors-node_modules_codemirror_commands_dist_index_js-node_modules_codemirror_lang-markdown_-240a59.iframe.bundle.js:67801:37)
    at http://localhost:8888/demo_components_PMSelection_tsx-demo_components_ProseMirrorDevTools_tsx-demo_utils_cn_ts-src_-fb75eb.iframe.bundle.js:1015:72
    at div
    at div
    at div
    at PlaygroundLayout (http://localhost:8888/demo_components_Playground_tsx-demo_utils_getInitialMd_ts-data_image_svg_xml_utf8_svg_xmlns_h-48243f.iframe.bundle.js:418:5)
    at http://localhost:8888/demo_components_Playground_tsx-demo_utils_getInitialMd_ts-data_image_svg_xml_utf8_svg_xmlns_h-48243f.iframe.bundle.js:72:5
    at PrivateLayoutProvider (http://localhost:8888/vendors-node_modules_gravity-ui_uikit_build_esm_index_js-node_modules_gravity-ui_uikit_build_-7fc4e1.iframe.bundle.js:26289:34)
    at ThemeProvider (http://localhost:8888/vendors-node_modules_gravity-ui_uikit_build_esm_index_js-node_modules_gravity-ui_uikit_build_-7fc4e1.iframe.bundle.js:28491:33)
    at ToasterProvider (http://localhost:8888/vendors-node_modules_gravity-ui_uikit_build_esm_index_js-node_modules_gravity-ui_uikit_build_-7fc4e1.iframe.bundle.js:23352:28)
    at unboundStoryFn (http://localhost:8888/sb-preview/runtime.js:5004:109)
    at ErrorBoundary (http://localhost:8888/vendors-node_modules_gravity-ui_uikit_build_esm_index…s-node_modules_gravity-ui_uikit_build_-7fc4e1.iframe.bundle.js:35815:42806)
    at WithCallback (http://localhost:8888/node_modules_storybook_react-dom-shim_dist_react-18_mjs.iframe.bundle.js:21:117)
```