### PR TITLE
feat(CodeBlock): create new code blocks without line numbers

### DIFF
--- a/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
@@ -1,5 +1,5 @@
-import type {ExtensionAuto, ExtensionNodeSpec} from '../../../../core';
-import {nodeTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto, ExtensionNodeSpec} from '#core';
+import {nodeTypeFactory} from 'src/utils/schema';
 
 export const CodeBlockNodeAttr = {
     Lang: 'data-language',
@@ -11,7 +11,20 @@ export const CodeBlockNodeAttr = {
 export const codeBlockNodeName = 'code_block';
 export const codeBlockType = nodeTypeFactory(codeBlockNodeName);
 
-export type LineNumbersOptions = {enabled?: boolean; showByDefault?: boolean};
+export type LineNumbersOptions = {
+    /**
+     * Allow line numbers in codeblock.
+     * Available with @diplodoc/transform v4.55.0 or higher.
+     * @default true
+     */
+    // TODO [MAJOR]: enable by default and remove option
+    enabled?: boolean;
+    /**
+     * By default, new code blocks are added with line numbers.
+     * @default false
+     */
+    showByDefault?: boolean;
+};
 
 export type CodeBlockSpecsOptions = {
     nodeview?: ExtensionNodeSpec['view'];

--- a/src/extensions/markdown/CodeBlock/const.ts
+++ b/src/extensions/markdown/CodeBlock/const.ts
@@ -1,5 +1,11 @@
-import {codeBlockType} from './CodeBlockSpecs';
+import {type LineNumbersOptions, codeBlockType} from './CodeBlockSpecs';
 
 export {codeBlockNodeName, CodeBlockNodeAttr as CodeBlockAttr} from './CodeBlockSpecs';
 export const cbAction = 'toCodeBlock';
 export {codeBlockType};
+
+// After changing the default, don't forget to update LineNumbersOptions
+export const lineNumbersOptionsDefault: LineNumbersOptions = {
+    enabled: true,
+    showByDefault: false,
+};

--- a/src/extensions/markdown/CodeBlock/index.ts
+++ b/src/extensions/markdown/CodeBlock/index.ts
@@ -1,20 +1,14 @@
-import type {NodeType} from 'prosemirror-model';
-// @ts-ignore // TODO: fix cjs build
-import {hasParentNodeOfType} from 'prosemirror-utils';
-
-import type {Action, ExtensionAuto, Keymap} from '../../../core';
-import {isFunction} from '../../../lodash';
-import {textblockTypeInputRule} from '../../../utils/inputrules';
-import {withLogAction} from '../../../utils/keymap';
+import type {Action, ExtensionAuto, Keymap} from '#core';
+import type {NodeType} from '#pm/model';
+import {hasParentNodeOfType} from '#pm/utils';
+import {isFunction} from 'src/lodash';
+import {textblockTypeInputRule} from 'src/utils/inputrules';
+import {withLogAction} from 'src/utils/keymap';
 
 import {CodeBlockHighlight, type HighlightLangMap} from './CodeBlockHighlight/CodeBlockHighlight';
-import {
-    CodeBlockSpecs,
-    type CodeBlockSpecsOptions,
-    type LineNumbersOptions,
-} from './CodeBlockSpecs';
+import {CodeBlockSpecs, type CodeBlockSpecsOptions} from './CodeBlockSpecs';
 import {newlineInCode, resetCodeblock, setCodeBlockType} from './commands';
-import {cbAction, codeBlockType} from './const';
+import {cbAction, codeBlockType, lineNumbersOptionsDefault} from './const';
 import {codeBlockPastePlugin} from './plugins/codeBlockPastePlugin';
 
 export {resetCodeblock} from './commands';
@@ -24,8 +18,6 @@ export type CodeBlockOptions = CodeBlockSpecsOptions & {
     codeBlockKey?: string | null;
     langs?: HighlightLangMap;
 };
-
-export const lineNumbersOptionsDefault: LineNumbersOptions = {enabled: true, showByDefault: true};
 
 export const CodeBlock: ExtensionAuto<CodeBlockOptions> = (builder, opts) => {
     const optsNormalized: CodeBlockOptions = {


### PR DESCRIPTION
To override default behavior:

```ts
const editor = useMarkdownEditor({
  wysiwygConfig: {
    extensionOptions: {
      codeBlock: {
        lineNumbers: {
          enabled: true, // pass false to disable line numbers completely
          showByDefault: false, // pass true to have all new code blocks created with line numbers
        },
      },
    },
  },
});
```