### PR TITLE
fix(behavior): fix circular deps

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -26,7 +26,7 @@
     "test:cov": "jest --coverage",
     "test:watch": "jest --watchAll",
     "test:esbuild": "node tests/esbuild-test/esbuild-tester.js",
-    "test:circular-deps": "node scripts/check-circular-deps.js 13",
+    "test:circular-deps": "node scripts/check-circular-deps.js 12",
     "prepack": "cp ../../README.md ./README.md",
     "postpack": "rm -f ./README.md",
     "prepublishOnly": "pnpm run lint && pnpm run clean && pnpm run build"

--- a/packages/editor/src/extensions/behavior/WidgetDecoration/WidgetDescriptor.ts
+++ b/packages/editor/src/extensions/behavior/WidgetDecoration/WidgetDescriptor.ts
@@ -4,7 +4,7 @@ import type {EditorView} from 'prosemirror-view';
 import {uniqueId} from '../../../lodash';
 
 import {removeDecoration} from './actions';
-import {widgetDecorationPluginKey} from './plugin';
+import {widgetDecorationPluginKey} from './plugin-key';
 import type {Meta} from './types';
 
 export abstract class WidgetDescriptor {

--- a/packages/editor/src/extensions/behavior/WidgetDecoration/actions.ts
+++ b/packages/editor/src/extensions/behavior/WidgetDecoration/actions.ts
@@ -1,6 +1,6 @@
 import type {Transaction} from 'prosemirror-state';
 
-import {widgetDecorationPluginKey} from './plugin';
+import {widgetDecorationPluginKey} from './plugin-key';
 import type {Meta} from './types';
 
 export const removeDecoration = (tr: Transaction, id: string) => {

--- a/packages/editor/src/extensions/behavior/WidgetDecoration/index.ts
+++ b/packages/editor/src/extensions/behavior/WidgetDecoration/index.ts
@@ -3,7 +3,7 @@ import type {ExtensionAuto} from '../../../core';
 import {WidgetDecorationPlugin} from './plugin';
 
 export {removeDecoration} from './actions';
-export {widgetDecorationPluginKey} from './plugin';
+export {widgetDecorationPluginKey} from './plugin-key';
 export {WidgetDescriptor} from './WidgetDescriptor';
 export {ReactWidgetDescriptor} from './ReactWidgetDescriptor';
 

--- a/packages/editor/src/extensions/behavior/WidgetDecoration/plugin-key.ts
+++ b/packages/editor/src/extensions/behavior/WidgetDecoration/plugin-key.ts
@@ -1,0 +1,4 @@
+import {PluginKey} from 'prosemirror-state';
+import type {DecorationSet} from 'prosemirror-view';
+
+export const widgetDecorationPluginKey = new PluginKey<DecorationSet>();

--- a/packages/editor/src/extensions/behavior/WidgetDecoration/plugin.ts
+++ b/packages/editor/src/extensions/behavior/WidgetDecoration/plugin.ts
@@ -1,9 +1,8 @@
-import {Plugin, PluginKey} from 'prosemirror-state';
+import {Plugin} from 'prosemirror-state';
 import {Decoration, DecorationSet} from 'prosemirror-view';
 
+import {widgetDecorationPluginKey} from './plugin-key';
 import type {Meta, WidgetSpec} from './types';
-
-export const widgetDecorationPluginKey = new PluginKey<DecorationSet>();
 
 export const WidgetDecorationPlugin = () => {
     return new Plugin<DecorationSet>({

--- a/packages/editor/src/plugins/BaseTooltip/index.tsx
+++ b/packages/editor/src/plugins/BaseTooltip/index.tsx
@@ -6,7 +6,10 @@ import {findDomRefAtPos, findParentNodeOfType, findSelectedNodeOfType} from 'pro
 import type {EditorView} from 'prosemirror-view';
 
 import {cn} from '../../classname';
-import {type RendererItem, getReactRendererFromState} from '../../extensions';
+import {
+    type RendererItem,
+    getReactRendererFromState,
+} from '../../extensions/behavior/ReactRenderer';
 import {ErrorLoggerBoundary} from '../../react-utils/ErrorBoundary';
 
 import './index.scss';


### PR DESCRIPTION
Fixes #1035

**Category A** — `BaseTooltip` imported `getReactRendererFromState` through the `../../extensions` barrel,
which pulled in the whole extension graph including BaseTooltipPluginView. In CJS this caused a
TDZ crash. 

Fix: import directly from the defining module.

**Category B** — `WidgetDecoration/plugin.ts` declared `widgetDecorationPluginKey` and also imported
`actions.ts` and `WidgetDescriptor.ts`; both of those imported `plugin.ts` for the key.

Fix: extract the key to `plugin-key.ts`.

