### PR TITLE
test: updated circular-deps check configuration

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -26,7 +26,7 @@
     "test:cov": "jest --coverage",
     "test:watch": "jest --watchAll",
     "test:esbuild": "node tests/esbuild-test/esbuild-tester.js",
-    "test:circular-deps": "node scripts/check-circular-deps.js 47",
+    "test:circular-deps": "node scripts/check-circular-deps.js 13",
     "prepack": "cp ../../README.md ./README.md",
     "postpack": "rm -f ./README.md",
     "prepublishOnly": "pnpm run lint && pnpm run clean && pnpm run build"

--- a/packages/editor/scripts/check-circular-deps.js
+++ b/packages/editor/scripts/check-circular-deps.js
@@ -3,10 +3,14 @@ const process = require('process');
 
 const {parseDependencyTree, parseCircular, prettyCircular} = require('dpdm');
 
-const threshold = parseInt(process.argv[2], 10) || 99; // Default to 99 if no argument provided
+const threshold = process.argv[2] !== undefined ? parseInt(process.argv[2], 10) : 0;
+if (isNaN(threshold)) {
+    console.error(`Invalid threshold argument: "${process.argv[2]}"`);
+    process.exit(1);
+}
 
 parseDependencyTree('./src/index.ts', {
-    /* options, see https://github.com/acrazing/dpdm?tab=readme-ov-file#api-reference */
+    transform: true,
 }).then((tree) => {
     const circulars = parseCircular(tree);
     if (circulars.length > threshold) {


### PR DESCRIPTION
1. Fixed the condition. `parseInt('0', 10) || 99` evaluates to 99 and threshold of 0 was never reachable. 
2. Added the flag to count only actual runtime cycles. Without `transform: true`, dpdm treats `import type` as runtime dependencies, reporting 34 phantom cycles (47 total vs 13 real).
