### PR TITLE
fix: keyboard navigation in nested block containers

### DIFF
--- a/src/extensions/behavior/Selection/commands.ts
+++ b/src/extensions/behavior/Selection/commands.ts
@@ -114,11 +114,48 @@ export function findFakeParaPosClosestToPos(
 
         if (dir === 'before') {
             if (isFirstChild || !isTextblock(parent.child(index - 1))) {
-                return $pos.doc.resolve($pos.before(depth));
+                const $target = $pos.doc.resolve($pos.before(depth));
+
+                const prevNode = $target.nodeBefore;
+                const nextNode = $target.nodeAfter;
+                if (prevNode && nextNode) {
+                    const prevIsBlockContainer =
+                        prevNode.isBlock && prevNode.type.spec.content?.includes('block');
+                    const nextIsBlockContainer =
+                        nextNode.isBlock && nextNode.type.spec.content?.includes('block');
+
+                    if (prevIsBlockContainer && nextIsBlockContainer) {
+                        // skip this depth, try next one
+                        continue;
+                    }
+                }
+
+                return $target;
             }
         } else if (dir === 'after') {
             if (isLastChild || !isTextblock(parent.child(index + 1))) {
-                return $pos.doc.resolve($pos.after(depth));
+                const $target = $pos.doc.resolve($pos.after(depth));
+
+                const prevNode = $target.nodeBefore;
+                const nextNode = $target.nodeAfter;
+
+                if (!nextNode && isLastChild && depth > 1) {
+                    continue;
+                }
+
+                if (prevNode && nextNode && isLastChild && depth > 1) {
+                    const prevIsBlockContainer =
+                        prevNode.isBlock && prevNode.type.spec.content?.includes('block');
+                    const nextIsBlockContainer =
+                        nextNode.isBlock && nextNode.type.spec.content?.includes('block');
+
+                    if (prevIsBlockContainer && nextIsBlockContainer) {
+                        // skip this depth, try next one
+                        continue;
+                    }
+                }
+
+                return $target;
             }
         }
 


### PR DESCRIPTION
### Problem
Cursor gets stuck when navigating with Arrow Up/Down keys in nested sections because the editor tries to place gap cursor between adjacent block containers, which is invalid per schema.

### Fix
Added validation in `findFakeParaPosClosestToPos()` to skip invalid positions between block containers (`content: 'block+'`) and search for valid positions at different depths. Special handling for Arrow Down prevents cursor from getting stuck at end-of-parent positions when `nodeAfter = null`.