### PR TITLE
refactor(Image,ImgSize): extend Image base extension instead of replacing it

### DIFF
--- a/packages/editor/src/extensions/markdown/Image/ImageSpecs/const.ts
+++ b/packages/editor/src/extensions/markdown/Image/ImageSpecs/const.ts
@@ -1,0 +1,8 @@
+export const imageNodeName = 'image';
+
+export const ImageAttr = {
+    Src: 'src',
+    Alt: 'alt',
+    Title: 'title',
+    Loading: 'loading',
+} as const;

--- a/packages/editor/src/extensions/markdown/Image/ImageSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Image/ImageSpecs/index.ts
@@ -1,15 +1,13 @@
 import type {ExtensionAuto} from '../../../../core';
 import {nodeTypeFactory} from '../../../../utils/schema';
 
-export const imageNodeName = 'image';
-export const imageType = nodeTypeFactory(imageNodeName);
+import {ImageAttr, imageNodeName} from './const';
+import {imageToMarkdown} from './utils';
 
-export const ImageAttr = {
-    Src: 'src',
-    Alt: 'alt',
-    Title: 'title',
-    Loading: 'loading',
-} as const;
+export {ImageAttr, imageNodeName} from './const';
+export {imageToMarkdown} from './utils';
+
+export const imageType = nodeTypeFactory(imageNodeName);
 
 export const ImageSpecs: ExtensionAuto = (builder) => {
     builder.addNode(imageNodeName, () => ({
@@ -52,26 +50,6 @@ export const ImageSpecs: ExtensionAuto = (builder) => {
                 }),
             },
         },
-        toMd: (state, {attrs}) => {
-            let result = '![';
-
-            if (attrs.alt) {
-                result += state.esc(attrs.alt);
-            }
-
-            result += '](';
-
-            if (attrs.src) {
-                result += state.esc(attrs.src);
-            }
-
-            if (attrs.title) {
-                result += ` ${state.quote(attrs.title)}`;
-            }
-
-            result += ')';
-
-            state.write(result);
-        },
+        toMd: imageToMarkdown(),
     }));
 };

--- a/packages/editor/src/extensions/markdown/Image/ImageSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Image/ImageSpecs/index.ts
@@ -5,7 +5,7 @@ import {ImageAttr, imageNodeName} from './const';
 import {imageToMarkdown} from './utils';
 
 export {ImageAttr, imageNodeName} from './const';
-export {imageToMarkdown} from './utils';
+export {imageToMarkdown, type ImageToMarkdownParams} from './utils';
 
 export const imageType = nodeTypeFactory(imageNodeName);
 

--- a/packages/editor/src/extensions/markdown/Image/ImageSpecs/utils.ts
+++ b/packages/editor/src/extensions/markdown/Image/ImageSpecs/utils.ts
@@ -4,7 +4,7 @@ import type {SerializerNodeToken} from '#core';
 
 import {ImageAttr} from './const';
 
-type ImageToMarkdownParams = {
+export type ImageToMarkdownParams = {
     /** Extra content to append before the closing ')'. Receives state and node, returns string. */
     renderExtra?: (state: Parameters<SerializerNodeToken>[0], node: Node) => string;
 };

--- a/packages/editor/src/extensions/markdown/Image/ImageSpecs/utils.ts
+++ b/packages/editor/src/extensions/markdown/Image/ImageSpecs/utils.ts
@@ -1,0 +1,31 @@
+import type {Node} from 'prosemirror-model';
+
+import type {SerializerNodeToken} from '#core';
+
+import {ImageAttr} from './const';
+
+type ImageToMarkdownParams = {
+    /** Extra content to append before the closing ')'. Receives state and node, returns string. */
+    renderExtra?: (state: Parameters<SerializerNodeToken>[0], node: Node) => string;
+};
+
+export function imageToMarkdown({renderExtra}: ImageToMarkdownParams = {}): SerializerNodeToken {
+    return (state, node) => {
+        const {attrs} = node;
+        let result = '![';
+
+        if (attrs[ImageAttr.Alt]) result += state.esc(attrs[ImageAttr.Alt]);
+
+        result += '](';
+
+        if (attrs[ImageAttr.Src]) result += state.esc(attrs[ImageAttr.Src]);
+
+        if (attrs[ImageAttr.Title]) result += ` ${state.quote(attrs[ImageAttr.Title])}`;
+
+        if (renderExtra) result += renderExtra(state, node);
+
+        result += ')';
+
+        state.write(result);
+    };
+}

--- a/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/const.ts
+++ b/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/const.ts
@@ -1,11 +1,10 @@
 import {ImsizeAttr} from '@diplodoc/transform/lib/plugins/imsize/const.js';
 
+import {ImageAttr} from 'src/extensions/markdown/Image/ImageSpecs/const';
+
 export const ImgSizeAttr = {
-    Alt: ImsizeAttr.Alt,
-    Src: ImsizeAttr.Src,
-    Title: ImsizeAttr.Title,
+    ...ImageAttr,
     Width: ImsizeAttr.Width,
     Height: ImsizeAttr.Height,
-    Loading: 'loading',
     Id: 'id',
 } as const;

--- a/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/const.ts
+++ b/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/const.ts
@@ -1,6 +1,8 @@
 import {ImsizeAttr} from '@diplodoc/transform/lib/plugins/imsize/const.js';
 
-import {ImageAttr} from 'src/extensions/markdown/Image/ImageSpecs/const';
+import {ImageAttr} from '../../../markdown/Image/ImageSpecs/const';
+
+export {imageNodeName} from '../../../markdown/Image/ImageSpecs/const';
 
 export const ImgSizeAttr = {
     ...ImageAttr,

--- a/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/index.ts
+++ b/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/index.ts
@@ -3,12 +3,12 @@ import imsize from '@diplodoc/transform/lib/plugins/imsize/index.js';
 import isNumber from 'is-number';
 import type {NodeSpec} from 'prosemirror-model';
 
-import type {ExtensionAuto} from '../../../../core';
-import {imageToMarkdown} from '../../../markdown/Image/ImageSpecs';
-import {imageNodeName} from '../../../markdown/Image/const';
+import type {ExtensionAuto} from '#core';
 
-import {ImgSizeAttr} from './const';
-import {renderImgSizeExtra} from './utils';
+import {ImageSpecs} from '../../../markdown/Image/ImageSpecs';
+
+import {ImgSizeAttr, imageNodeName} from './const';
+import {imageToMarkdown, renderImgSizeExtra} from './utils';
 
 export {ImgSizeAttr};
 
@@ -21,6 +21,10 @@ export type ImgSizeSpecsOptions = {
 
 export const ImgSizeSpecs: ExtensionAuto<ImgSizeSpecsOptions> = (builder, opts) => {
     const placeholderContent = builder.context.get('placeholder')?.imgSize;
+
+    if (!builder.hasNodeSpec(imageNodeName)) {
+        builder.use(ImageSpecs);
+    }
 
     builder.configureMd((md) => md.use(imsize, {log, enableInlineStyling: true}));
 

--- a/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/index.ts
+++ b/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/index.ts
@@ -4,19 +4,11 @@ import isNumber from 'is-number';
 import type {NodeSpec} from 'prosemirror-model';
 
 import type {ExtensionAuto} from '../../../../core';
+import {imageToMarkdown} from '../../../markdown/Image/ImageSpecs';
 import {imageNodeName} from '../../../markdown/Image/const';
 
 import {ImgSizeAttr} from './const';
-
-type ImsizeTypedAttributes = {
-    [ImgSizeAttr.Src]: string;
-    [ImgSizeAttr.Title]: string | null;
-    [ImgSizeAttr.Alt]: string | null;
-    [ImgSizeAttr.Width]: string | null;
-    [ImgSizeAttr.Height]: string | null;
-    [ImgSizeAttr.Loading]: string | null;
-    [ImgSizeAttr.Id]: string | null;
-};
+import {renderImgSizeExtra} from './utils';
 
 export {ImgSizeAttr};
 
@@ -31,91 +23,51 @@ export const ImgSizeSpecs: ExtensionAuto<ImgSizeSpecsOptions> = (builder, opts) 
     const placeholderContent = builder.context.get('placeholder')?.imgSize;
 
     builder.configureMd((md) => md.use(imsize, {log, enableInlineStyling: true}));
-    builder.addNode(imageNodeName, () => ({
-        spec: {
-            inline: true,
-            attrs: {
-                [ImgSizeAttr.Src]: {},
-                [ImgSizeAttr.Alt]: {default: null},
-                [ImgSizeAttr.Title]: {default: null},
-                [ImgSizeAttr.Height]: {default: null},
-                [ImgSizeAttr.Width]: {default: null},
-                [ImgSizeAttr.Loading]: {default: null},
-                [ImgSizeAttr.Id]: {default: null},
-            },
-            placeholder: placeholderContent ? {content: placeholderContent} : opts.placeholder,
-            group: 'inline',
-            draggable: true,
-            parseDOM: [
-                {
-                    tag: 'img[src]',
-                    getAttrs(dom) {
-                        const height = (dom as Element).getAttribute(ImgSizeAttr.Height);
-                        const width = (dom as Element).getAttribute(ImgSizeAttr.Width);
 
-                        return {
-                            [ImgSizeAttr.Src]: (dom as Element).getAttribute(ImgSizeAttr.Src),
-                            [ImgSizeAttr.Alt]: (dom as Element).getAttribute(ImgSizeAttr.Alt),
-                            [ImgSizeAttr.Title]: (dom as Element).getAttribute(ImgSizeAttr.Title),
-                            [ImgSizeAttr.Loading]: (dom as Element).getAttribute(
-                                ImgSizeAttr.Loading,
-                            ),
-                            [ImgSizeAttr.Height]: isNumber(height) ? height : null,
-                            [ImgSizeAttr.Width]: isNumber(width) ? height : null,
-                            [ImgSizeAttr.Id]: (dom as Element).getAttribute(ImgSizeAttr.Id),
-                        };
-                    },
+    builder.overrideNodeSpec(imageNodeName, (prev) => ({
+        ...prev,
+        attrs: {
+            ...prev.attrs,
+            [ImgSizeAttr.Height]: {default: null},
+            [ImgSizeAttr.Width]: {default: null},
+            [ImgSizeAttr.Id]: {default: null},
+        },
+        placeholder: placeholderContent ? {content: placeholderContent} : opts.placeholder,
+        parseDOM: [
+            {
+                tag: 'img[src]',
+                getAttrs(dom) {
+                    const height = (dom as Element).getAttribute(ImgSizeAttr.Height);
+                    const width = (dom as Element).getAttribute(ImgSizeAttr.Width);
+
+                    return {
+                        [ImgSizeAttr.Src]: (dom as Element).getAttribute(ImgSizeAttr.Src),
+                        [ImgSizeAttr.Alt]: (dom as Element).getAttribute(ImgSizeAttr.Alt),
+                        [ImgSizeAttr.Title]: (dom as Element).getAttribute(ImgSizeAttr.Title),
+                        [ImgSizeAttr.Loading]: (dom as Element).getAttribute(ImgSizeAttr.Loading),
+                        [ImgSizeAttr.Height]: isNumber(height) ? height : null,
+                        [ImgSizeAttr.Width]: isNumber(width) ? width : null,
+                        [ImgSizeAttr.Id]: (dom as Element).getAttribute(ImgSizeAttr.Id),
+                    };
                 },
-            ],
-            toDOM(node) {
-                return ['img', node.attrs];
             },
-        },
-        fromMd: {
-            tokenSpec: {
-                name: imageNodeName,
-                type: 'node',
-                getAttrs: (tok): ImsizeTypedAttributes => ({
-                    [ImgSizeAttr.Src]: tok.attrGet(ImgSizeAttr.Src)!,
-                    [ImgSizeAttr.Title]: tok.attrGet(ImgSizeAttr.Title),
-                    [ImgSizeAttr.Height]: tok.attrGet(ImgSizeAttr.Height),
-                    [ImgSizeAttr.Width]: tok.attrGet(ImgSizeAttr.Width),
-                    [ImgSizeAttr.Loading]: tok.attrGet(ImgSizeAttr.Loading),
-                    [ImgSizeAttr.Alt]: tok.children?.[0]?.content || null,
-                    [ImgSizeAttr.Id]: tok.attrGet(ImgSizeAttr.Id),
-                }),
-            },
-        },
-        toMd: (state, node) => {
-            const attrs = node.attrs as ImsizeTypedAttributes;
-            let result = '![';
-
-            if (attrs.alt) {
-                result += state.esc(attrs.alt);
-            }
-
-            result += '](';
-
-            if (attrs.src) {
-                result += state.esc(attrs.src);
-            }
-
-            if (attrs.title) {
-                result += ` ${state.quote(attrs.title)}`;
-            }
-
-            result += getSize(attrs);
-            result += ')';
-
-            state.write(result);
-        },
+        ],
     }));
+
+    builder.overrideMarkdownTokenParserSpec(imageNodeName, (prev) => ({
+        ...prev,
+        getAttrs: (tok) => ({
+            [ImgSizeAttr.Src]: tok.attrGet(ImgSizeAttr.Src)!,
+            [ImgSizeAttr.Title]: tok.attrGet(ImgSizeAttr.Title),
+            [ImgSizeAttr.Height]: tok.attrGet(ImgSizeAttr.Height),
+            [ImgSizeAttr.Width]: tok.attrGet(ImgSizeAttr.Width),
+            [ImgSizeAttr.Loading]: tok.attrGet(ImgSizeAttr.Loading),
+            [ImgSizeAttr.Alt]: tok.children?.[0]?.content || null,
+            [ImgSizeAttr.Id]: tok.attrGet(ImgSizeAttr.Id),
+        }),
+    }));
+
+    builder.overrideNodeSerializerSpec(imageNodeName, () =>
+        imageToMarkdown({renderExtra: renderImgSizeExtra}),
+    );
 };
-
-function getSize({width, height}: ImsizeTypedAttributes): string {
-    if (width || height) {
-        return ` =${width || ''}x${height || ''}`;
-    }
-
-    return '';
-}

--- a/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/utils.ts
+++ b/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/utils.ts
@@ -1,11 +1,15 @@
-import type {Node} from '#pm/model';
+import type {ImageToMarkdownParams} from '../../../markdown/Image/ImageSpecs/utils';
 
 import type {ImgSizeAttr} from './const';
 
-export function renderImgSizeExtra(_state: unknown, node: Node): string {
+export {imageToMarkdown} from '../../../markdown/Image/ImageSpecs/utils';
+
+type RenderImageExtra = NonNullable<ImageToMarkdownParams['renderExtra']>;
+
+export const renderImgSizeExtra: RenderImageExtra = (_state, node): string => {
     const {width, height} = node.attrs as {
         [ImgSizeAttr.Width]: string | null;
         [ImgSizeAttr.Height]: string | null;
     };
     return width || height ? ` =${width || ''}x${height || ''}` : '';
-}
+};

--- a/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/utils.ts
+++ b/packages/editor/src/extensions/yfm/ImgSize/ImgSizeSpecs/utils.ts
@@ -1,0 +1,11 @@
+import type {Node} from '#pm/model';
+
+import type {ImgSizeAttr} from './const';
+
+export function renderImgSizeExtra(_state: unknown, node: Node): string {
+    const {width, height} = node.attrs as {
+        [ImgSizeAttr.Width]: string | null;
+        [ImgSizeAttr.Height]: string | null;
+    };
+    return width || height ? ` =${width || ''}x${height || ''}` : '';
+}

--- a/packages/editor/src/extensions/yfm/ImgSize/YfmImage.test.ts
+++ b/packages/editor/src/extensions/yfm/ImgSize/YfmImage.test.ts
@@ -1,9 +1,9 @@
+import {DOMParser} from 'prosemirror-model';
 import {builders} from 'prosemirror-test-builder';
 
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base';
-import {ImageSpecs} from '../../markdown/Image/ImageSpecs';
 
 import {ImgSizeSpecs} from './ImgSizeSpecs';
 import {ImgSizeAttr, imageNodeName} from './const';
@@ -13,7 +13,7 @@ const {
     markupParser: parser,
     serializer,
 } = new ExtensionsManager({
-    extensions: (builder) => builder.use(BaseSchema, {}).use(ImageSpecs).use(ImgSizeSpecs, {}),
+    extensions: (builder) => builder.use(BaseSchema, {}).use(ImgSizeSpecs, {}),
 }).buildDeps();
 
 const {doc, p, img, img2, img3, img4} = builders<'doc' | 'p' | 'img' | 'img2' | 'img3' | 'img4'>(
@@ -62,5 +62,16 @@ describe('Image extension', () => {
 
     it('should parse image with size, alt and title', () => {
         same('![alt text 2](img4.png "title text 2" =400x300)', doc(p(img4())));
+    });
+
+    it('should correctly parse width and height from HTML img element', () => {
+        const dom = document.createElement('div');
+        dom.innerHTML = '<img src="img.png" width="200" height="100">';
+
+        const parsed = DOMParser.fromSchema(schema).parse(dom);
+        const imgNode = parsed.firstChild!.firstChild!;
+
+        expect(imgNode.attrs[ImgSizeAttr.Width]).toBe('200');
+        expect(imgNode.attrs[ImgSizeAttr.Height]).toBe('100');
     });
 });

--- a/packages/editor/src/extensions/yfm/ImgSize/YfmImage.test.ts
+++ b/packages/editor/src/extensions/yfm/ImgSize/YfmImage.test.ts
@@ -3,6 +3,7 @@ import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base';
+import {ImageSpecs} from '../../markdown/Image/ImageSpecs';
 
 import {ImgSizeSpecs} from './ImgSizeSpecs';
 import {ImgSizeAttr, imageNodeName} from './const';
@@ -12,7 +13,7 @@ const {
     markupParser: parser,
     serializer,
 } = new ExtensionsManager({
-    extensions: (builder) => builder.use(BaseSchema, {}).use(ImgSizeSpecs, {}),
+    extensions: (builder) => builder.use(BaseSchema, {}).use(ImageSpecs).use(ImgSizeSpecs, {}),
 }).buildDeps();
 
 const {doc, p, img, img2, img3, img4} = builders<'doc' | 'p' | 'img' | 'img2' | 'img3' | 'img4'>(

--- a/packages/editor/src/presets/yfm-specs.ts
+++ b/packages/editor/src/presets/yfm-specs.ts
@@ -47,7 +47,6 @@ export type YfmSpecsPresetOptions = Omit<DefaultSpecsPresetOptions, 'heading' | 
 export const YfmSpecsPreset: ExtensionAuto<YfmSpecsPresetOptions> = (builder, opts) => {
     builder.use(DefaultSpecsPreset, {
         ...opts,
-        image: false,
         heading: opts.yfmHeading,
     } satisfies DefaultSpecsPresetOptions);
 

--- a/packages/editor/src/presets/yfm.ts
+++ b/packages/editor/src/presets/yfm.ts
@@ -7,6 +7,7 @@ import {
     Underline,
     type UnderlineOptions,
 } from '../extensions/markdown';
+import {ImageSpecs} from '../extensions/markdown/Image/ImageSpecs';
 import {
     Checkbox,
     type CheckboxOptions,
@@ -49,7 +50,7 @@ export type YfmPresetOptions = Omit<DefaultPresetOptions, 'heading' | 'image'> &
 export const YfmPreset: ExtensionAuto<YfmPresetOptions> = (builder, opts) => {
     builder.use(DefaultPreset, {
         ...opts,
-        image: false,
+        image: ImageSpecs,
         heading: opts.yfmHeading,
     } satisfies DefaultPresetOptions);
 


### PR DESCRIPTION
## Summary
- Replace `builder.addNode(...)` in `ImgSizeSpecs` with `overrideNodeSpec` / `overrideMarkdownTokenParserSpec` / `overrideNodeSerializerSpec`, eliminating duplication of the base `image` node spec (same pattern applied to `YfmHeading` previously)
- Extract `imageToMarkdown()` serializer factory to `ImageSpecs/utils.ts` so `ImgSizeSpecs` can extend it via `renderExtra` callback instead of copy-pasting the serializer logic
- Update `yfm.ts` and `yfm-specs.ts` presets so `ImageSpecs` is loaded through the base preset and `ImgSize` only overrides it; fix pre-existing bug `isNumber(width) ? height : null` → `isNumber(width) ? width : null`