### PR TITLE
fix(YfmHeading): remove implicit HeadingSpecs dependency

### DIFF
--- a/packages/editor/src/extensions/additional/FoldingHeading/FoldingHeadingSpec/FoldingHeadingSpecs.test.ts
+++ b/packages/editor/src/extensions/additional/FoldingHeading/FoldingHeadingSpec/FoldingHeadingSpecs.test.ts
@@ -3,7 +3,7 @@ import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../../tests/sameMarkup';
 import {ExtensionsManager} from '../../../../core';
 import {BaseNode, BaseSchemaSpecs} from '../../../base/specs';
-import {HeadingSpecs, ItalicSpecs, headingNodeName, italicMarkName} from '../../../markdown/specs';
+import {ItalicSpecs, headingNodeName, italicMarkName} from '../../../markdown/specs';
 import {YfmHeadingAttr, YfmHeadingSpecs} from '../../../yfm/specs';
 
 import {FoldingHeadingSpecs} from './FoldingHeadingSpecs';
@@ -13,7 +13,6 @@ const {schema, markupParser, serializer} = new ExtensionsManager({
         builder
             .use(BaseSchemaSpecs, {})
             .use(ItalicSpecs)
-            .use(HeadingSpecs, {})
             .use(YfmHeadingSpecs, {})
             .use(FoldingHeadingSpecs),
 }).buildDeps();

--- a/packages/editor/src/extensions/yfm/YfmHeading/YfmHeading.test.ts
+++ b/packages/editor/src/extensions/yfm/YfmHeading/YfmHeading.test.ts
@@ -5,7 +5,7 @@ import {parseDOM} from '../../../../tests/parse-dom';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchemaSpecs} from '../../base/specs';
-import {BoldSpecs, HeadingSpecs, boldMarkName, headingNodeName} from '../../markdown/specs';
+import {BoldSpecs, boldMarkName, headingNodeName} from '../../markdown/specs';
 import {YfmConfigsSpecs} from '../specs';
 
 import {YfmHeadingAttr, YfmHeadingSpecs} from './YfmHeadingSpecs';
@@ -18,7 +18,6 @@ const {
     extensions: (builder) =>
         builder
             .use(BaseSchemaSpecs, {})
-            .use(HeadingSpecs, {})
             .use(YfmConfigsSpecs, {attrs: {allowedAttributes: ['id']}})
             .use(YfmHeadingSpecs, {})
             .use(BoldSpecs),
@@ -115,7 +114,6 @@ describe('Heading extension', () => {
                 builder
                     .use(BaseSchemaSpecs, {})
                     .use(BoldSpecs)
-                    .use(HeadingSpecs, {})
                     .use(YfmConfigsSpecs, {disableAttrs: true})
                     .use(YfmHeadingSpecs, {}),
         }).buildDeps();

--- a/packages/editor/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/index.ts
+++ b/packages/editor/src/extensions/yfm/YfmHeading/YfmHeadingSpecs/index.ts
@@ -1,8 +1,10 @@
 import type {ExtensionAuto} from '#core';
+
 import {
+    HeadingSpecs,
     type HeadingSpecsOptions,
     headingToMarkdown,
-} from 'src/extensions/markdown/Heading/HeadingSpecs';
+} from '../../../markdown/Heading/HeadingSpecs';
 
 import {YfmHeadingAttr, headingNodeName} from './const';
 import {headingIdsPlugin} from './markdown/heading-ids';
@@ -14,7 +16,11 @@ export {renderYfmHeadingAttributes, renderYfmHeadingMarkup} from './utils';
 export type YfmHeadingSpecsOptions = HeadingSpecsOptions & {};
 
 /** YfmHeading extension needs markdown-it-attrs plugin */
-export const YfmHeadingSpecs: ExtensionAuto<YfmHeadingSpecsOptions> = (builder, _opts) => {
+export const YfmHeadingSpecs: ExtensionAuto<YfmHeadingSpecsOptions> = (builder, opts) => {
+    if (!builder.hasNodeSpec(headingNodeName)) {
+        builder.use(HeadingSpecs, opts);
+    }
+
     builder.configureMd((md) => md.use(headingIdsPlugin));
 
     builder.overrideNodeSpec(headingNodeName, (prev) => ({


### PR DESCRIPTION
`YfmHeadingSpecs` previously relied on `HeadingSpecs` being manually added, creating a hidden dependency. Now auto-includes `HeadingSpecs` when needed, making the extension self-contained and safe to use without explicit imports.