### PR TITLE
perf: optimize toolbar rendering

### DIFF
--- a/packages/editor/src/bundle/MarkupEditorView.tsx
+++ b/packages/editor/src/bundle/MarkupEditorView.tsx
@@ -80,7 +80,6 @@ export const MarkupEditorView = memo<MarkupEditorViewProps>((props) => {
                         hiddenActionsConfig={hiddenActionsConfig}
                         stickyToolbar={stickyToolbar}
                         toolbarConfig={toolbarConfig}
-                        toolbarFocus={() => editor.focus()}
                         settingsVisible={settingsVisible}
                         className={b('toolbar', [toolbarClassName])}
                         toolbarDisplay={toolbarDisplay}

--- a/packages/editor/src/bundle/ToolbarView.tsx
+++ b/packages/editor/src/bundle/ToolbarView.tsx
@@ -1,25 +1,36 @@
-import {useLayoutEffect, useRef} from 'react';
+import {type ComponentProps, useCallback, useLayoutEffect, useMemo, useRef} from 'react';
 
 import type {QAProps} from '@gravity-ui/uikit';
-import {useUpdate} from 'react-use';
 
 import {LAYOUT} from 'src/common/layout';
+import {typedMemo} from 'src/react-utils/memo';
+import {EventEmitter} from 'src/utils';
 
 import type {ClassNameProps} from '../classname';
 import {i18n} from '../i18n/menubar';
 import {useSticky} from '../react-utils/useSticky';
-import {FlexToolbar, type ToolbarData, type ToolbarDisplay, type ToolbarItemData} from '../toolbar';
+import {
+    FlexToolbar,
+    type FlexToolbarProps,
+    type ToolbarData,
+    type ToolbarDisplay,
+    type ToolbarItemData,
+    ToolbarProvider,
+} from '../toolbar';
 
 import type {EditorInt} from './Editor';
 import {stickyCn} from './sticky';
 import type {MarkdownEditorMode} from './types';
+
+const MemoizedFlexibleToolbar = typedMemo(FlexToolbar);
+
+type ToolbarProviderValue = NonNullable<ComponentProps<typeof ToolbarProvider>['value']>;
 
 export type ToolbarViewProps<T> = ClassNameProps &
     QAProps & {
         editor: EditorInt;
         editorMode: MarkdownEditorMode;
         toolbarEditor: T;
-        toolbarFocus: () => void;
         toolbarConfig: ToolbarData<T>;
         settingsVisible?: boolean;
         hiddenActionsConfig?: ToolbarItemData<T>[];
@@ -32,7 +43,6 @@ export function ToolbarView<T>({
     editor,
     editorMode,
     toolbarEditor,
-    toolbarFocus,
     toolbarConfig,
     toolbarDisplay,
     hiddenActionsConfig,
@@ -42,18 +52,39 @@ export function ToolbarView<T>({
     stickyToolbar,
     qa,
 }: ToolbarViewProps<T>) {
-    const rerender = useUpdate();
-    useLayoutEffect(() => {
-        editor.on('rerender-toolbar', rerender);
-        return () => {
-            editor.off('rerender-toolbar', rerender);
-        };
-    }, [editor, rerender]);
-
     const wrapperRef = useRef<HTMLDivElement>(null);
     const isStickyActive = useSticky(wrapperRef) && stickyToolbar;
 
     const mobile = editor.mobile;
+
+    const clickHandle = useCallback<NonNullable<FlexToolbarProps<T>['onClick']>>(
+        (id, attrs) => editor.emit('toolbar-action', {id, attrs, editorMode}),
+        [editor, editorMode],
+    );
+
+    const toolbarProviderValue = useMemo(
+        () =>
+            ({
+                editor: toolbarEditor,
+                eventBus: new EventEmitter<{update: null}>(),
+            }) satisfies ToolbarProviderValue,
+        [toolbarEditor],
+    );
+
+    const handleFocus = useCallback(() => {
+        editor.focus();
+    }, [editor]);
+
+    useLayoutEffect(() => {
+        const onRerender = () => {
+            toolbarProviderValue.eventBus.emit('update', null);
+        };
+
+        editor.on('rerender-toolbar', onRerender);
+        return () => {
+            editor.off('rerender-toolbar', onRerender);
+        };
+    }, [editor, toolbarProviderValue]);
 
     return (
         <div
@@ -69,18 +100,20 @@ export function ToolbarView<T>({
             )}
             data-layout={LAYOUT.STICKY_TOOLBAR}
         >
-            <FlexToolbar
-                data={toolbarConfig}
-                hiddenActions={hiddenActionsConfig}
-                editor={toolbarEditor}
-                focus={toolbarFocus}
-                dotsTitle={i18n('more_action')}
-                onClick={(id, attrs) => editor.emit('toolbar-action', {id, attrs, editorMode})}
-                display={toolbarDisplay}
-                disableTooltip={mobile}
-                disableHotkey={mobile}
-                disablePreview={mobile}
-            />
+            <ToolbarProvider value={toolbarProviderValue}>
+                <MemoizedFlexibleToolbar
+                    data={toolbarConfig}
+                    hiddenActions={hiddenActionsConfig}
+                    editor={toolbarEditor}
+                    focus={handleFocus}
+                    dotsTitle={i18n('more_action')}
+                    onClick={clickHandle}
+                    display={toolbarDisplay}
+                    disableTooltip={mobile}
+                    disableHotkey={mobile}
+                    disablePreview={mobile}
+                />
+            </ToolbarProvider>
             {children}
         </div>
     );

--- a/packages/editor/src/bundle/WysiwygEditorView.tsx
+++ b/packages/editor/src/bundle/WysiwygEditorView.tsx
@@ -1,5 +1,3 @@
-import {memo} from 'react';
-
 import type {QAProps} from '@gravity-ui/uikit';
 
 import {type ClassNameProps, cn} from '../classname';
@@ -30,7 +28,7 @@ export type WysiwygEditorViewProps = ClassNameProps &
         toolbarDisplay?: ToolbarDisplay;
     };
 
-export const WysiwygEditorView = memo<WysiwygEditorViewProps>((props) => {
+export const WysiwygEditorView: React.FC<WysiwygEditorViewProps> = (props) => {
     const {
         editor,
         autofocus,
@@ -69,7 +67,6 @@ export const WysiwygEditorView = memo<WysiwygEditorViewProps>((props) => {
                     toolbarEditor={editor}
                     stickyToolbar={stickyToolbar}
                     toolbarConfig={toolbarConfig}
-                    toolbarFocus={() => editor.focus()}
                     hiddenActionsConfig={hiddenActionsConfig}
                     settingsVisible={settingsVisible}
                     className={b('toolbar', [toolbarClassName])}
@@ -83,5 +80,5 @@ export const WysiwygEditorView = memo<WysiwygEditorViewProps>((props) => {
             </WysiwygEditorComponent>
         </div>
     );
-});
+};
 WysiwygEditorView.displayName = 'MarkdownWysiwgEditorView';

--- a/packages/editor/src/bundle/config/markup.tsx
+++ b/packages/editor/src/bundle/config/markup.tsx
@@ -535,6 +535,7 @@ export const mToolbarConfig: MToolbarData = [
         {
             id: 'colorify',
             type: ToolbarDataType.ReactComponent,
+            noRerenderOnUpdate: true, // static state in markup mode
             component: MToolbarColors,
             width: 42,
         },

--- a/packages/editor/src/bundle/config/wysiwyg.ts
+++ b/packages/editor/src/bundle/config/wysiwyg.ts
@@ -487,6 +487,7 @@ export const wToolbarConfig: WToolbarData = [
             id: 'colorify',
             type: ToolbarDataType.ReactComponent,
             component: WToolbarColors,
+            noRerenderOnUpdate: true, // WToolbarColors uses toolbar context to update its own state
             width: 42,
         },
         wLinkItemData,
@@ -521,6 +522,7 @@ export const wSelectionMenuConfig: SelectionContextConfig = [
             id: 'colorify',
             type: ToolbarDataType.ReactComponent,
             component: WToolbarColors,
+            noRerenderOnUpdate: true, // WToolbarColors uses toolbar context to update its own state
             props: {disablePortal: true} satisfies Partial<WToolbarColorsProps>,
             width: 42,
         },

--- a/packages/editor/src/bundle/toolbar/wysiwyg/WToolbarColors.tsx
+++ b/packages/editor/src/bundle/toolbar/wysiwyg/WToolbarColors.tsx
@@ -1,3 +1,11 @@
+import {useEffect, useState} from 'react';
+
+import {useLatest} from 'react-use';
+
+import type {ActionStorage} from '#core';
+import {isEqual} from 'src/lodash';
+import {useToolbarContext} from 'src/toolbar/context';
+
 import {ToolbarColors, type ToolbarColorsProps} from '../custom/ToolbarColors';
 import type {WToolbarBaseProps} from '../types';
 
@@ -10,13 +18,13 @@ export const WToolbarColors: React.FC<WToolbarColorsProps> = ({
     focus,
     onClick,
 }) => {
+    const {active, enabled, currentColor} = useColorsState(editor);
     const action = editor.actions.colorify;
-    const currentColor = action.meta();
 
     return (
         <ToolbarColors
-            active={action.isActive()}
-            enable={action.isEnable()}
+            active={active}
+            enable={enabled}
             currentColor={currentColor}
             exec={(color) => {
                 action.run({color: color === currentColor ? '' : color});
@@ -29,3 +37,48 @@ export const WToolbarColors: React.FC<WToolbarColorsProps> = ({
         />
     );
 };
+
+type ColorsState = {
+    active: boolean;
+    enabled: boolean;
+    currentColor: string;
+};
+
+function useColorsState(editor: ActionStorage): ColorsState {
+    const action = editor.actions.colorify;
+
+    const context = useToolbarContext();
+
+    const [state, setState] = useState<ColorsState>({
+        active: false,
+        enabled: true,
+        currentColor: '',
+    });
+    const stateRef = useLatest(state);
+
+    useEffect(() => {
+        if (!context) return undefined;
+
+        const onUpdate = () => {
+            const newState = {
+                active: action.isActive(),
+                enabled: action.isEnable(),
+                currentColor: action.meta(),
+            };
+
+            if (!isEqual(stateRef.current, newState)) {
+                setState(newState);
+            }
+        };
+
+        onUpdate();
+
+        context.eventBus.on('update', onUpdate);
+
+        return () => {
+            context.eventBus.off('update', onUpdate);
+        };
+    }, [action, context, stateRef]);
+
+    return state;
+}

--- a/packages/editor/src/modules/toolbars/items.tsx
+++ b/packages/editor/src/modules/toolbars/items.tsx
@@ -776,10 +776,12 @@ export const colorifyItemView: ToolbarItemView<ToolbarDataType.ReactComponent> =
 };
 export const colorifyItemWysiwyg: ToolbarItemWysiwyg<ToolbarDataType.ReactComponent> = {
     component: WToolbarColors,
+    noRerenderOnUpdate: true, // WToolbarColors uses toolbar context to update its own state
     width: 42,
 };
 export const colorifyItemMarkup: ToolbarItemMarkup<ToolbarDataType.ReactComponent> = {
     component: MToolbarColors,
+    noRerenderOnUpdate: true, // static state in markup mode
     width: 42,
 };
 

--- a/packages/editor/src/modules/toolbars/types.ts
+++ b/packages/editor/src/modules/toolbars/types.ts
@@ -60,6 +60,7 @@ type ToolbarItemEditor<T, E> = Partial<EditorActions<E>> & {
         : T extends ToolbarDataType.ReactComponent
           ? {
                 width: number;
+                noRerenderOnUpdate?: boolean;
                 component: React.ComponentType<ToolbarBaseProps<E>>;
             }
           : {});

--- a/packages/editor/src/react-utils/memo.ts
+++ b/packages/editor/src/react-utils/memo.ts
@@ -1,0 +1,9 @@
+// hack to allow using generic components with memo
+
+import {memo} from 'react';
+
+// DO NOT TRY TO PASS GENERIC PARAMETERS TO THIS FUNCTION!
+export const typedMemo: <Props extends object, Return extends React.ReactNode>(
+    Component: (props: Props) => Return,
+    compare?: (prevProps: Props, newProps: Props) => boolean,
+) => (props: Props) => Return = memo;

--- a/packages/editor/src/toolbar/Toolbar.tsx
+++ b/packages/editor/src/toolbar/Toolbar.tsx
@@ -3,6 +3,7 @@ import {Fragment} from 'react';
 import {cn} from '../classname';
 
 import {ToolbarButtonGroup} from './ToolbarGroup';
+import {ToolbarWrapToContext} from './ToolbarRerender';
 import type {ToolbarBaseProps, ToolbarData} from './types';
 
 import './Toolbar.scss';
@@ -15,6 +16,10 @@ export type ToolbarProps<E> = ToolbarBaseProps<E> & {
     data: ToolbarData<E>;
 };
 
+/**
+ The component is not memoized. To optimize number of rerenders,
+ memoize component yourself and wrap it in a toolbar context (use ToolbarProvider component).
+ */
 export function Toolbar<E>({
     editor,
     data,
@@ -28,26 +33,28 @@ export function Toolbar<E>({
     disableTooltip,
 }: ToolbarProps<E>) {
     return (
-        <div className={b({display}, [className])} data-qa={qa}>
-            {data.map<React.ReactNode>((group, index) => {
-                const isLastGroup = index === data.length - 1;
+        <ToolbarWrapToContext editor={editor}>
+            <div className={b({display}, [className])} data-qa={qa}>
+                {data.map<React.ReactNode>((group, index) => {
+                    const isLastGroup = index === data.length - 1;
 
-                return (
-                    <Fragment key={index}>
-                        <ToolbarButtonGroup
-                            data={group}
-                            editor={editor}
-                            focus={focus}
-                            onClick={onClick}
-                            className={b('group')}
-                            disableHotkey={disableHotkey}
-                            disablePreview={disablePreview}
-                            disableTooltip={disableTooltip}
-                        />
-                        {isLastGroup || <div className={b('group-separator')} />}
-                    </Fragment>
-                );
-            })}
-        </div>
+                    return (
+                        <Fragment key={index}>
+                            <ToolbarButtonGroup
+                                data={group}
+                                editor={editor}
+                                focus={focus}
+                                onClick={onClick}
+                                className={b('group')}
+                                disableHotkey={disableHotkey}
+                                disablePreview={disablePreview}
+                                disableTooltip={disableTooltip}
+                            />
+                            {isLastGroup || <div className={b('group-separator')} />}
+                        </Fragment>
+                    );
+                })}
+            </div>
+        </ToolbarWrapToContext>
     );
 }

--- a/packages/editor/src/toolbar/ToolbarButton.tsx
+++ b/packages/editor/src/toolbar/ToolbarButton.tsx
@@ -7,6 +7,7 @@ import {i18n} from '../i18n/common';
 import {isFunction} from '../lodash';
 
 import {ToolbarTooltipDelay} from './const';
+import {useActionState} from './hooks';
 import type {ToolbarBaseProps, ToolbarItemData} from './types';
 
 import './ToolbarButton.scss';
@@ -111,10 +112,8 @@ export const ToolbarButtonView = forwardRef<HTMLButtonElement, ToolbarButtonView
 );
 
 export function ToolbarButton<E>(props: ToolbarButtonProps<E>) {
-    const {id, editor, focus, isActive, isEnable, exec, onClick} = props;
-
-    const active = isActive(editor);
-    const enabled = isEnable(editor);
+    const {id, editor, focus, exec, onClick} = props;
+    const {active, enabled} = useActionState(editor, props);
 
     const handleClick = () => {
         focus();

--- a/packages/editor/src/toolbar/ToolbarButtonPopup.tsx
+++ b/packages/editor/src/toolbar/ToolbarButtonPopup.tsx
@@ -1,19 +1,18 @@
 import {useBooleanState, useElementState} from '../react-utils/hooks';
 
 import {ToolbarButtonView} from './ToolbarButton';
+import {useActionState} from './hooks';
 import type {ToolbarBaseProps, ToolbarButtonPopupData} from './types';
 
 export type ToolbarButtonPopupProps<E> = ToolbarBaseProps<E> & ToolbarButtonPopupData<E>;
 
 export function ToolbarButtonPopup<E>(props: ToolbarButtonPopupProps<E>) {
-    const {className, editor, isActive, isEnable, renderPopup, disableTooltip, ...buttonProps} =
-        props;
+    const {className, editor, renderPopup, disableTooltip, ...buttonProps} = props;
 
     const [anchorElement, setAnchorElement] = useElementState();
     const [isOpen, , close, toggle] = useBooleanState(false);
 
-    const active = isActive(editor);
-    const enabled = isEnable(editor);
+    const {active, enabled} = useActionState(editor, props);
 
     return (
         <>

--- a/packages/editor/src/toolbar/ToolbarGroup.tsx
+++ b/packages/editor/src/toolbar/ToolbarGroup.tsx
@@ -1,10 +1,9 @@
-import {Fragment} from 'react';
-
 import {cn} from '../classname';
 
 import {ToolbarButton} from './ToolbarButton';
 import {ToolbarButtonPopup} from './ToolbarButtonPopup';
 import {ToolbarListButton} from './ToolbarListButton';
+import {ToolbarUpdateOnRerender} from './ToolbarRerender';
 import {type ToolbarBaseProps, ToolbarDataType, type ToolbarGroupData} from './types';
 
 import './ToolbarGroup.scss';
@@ -77,24 +76,33 @@ export function ToolbarButtonGroup<E>({
 
                 if (item.type === ToolbarDataType.ReactComponent) {
                     const Component = item.component;
-                    return (
+                    const renderFn = () => (
                         <Component
                             {...item.props}
-                            key={item.id}
                             editor={editor}
                             focus={focus}
                             onClick={onClick}
                             className={b(item.type, {id: item.id}, [item.className])}
                         />
                     );
+                    return item.noRerenderOnUpdate ? (
+                        renderFn()
+                    ) : (
+                        <ToolbarUpdateOnRerender key={item.id} content={renderFn} />
+                    );
                 }
 
                 if (item.type === ToolbarDataType.ReactNode) {
-                    return <Fragment key={item.id}>{item.content}</Fragment>;
+                    return <ToolbarUpdateOnRerender key={item.id} content={() => item.content} />;
                 }
 
                 if (item.type === ToolbarDataType.ReactNodeFn) {
-                    return <Fragment key={item.id}>{item.content(editor)}</Fragment>;
+                    return (
+                        <ToolbarUpdateOnRerender
+                            key={item.id}
+                            content={() => item.content(editor)}
+                        />
+                    );
                 }
 
                 return null;

--- a/packages/editor/src/toolbar/ToolbarListButton.tsx
+++ b/packages/editor/src/toolbar/ToolbarListButton.tsx
@@ -13,6 +13,7 @@ import {useBooleanState, useElementState} from '../react-utils/hooks';
 
 import {PreviewTooltip} from './PreviewTooltip';
 import {ToolbarButtonView} from './ToolbarButton';
+import {useActionsState} from './hooks';
 import type {
     ToolbarBaseProps,
     ToolbarButtonPopupData,
@@ -55,7 +56,9 @@ export function ToolbarListButton<E>({
     const [popupItem, setPopupItem] = useState<ToolbarButtonPopupData<E>>();
     const zIndex = useTargetZIndex(LAYOUT.STICKY_TOOLBAR);
 
-    const everyDisabled = alwaysActive ? false : data.every((item) => !item.isEnable(editor));
+    const actionsState = useActionsState(editor, data);
+
+    const everyDisabled = alwaysActive ? false : actionsState.every((item) => !item.enabled);
     const popupOpen = everyDisabled ? false : open;
     const shouldForceHide = open && !popupOpen;
 
@@ -67,7 +70,9 @@ export function ToolbarListButton<E>({
 
     if (data.length === 0) return null;
 
-    const activeItem = data.find((item) => item.isActive(editor) && !item.doNotActivateList);
+    const activeItem = data.find(
+        (item, idx) => actionsState[idx].active && !item.doNotActivateList,
+    );
     const someActive = alwaysActive ? false : Boolean(activeItem);
 
     if (replaceActiveIcon && someActive && activeItem) {
@@ -106,24 +111,15 @@ export function ToolbarListButton<E>({
             >
                 <Menu size="l" className={b('menu')} qa={qaMenu} data-toolbar-menu-for={titleText}>
                     {data
-                        .map((data) => {
-                            const {
-                                id,
-                                title,
-                                icon,
-                                hotkey,
-                                isActive,
-                                isEnable,
-                                exec,
-                                hint,
-                                hintWhenDisabled,
-                                preview,
-                            } = data;
+                        .map((data, idx) => {
+                            const {id, title, icon, hotkey, exec, hint, hintWhenDisabled, preview} =
+                                data;
 
                             const titleText = isFunction(title) ? title() : title;
                             const hintText = isFunction(hint) ? hint() : hint;
 
-                            const disabled = !isEnable(editor);
+                            const actionState = actionsState[idx];
+                            const disabled = !actionState.enabled;
 
                             const hideHintWhenDisabled = hintWhenDisabled === false || !disabled;
                             const hintWhenDisabledText =
@@ -165,8 +161,8 @@ export function ToolbarListButton<E>({
                                             <Menu.Item
                                                 key={id}
                                                 ref={ref}
-                                                active={isActive(editor)}
-                                                disabled={!isEnable(editor)}
+                                                active={actionState.active}
+                                                disabled={disabled}
                                                 onClick={handleClick}
                                                 iconStart={
                                                     <Icon data={icon.data} size={icon.size ?? 16} />

--- a/packages/editor/src/toolbar/ToolbarRerender.tsx
+++ b/packages/editor/src/toolbar/ToolbarRerender.tsx
@@ -1,0 +1,66 @@
+import {type PropsWithChildren, useEffect, useMemo} from 'react';
+
+import {useUpdate} from 'react-use';
+
+import {EventEmitter} from 'src/utils';
+
+import {
+    type ToolbarContextValue,
+    type ToolbarEvents,
+    ToolbarProvider,
+    useToolbarContext,
+} from './context';
+
+export type ToolbarRerenderWrapperProps = {
+    content: () => React.ReactNode;
+};
+
+/**
+ Rerender the content when an update event is received in the event bus from the context.
+ @internal
+ */
+// TODO [major]: Always expect the toolbar to be wrapped in context; remove this component as unnecessary.
+export function ToolbarUpdateOnRerender({content}: ToolbarRerenderWrapperProps) {
+    const rerender = useUpdate();
+    const context = useToolbarContext();
+
+    useEffect(() => {
+        if (!context) return undefined;
+        context.eventBus.on('update', rerender);
+        return () => {
+            context.eventBus.off('update', rerender);
+        };
+    }, [context, rerender]);
+
+    return <>{content()}</>;
+}
+
+type ToolbarWrapToContextProps<E> = PropsWithChildren<{
+    editor: E;
+}>;
+
+/**
+ If there is no external context, wraps the content in the toolbar context
+ and emits an update event on each component re-render.
+ @internal
+ */
+// TODO [major]: Always expect the toolbar to be wrapped in context; remove this component as unnecessary.
+export function ToolbarWrapToContext<E>({editor, children}: ToolbarWrapToContextProps<E>) {
+    const outerContext = useToolbarContext();
+    const innerContext = useMemo(() => {
+        if (outerContext) return undefined;
+        const eventBus = new EventEmitter<ToolbarEvents>();
+        return {editor, eventBus} satisfies ToolbarContextValue<E>;
+    }, [editor, outerContext]);
+
+    useEffect(() => {
+        innerContext?.eventBus.emit('update', null);
+    });
+
+    // wrapping in inner context only if there is no outer context
+    return innerContext ? (
+        <ToolbarProvider value={innerContext}>{children}</ToolbarProvider>
+    ) : (
+        <>{children}</>
+    );
+}

--- a/packages/editor/src/toolbar/context.ts
+++ b/packages/editor/src/toolbar/context.ts
@@ -1,0 +1,22 @@
+import {createContext, useContext} from 'react';
+
+import type {Receiver} from 'src/utils/event-emitter';
+
+export type ToolbarEvents = {
+    update: null;
+};
+
+// TODO: [major] pass to context all other methods (focus, onClick, etc.)
+export type ToolbarContextValue<E> = {
+    editor: E;
+    eventBus: Receiver<ToolbarEvents>;
+};
+
+// TODO: specify generic editor type
+const ToolbarContext = createContext<ToolbarContextValue<unknown> | undefined>(undefined);
+
+export const ToolbarProvider = ToolbarContext.Provider;
+
+export function useToolbarContext<E>(): ToolbarContextValue<E> {
+    return useContext(ToolbarContext) as ToolbarContextValue<E>;
+}

--- a/packages/editor/src/toolbar/hooks.ts
+++ b/packages/editor/src/toolbar/hooks.ts
@@ -1,0 +1,94 @@
+import {useEffect, useState} from 'react';
+
+import {useLatest} from 'react-use';
+
+import {isEqual} from 'src/lodash';
+
+import {useToolbarContext} from './context';
+import type {ToolbarItemData} from './types';
+
+export type UseActionStateReturn = {
+    active: boolean;
+    enabled: boolean;
+};
+
+export type ToolbarAction<E> = Pick<ToolbarItemData<E>, 'isActive' | 'isEnable'>;
+
+export function useActionState<E>(
+    editor: E,
+    {isActive, isEnable}: ToolbarAction<E>,
+): UseActionStateReturn {
+    const context = useToolbarContext();
+    const eventBus = context?.eventBus;
+
+    const [state, setState] = useState<UseActionStateReturn>({
+        active: false,
+        enabled: true,
+    });
+    const stateRef = useLatest(state);
+
+    useEffect(() => {
+        const onUpdate = () => {
+            const newActive = isActive(editor);
+            const newEnabled = isEnable(editor);
+
+            const {active, enabled} = stateRef.current;
+            if (active !== newActive || enabled !== newEnabled) {
+                setState({
+                    active: newActive,
+                    enabled: newEnabled,
+                });
+            }
+        };
+
+        onUpdate();
+
+        if (eventBus) {
+            eventBus.on('update', onUpdate);
+            return () => eventBus.off('update', onUpdate);
+        }
+
+        return undefined;
+    }, [editor, isActive, isEnable, eventBus, stateRef]);
+
+    return state;
+}
+
+export function useActionsState<E>(editor: E, actions: ToolbarAction<E>[]): UseActionStateReturn[] {
+    const context = useToolbarContext();
+    const eventBus = context?.eventBus;
+
+    const [state, setState] = useState<UseActionStateReturn[]>(() =>
+        actions.map(() => ({
+            active: false,
+            enabled: true,
+        })),
+    );
+    const stateRef = useLatest(state);
+
+    useEffect(() => {
+        const onUpdate = () => {
+            const currentState = stateRef.current;
+            const newState = actions.map(({isActive, isEnable}) => ({
+                active: isActive(editor),
+                enabled: isEnable(editor),
+            }));
+            if (!isEqual(currentState, newState)) {
+                setState(newState);
+            }
+        };
+
+        onUpdate();
+
+        if (eventBus) {
+            eventBus.on('update', onUpdate);
+            return () => eventBus.off('update', onUpdate);
+        }
+
+        return undefined;
+    }, [actions, editor, eventBus, stateRef]);
+
+    return state.length === actions.length
+        ? state
+        : actions.map(() => ({active: false, enabled: true}));
+}

--- a/packages/editor/src/toolbar/index.ts
+++ b/packages/editor/src/toolbar/index.ts
@@ -5,3 +5,5 @@ export * from './ToolbarButton';
 export * from './ToolbarGroup';
 export * from './ToolbarListButton';
 export * from './FlexToolbar';
+
+export {ToolbarProvider, useToolbarContext, type ToolbarContextValue} from './context';

--- a/packages/editor/src/toolbar/types.ts
+++ b/packages/editor/src/toolbar/types.ts
@@ -83,6 +83,7 @@ export type ToolbarReactComponentData<E> = {
     width: number;
     className?: string;
     component: React.ComponentType<ToolbarBaseProps<E>>;
+    noRerenderOnUpdate?: boolean;
     props?: object;
 };
 


### PR DESCRIPTION
- optimized re-rendering of toolbar in editor (wysiwyg and markup mode)
- `Toolbar` and `FlexToolbar` components now expects to be wrapped in a context (`ToolbarProvider` component) containing an event bus. Controls within toolbar update their state when receiving an "update" event via the event bus.
- for backward compatibility, `Toolbar` and `FlexToolbar` components continue to work without context. However, this will be removed in the next major version.
- For custom toolbar controls (with `type=ToolbarDataType.ReactComponent`), you can use the `useToolbarContext()` hook to access the context and event bus. This way, you can manually subscribe to "update" event. Set `noRerenderOnUpdate:true` to disable component re-rendering; otherwise, toolbar will re-render your component when it receives the "update" event.