### PR TITLE
fix(YfmHeading): fix parsing custom ids in headings

### DIFF
--- a/src/extensions/yfm/YfmHeading/YfmHeading.test.ts
+++ b/src/extensions/yfm/YfmHeading/YfmHeading.test.ts
@@ -104,8 +104,33 @@ describe('Heading extension', () => {
         );
     });
 
-    it('should parse headings with id without markdown-it-attrs', () => {
-        const markup = dd`
+    describe('without markdown-it-attrs', () => {
+        const {
+            schema,
+            markupParser: parser,
+            serializer,
+        } = new ExtensionsManager({
+            extensions: (builder) =>
+                builder
+                    .use(BaseSchemaSpecs, {})
+                    .use(BoldSpecs)
+                    .use(YfmConfigsSpecs, {disableAttrs: true})
+                    .use(YfmHeadingSpecs, {}),
+        }).buildDeps();
+        const {same} = createMarkupChecker({parser, serializer});
+
+        const {doc, b, p, h} = builders<
+            'doc' | 'b' | 'p' | 'h' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+            'b'
+        >(schema, {
+            doc: {nodeType: BaseNode.Doc},
+            b: {markType: boldMarkName},
+            p: {nodeType: BaseNode.Paragraph},
+            h: {nodeType: headingNodeName},
+        });
+
+        it('should parse headings with id', () => {
+            const markup = dd`
             # h1 {#one}
 
             ## h2 {#two}
@@ -121,40 +146,59 @@ describe('Heading extension', () => {
             para
             `.trim();
 
-        const {
-            schema,
-            markupParser: parser,
-            serializer,
-        } = new ExtensionsManager({
-            extensions: (builder) =>
-                builder
-                    .use(BaseSchemaSpecs, {})
-                    .use(YfmConfigsSpecs, {disableAttrs: true})
-                    .use(YfmHeadingSpecs, {}),
-        }).buildDeps();
-        const {same} = createMarkupChecker({parser, serializer});
-
-        const {doc, p, h} = builders<
-            'doc' | 'p' | 'h' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
-            'b'
-        >(schema, {
-            doc: {nodeType: BaseNode.Doc},
-            p: {nodeType: BaseNode.Paragraph},
-            h: {nodeType: headingNodeName},
+            same(
+                markup,
+                doc(
+                    h({[YfmHeadingAttr.Level]: 1, [YfmHeadingAttr.Id]: 'one'}, 'h1'),
+                    h({[YfmHeadingAttr.Level]: 2, [YfmHeadingAttr.Id]: 'two'}, 'h2'),
+                    h({[YfmHeadingAttr.Level]: 3, [YfmHeadingAttr.Id]: 'three'}, 'h3'),
+                    h({[YfmHeadingAttr.Level]: 4, [YfmHeadingAttr.Id]: 'four'}, 'h4'),
+                    h({[YfmHeadingAttr.Level]: 5, [YfmHeadingAttr.Id]: 'five'}, 'h5'),
+                    h({[YfmHeadingAttr.Level]: 6, [YfmHeadingAttr.Id]: 'six'}, 'h6'),
+                    p('para'),
+                ),
+            );
         });
 
-        same(
-            markup,
-            doc(
-                h({[YfmHeadingAttr.Level]: 1, [YfmHeadingAttr.Id]: 'one'}, 'h1'),
-                h({[YfmHeadingAttr.Level]: 2, [YfmHeadingAttr.Id]: 'two'}, 'h2'),
-                h({[YfmHeadingAttr.Level]: 3, [YfmHeadingAttr.Id]: 'three'}, 'h3'),
-                h({[YfmHeadingAttr.Level]: 4, [YfmHeadingAttr.Id]: 'four'}, 'h4'),
-                h({[YfmHeadingAttr.Level]: 5, [YfmHeadingAttr.Id]: 'five'}, 'h5'),
-                h({[YfmHeadingAttr.Level]: 6, [YfmHeadingAttr.Id]: 'six'}, 'h6'),
-                p('para'),
-            ),
-        );
+        it('should parse id with dots', () => {
+            const markup = dd`
+            ## Heading2 {#heading.two}
+            `.trim();
+
+            same(
+                markup,
+                doc(h({[YfmHeadingAttr.Level]: 2, [YfmHeadingAttr.Id]: 'heading.two'}, 'Heading2')),
+            );
+        });
+
+        it('should parse id in russian', () => {
+            const markup = dd`
+            ## Заголовок2 {#якорь.два}
+            `.trim();
+
+            same(
+                markup,
+                doc(h({[YfmHeadingAttr.Level]: 2, [YfmHeadingAttr.Id]: 'якорь.два'}, 'Заголовок2')),
+            );
+        });
+
+        it('should parse id in heading with inline markup', () => {
+            const markup = dd`
+            ## Head**ing**two {#anchor.second}
+            `.trim();
+
+            same(
+                markup,
+                doc(
+                    h(
+                        {[YfmHeadingAttr.Level]: 2, [YfmHeadingAttr.Id]: 'anchor.second'},
+                        'Head',
+                        b('ing'),
+                        'two',
+                    ),
+                ),
+            );
+        });
     });
 
     it.each([1, 2, 3, 4, 5, 6])('should parse html - h%s tag', (lvl) => {

--- a/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/index.ts
+++ b/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/index.ts
@@ -2,7 +2,7 @@ import type {ExtensionAuto} from '#core';
 import type {Node, NodeSpec} from '#pm/model';
 
 import {YfmHeadingAttr, headingNodeName} from './const';
-import {headingAttrsPlugin} from './markdown/heading-attrs';
+import {headingIdsPlugin} from './markdown/heading-ids';
 import {getNodeAttrs} from './utils';
 
 const DEFAULT_PLACEHOLDER = (node: Node) => 'Heading ' + node.attrs[YfmHeadingAttr.Level];
@@ -18,7 +18,7 @@ export type YfmHeadingSpecsOptions = {
 
 /** YfmHeading extension needs markdown-it-attrs plugin */
 export const YfmHeadingSpecs: ExtensionAuto<YfmHeadingSpecsOptions> = (builder, opts) => {
-    builder.configureMd((md) => md.use(headingAttrsPlugin));
+    builder.configureMd((md) => md.use(headingIdsPlugin));
     builder.addNode(headingNodeName, () => ({
         spec: {
             attrs: {

--- a/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/markdown/heading-ids.ts
+++ b/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/markdown/heading-ids.ts
@@ -1,0 +1,29 @@
+import type MarkdownIt from 'markdown-it';
+
+import {getCustomIds, removeCustomIds} from './utils/custom-id';
+
+/**
+ * MarkdownIt plugin for parsing custom IDs in headings.
+ * It replicates the logic of '@diplodoc/transform'.
+ * @see https://github.com/diplodoc-platform/transform/blob/master/src/transform/plugins/anchors/index.ts
+ */
+export const headingIdsPlugin: MarkdownIt.PluginSimple = (md) => {
+    md.core.ruler.push('heading-attrs', (state) => {
+        const {tokens} = state;
+
+        for (let i = 0; i < tokens.length; i++) {
+            const token = tokens[i];
+            if (token.type !== 'heading_open') continue;
+
+            const inlineToken = tokens[i + 1];
+            if (inlineToken?.type !== 'inline') continue;
+
+            const customIds = getCustomIds(inlineToken.content);
+            if (customIds) {
+                const id = customIds[0];
+                token.attrSet('id', id);
+                removeCustomIds(inlineToken);
+            }
+        }
+    });
+};

--- a/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/markdown/utils/custom-id.ts
+++ b/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/markdown/utils/custom-id.ts
@@ -1,0 +1,47 @@
+//
+// Utils for working with custom ids in heading tokens.
+// Copied from https://github.com/diplodoc-platform/transform/blob/master/src/transform/plugins/anchors/custom-id.ts
+// TODO [MAJOR]: import directly from '@diplodoc/transform' after bump it in peerDependencies.
+//
+
+import type Token from 'markdown-it/lib/token';
+
+export const CUSTOM_ID_REGEXP = /\[?{ ?#(\S+) ?}]?/g;
+export const CUSTOM_ID_EXCEPTION = '[{#T}]';
+
+export const getCustomIds = (content: string) => {
+    const ids: string[] = [];
+
+    content.replace(CUSTOM_ID_REGEXP, (match, customId) => {
+        if (match !== CUSTOM_ID_EXCEPTION) {
+            ids.push(customId);
+        }
+
+        return '';
+    });
+
+    return ids.length ? ids : null;
+};
+
+export const removeCustomId = (content: string) => {
+    if (CUSTOM_ID_REGEXP.test(content)) {
+        return content
+            .replace(CUSTOM_ID_REGEXP, (match) => {
+                if (match === CUSTOM_ID_EXCEPTION) {
+                    return match;
+                }
+
+                return '';
+            })
+            .trim();
+    }
+
+    return content;
+};
+
+export const removeCustomIds = (token: Token) => {
+    token.content = removeCustomId(token.content);
+    token.children?.forEach((child) => {
+        child.content = removeCustomId(child.content);
+    });
+};


### PR DESCRIPTION
Allow dots and other symbols in heading IDs. Same as in `@diplodoc/transform`