### PR TITLE
fix(Search): auto-scroll to search match when only one result found

### DIFF
--- a/src/extensions/behavior/Search/SearchViewPlugin.ts
+++ b/src/extensions/behavior/Search/SearchViewPlugin.ts
@@ -5,11 +5,12 @@ import {type Command, Plugin, type PluginView, TextSelection} from '#pm/state';
 import {findParentNodeClosestToPos} from '#pm/utils';
 import type {EditorView} from '#pm/view';
 import {type SearchCounter, type SearchState, renderSearchPopup} from 'src/modules/search';
+import {isElementInViewport} from 'src/utils/dom';
 
 import {getReactRendererFromState} from '../ReactRenderer';
 
 import {closeSearch, findNext, findPrev, replaceAll, replaceNext} from './commands';
-import {pluginKey} from './const';
+import {SearchClassName, pluginKey} from './const';
 import {searchKeyHandler} from './key-handler';
 import type {SearchViewState} from './types';
 import {startTracking} from './utils/connect-tracker';
@@ -166,10 +167,12 @@ class SeachPluginView implements PluginView {
 
     private _onSearchPrev = () => {
         this._preserveFocus(findPrev);
+        requestAnimationFrame(() => this._scrollToActiveIfNeeded());
     };
 
     private _onSearchNext = () => {
         this._preserveFocus(findNext);
+        requestAnimationFrame(() => this._scrollToActiveIfNeeded());
     };
 
     private _onReplaceNext = () => {
@@ -186,4 +189,17 @@ class SeachPluginView implements PluginView {
         command(this._view.state, this._view.dispatch, this._view);
         this._focusManager.restoreFocus({preventScroll: true});
     }
+
+    private _scrollToActiveIfNeeded = () => {
+        const activeElem = this._view.dom
+            .getElementsByClassName(SearchClassName.ActiveMatch)
+            .item(0);
+
+        if (activeElem && !isElementInViewport(activeElem)) {
+            activeElem.scrollIntoView({
+                block: 'nearest',
+                inline: 'nearest',
+            });
+        }
+    };
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,10 @@
+export function isElementInViewport(element: Element) {
+    const document = element.ownerDocument;
+    const rect = element.getBoundingClientRect();
+    return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+}


### PR DESCRIPTION
Problem: In WYSIWYG mode, when only one search result is found, clicking the 
next/previous buttons in the search panel does not scroll to that result.
