### PR TITLE
feat(code-block): support line numbers in code blocks

### DIFF
--- a/src/extensions/markdown/CodeBlock/CodeBlockHighlight/TooltipPlugin/TooltipView.scss
+++ b/src/extensions/markdown/CodeBlock/CodeBlockHighlight/TooltipPlugin/TooltipView.scss
@@ -28,3 +28,7 @@
 .g-md-code-block__select-button {
     margin: auto 0;
 }
+
+.g-md-code-block__show-line-numbers {
+    margin: auto 0;
+}

--- a/src/extensions/markdown/CodeBlock/CodeBlockHighlight/TooltipPlugin/index.tsx
+++ b/src/extensions/markdown/CodeBlock/CodeBlockHighlight/TooltipPlugin/index.tsx
@@ -1,5 +1,7 @@
+import type {ChangeEventHandler} from 'react';
+
 import {TrashBin} from '@gravity-ui/icons';
-import {Select, type SelectOption} from '@gravity-ui/uikit';
+import {Checkbox, Select, type SelectOption} from '@gravity-ui/uikit';
 import type {Node} from 'prosemirror-model';
 import type {EditorView} from 'prosemirror-view';
 
@@ -22,6 +24,7 @@ type CodeMenuProps = {
 
 const CodeMenu: React.FC<CodeMenuProps> = ({view, pos, node, selectItems, mapping}) => {
     const lang = node.attrs[CodeBlockNodeAttr.Lang];
+    const showLineNumbers = node.attrs[CodeBlockNodeAttr.ShowLineNumbers];
     const value = mapping[lang] ?? lang;
 
     const handleClick = (type: string) => {
@@ -31,6 +34,7 @@ const CodeMenu: React.FC<CodeMenuProps> = ({view, pos, node, selectItems, mappin
         view.dispatch(
             view.state.tr.setNodeMarkup(pos, null, {
                 [CodeBlockNodeAttr.Lang]: type,
+                [CodeBlockNodeAttr.ShowLineNumbers]: showLineNumbers,
             }),
         );
     };
@@ -52,6 +56,35 @@ const CodeMenu: React.FC<CodeMenuProps> = ({view, pos, node, selectItems, mappin
             )}
             // TODO: in onOpenChange return focus to view.dom after press Esc in Select
             // after https://github.com/gravity-ui/uikit/issues/2075
+        />
+    );
+};
+
+type ShowLineNumbersProps = {
+    view: EditorView;
+    pos: number;
+    node: Node;
+};
+
+const ShowLineNumbers: React.FC<ShowLineNumbersProps> = ({view, pos, node}) => {
+    const lang = node.attrs[CodeBlockNodeAttr.Lang];
+    const showLineNumbers = node.attrs[CodeBlockNodeAttr.ShowLineNumbers] === 'true';
+
+    const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+        view.dispatch(
+            view.state.tr.setNodeMarkup(pos, null, {
+                [CodeBlockNodeAttr.Lang]: lang,
+                [CodeBlockNodeAttr.ShowLineNumbers]: event.target.checked ? 'true' : undefined,
+            }),
+        );
+    };
+
+    return (
+        <Checkbox
+            checked={showLineNumbers}
+            className="g-md-code-block__show-line-numbers"
+            content={i18n('show_line_numbers')}
+            onChange={handleChange}
         />
     );
 };
@@ -84,6 +117,14 @@ export const codeLangSelectTooltipViewCreator = (
                                     mapping={mapping}
                                 />
                             ),
+                            width: 28,
+                        },
+                    ],
+                    [
+                        {
+                            id: 'code-block-showlinenumbers',
+                            type: ToolbarDataType.ReactComponent,
+                            component: () => <ShowLineNumbers view={view} pos={pos} node={node} />,
                             width: 28,
                         },
                     ],

--- a/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
@@ -4,6 +4,7 @@ import {nodeTypeFactory} from '../../../../utils/schema';
 export const CodeBlockNodeAttr = {
     Lang: 'data-language',
     Markup: 'data-markup',
+    ShowLineNumbers: 'data-show-line-numbers',
 } as const;
 
 export const codeBlockNodeName = 'code_block';
@@ -38,6 +39,7 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
             attrs: {
                 [CodeBlockNodeAttr.Lang]: {default: ''},
                 [CodeBlockNodeAttr.Markup]: {default: '```'},
+                [CodeBlockNodeAttr.ShowLineNumbers]: {default: ''},
             },
             content: 'text*',
             group: 'block',
@@ -71,8 +73,15 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
         toMd: (state, node) => {
             const lang: string = node.attrs[CodeBlockNodeAttr.Lang];
             const markup: string = node.attrs[CodeBlockNodeAttr.Markup];
+            const showLineNumbers: string = node.attrs[CodeBlockNodeAttr.ShowLineNumbers];
 
-            state.write(markup + lang + '\n');
+            let info = lang;
+
+            if (showLineNumbers === 'true') {
+                info += ' showLineNumbers';
+            }
+
+            state.write(markup + info + '\n');
             state.text(node.textContent, false);
             // Add a newline to the current content before adding closing marker
             state.write('\n');
@@ -96,7 +105,12 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
                     if (tok.info) {
                         // like in markdown-it
                         // https://github.com/markdown-it/markdown-it/blob/d07d585b6b15aaee2bc8f7a54b994526dad4dbc5/lib/renderer.mjs#L36-L37
-                        attrs[CodeBlockNodeAttr.Lang] = tok.info.split(/(\s+)/g)[0];
+                        const parts = tok.info.split(/\s+/);
+                        attrs[CodeBlockNodeAttr.Lang] = parts[0];
+
+                        if (parts.includes('showLineNumbers')) {
+                            attrs[CodeBlockNodeAttr.ShowLineNumbers] = 'true';
+                        }
                     }
                     return attrs;
                 },

--- a/src/i18n/codeblock/en.json
+++ b/src/i18n/codeblock/en.json
@@ -1,4 +1,5 @@
 {
   "remove": "Remove",
-  "empty_option": "No matches found"
+  "empty_option": "No matches found",
+  "show_line_numbers": "Line numbers"
 }

--- a/src/i18n/codeblock/ru.json
+++ b/src/i18n/codeblock/ru.json
@@ -1,4 +1,5 @@
 {
   "remove": "Удалить",
-  "empty_option": "Ничего не найдено"
+  "empty_option": "Ничего не найдено",
+  "show_line_numbers": "Нумерация строк"
 }


### PR DESCRIPTION
Fixes #835 

This PR adds the ability to display line numbers in code blocks. Users can now toggle line numbers visibility through a checkbox in the code block toolbar.

<img width="1418" height="932" alt="image" src="https://github.com/user-attachments/assets/0348f812-7d08-4f2e-a900-002e7dc19382" />
