### PR TITLE
fix(CodeBlock): prevent dispatch on destroyed `EditorView`

### DIFF
--- a/src/extensions/markdown/CodeBlock/CodeBlockHighlight/CodeBlockHighlight.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlockHighlight/CodeBlockHighlight.ts
@@ -89,13 +89,13 @@ export const CodeBlockHighlight: ExtensionAuto<CodeBlockHighlightOptions> = (bui
                                     for (const alias of defs.aliases) {
                                         mapping[alias] = lang;
                                     }
+                                }
+                            }
+
+                            if (view && !view.isDestroyed) {
+                                view.dispatch(view.state.tr.setMeta(key, {modulesLoaded}));
                             }
                         }
-
-                        if (view && !view.isDestroyed) {
-                            view.dispatch(view.state.tr.setMeta(key, {modulesLoaded}));
-                        }
-                    }
                     });
                     return getDecorations(state.doc);
                 },


### PR DESCRIPTION
Fixes https://github.com/gravity-ui/markdown-editor/issues/915