### PR TITLE
fix(imageSize): fixed the insertion of the svg image

### DIFF
--- a/src/extensions/yfm/ImgSize/const.ts
+++ b/src/extensions/yfm/ImgSize/const.ts
@@ -6,3 +6,5 @@ export {imageNodeName, addImageAction} from '../../markdown/Image/const';
 export const IMG_MAX_HEIGHT = 600; //px
 export type ImageRendererState = {linkAdded: boolean};
 export const imageRendererKey = new PluginKey<ImageRendererState>('imageRenderer');
+export const DEFAULT_SVG_HEIGHT = 200;
+export const DEFAULT_SVG_WIDTH = 300;

--- a/src/extensions/yfm/ImgSize/utils.ts
+++ b/src/extensions/yfm/ImgSize/utils.ts
@@ -34,6 +34,18 @@ export const createImageNode =
                 logger.error({error: err});
             }
         }
+
+        const isSvg = checkSvg(result.url) || file.type === 'image/svg+xml';
+
+        if (isSvg) {
+            const sizes = await loadImage(file).then(getImageSizeNew);
+            return imgType.create({
+                ...attrs,
+                [ImgSizeAttr.Width]: sizes.width,
+                [ImgSizeAttr.Height]: sizes.height,
+            });
+        }
+
         return imgType.create(attrs);
     };
 
@@ -63,4 +75,8 @@ export function getImageSizeNew({width, height}: HTMLImageElement): {
         imgMaxHeight: IMG_MAX_HEIGHT,
     });
     return {width: String(size.width), height: String(size.height)};
+}
+
+export function checkSvg(imageUrl?: string) {
+    return imageUrl && (/\.svg($|\?|#)/i.test(imageUrl) || imageUrl.startsWith('data:image/svg'));
 }


### PR DESCRIPTION
Fixed SVG image insertion via URL paste and copy/paste.

Problem: Browser renders SVG with 0x0 dimensions when width/height attributes are missing.

Solution:
- Added default dimensions 300x200 for SVG without size attributes  
- Preload SVG to extract actual dimensions before insertion
- Added 2-second timeout fallback for slow loading images

Note: SVG images are loaded twice (dimension detection + rendering), but the second load 
uses browser cache, making the performance impact negligible.

Fixes issue where SVG images rendered with 0x0 size in editor
