### PR TITLE
fix(build): resolve SCSS imports from node_modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('scss', () => {
         .pipe(
             replace(/@(import|use) '~.+'/g, (match) => match.replace('~', NODE_MODULES_DIR + '/')),
         )
-        .pipe(sass())
+        .pipe(sass({loadPaths: [NODE_MODULES_DIR]}))
         .pipe(gulp.dest(BUILD_DIR_CJS))
         .pipe(gulp.dest(BUILD_DIR_ESM))
         .pipe(concat('styles.css')) // also bundle all css to single file


### PR DESCRIPTION
Fixes https://github.com/gravity-ui/markdown-editor/actions/runs/20097010905/job/57657841466