### PR TITLE
fix(SelectionContext): skip updates on attribute-only DOM mutations

### DIFF
--- a/src/extensions/behavior/SelectionContext/index.ts
+++ b/src/extensions/behavior/SelectionContext/index.ts
@@ -147,16 +147,22 @@ class SelectionTooltip implements PluginSpec<PluginState> {
         const hideFromTr = pluginKey.getState(view.state)?.disabled;
 
         // Don't show tooltip if editor not mounted to the DOM
-        // or when view is out of focus
-        if (hideFromTr || !view.dom.parentNode || !view.hasFocus()) {
+        if (hideFromTr || !view.dom.parentNode) {
             this.tooltip.hide(view);
             return;
         }
 
         const {state} = view;
         // Don't do anything if the document/selection didn't change
-        if (prevState && prevState.doc.eq(state.doc) && prevState.selection.eq(state.selection))
+        if (prevState && prevState.doc.eq(state.doc) && prevState.selection.eq(state.selection)) {
             return;
+        }
+
+        // Don't show tooltip if editor out of focus
+        if (!view.hasFocus()) {
+            this.tooltip.hide(view);
+            return;
+        }
 
         const {selection} = state;
         // Hide the tooltip if the selection is empty


### PR DESCRIPTION
When the editor is embedded into an environment that mutates DOM attributes (e.g. Floating UI focus management), ProseMirror’s `DOMObserver` may trigger an extra `view.updateState()` (`flush` ) even when doc/selection didn’t change, which could hide the selection tooltip unexpectedly.

This PR splits the logic:
	•	Stage 1: ignore attribute-only updates (early return on unchanged doc/selection)
	•	Stage 2: hide only on real focus loss (!view.hasFocus())