### PR TITLE
feat(view): add support of yfm-files to `useFilesGallery()` hook

### DIFF
--- a/demo/stories/view/gallery/markup.ts
+++ b/demo/stories/view/gallery/markup.ts
@@ -6,5 +6,13 @@ export const galleryMarkup = `
 
 ![Dojocat](https://octodex.github.com/images/dojocat.jpg "The Dojocat")
 
+## Video
+
 [Video](https://static.videezy.com/system/resources/previews/000/013/444/original/Water_43_-_37s_-_4k_res.mp4)
+
+## Files
+
+{% file src="https://octodex.github.com/images/forktocat.jpg" name="Forktocat" type="image/jpeg" %} 
+
+{% file src="https://static.videezy.com/system/resources/previews/000/012/253/original/Water_17_-_9s_-_4k_res.mp4" name="Rings of water" type="video/mp4" %} 
 `.trim();

--- a/src/view/hooks/useFilesGallery/constants.ts
+++ b/src/view/hooks/useFilesGallery/constants.ts
@@ -5,3 +5,9 @@ export const supportedVideoExtensions = ['mp4', 'webm', 'ogg'];
 export const supportedExtensions = [...supportedImageExtensions, ...supportedVideoExtensions];
 
 export const extensionRegex = /\w+?$/;
+
+export const YfmFileClassname = 'yfm-file';
+export const YfmFileAttrs = {
+    Download: 'download',
+    Type: 'type',
+} as const;

--- a/src/view/hooks/useFilesGallery/helpers.ts
+++ b/src/view/hooks/useFilesGallery/helpers.ts
@@ -1,0 +1,34 @@
+import {YfmFileAttrs, YfmFileClassname} from './constants';
+
+type LinkObject = {
+    name?: string | null;
+    mimetype?: string | null;
+    type: 'image' | 'link' | 'file';
+    link: string;
+};
+
+export function buildLinkObject(elem: Element): LinkObject | null {
+    let obj: LinkObject | null = null;
+
+    if (elem.tagName === 'IMG') {
+        obj = {
+            type: 'image',
+            name: elem.getAttribute('alt'),
+            link: elem.getAttribute('src') ?? '',
+        };
+    } else if (elem.tagName === 'A') {
+        obj = {
+            type: 'link',
+            name: elem.getAttribute('title'),
+            link: elem.getAttribute('href') ?? '',
+        };
+
+        if (elem.classList.contains(YfmFileClassname)) {
+            obj.type = 'file';
+            obj.name = elem.getAttribute(YfmFileAttrs.Download);
+            obj.mimetype = elem.getAttribute(YfmFileAttrs.Type);
+        }
+    }
+
+    return obj;
+}


### PR DESCRIPTION
Added support for YFM files to `useFilesGallery()` hook: getting the file name and type from element attributes