### PR TITLE
fix(withMermaid): handle render errors

### DIFF
--- a/src/view/hocs/withMermaid/index.tsx
+++ b/src/view/hocs/withMermaid/index.tsx
@@ -28,7 +28,7 @@ export function withMermaid(opts: WithMermaidOptions) {
             useMermaidRuntime(meta, opts.runtime);
 
             useEffect(() => {
-                renderMermaid(mermaidConfig);
+                renderMermaid(mermaidConfig).catch(() => {});
             }, [html, mermaidConfig, renderMermaid]);
 
             return <Component {...props} ref={ref} />;


### PR DESCRIPTION
When Mermaid throw some errors (like diagram syntax errors), this errors end up as unhandled in browser console