### PR TITLE
refactor(Math): use new builder methods to register nodes

### DIFF
--- a/packages/editor/src/extensions/additional/Math/MathSpecs/const.ts
+++ b/packages/editor/src/extensions/additional/Math/MathSpecs/const.ts
@@ -3,6 +3,11 @@ export enum MathNode {
     Block = 'math_display',
 }
 
+export const MathToken = {
+    Inline: 'math_inline',
+    Block: 'math_block',
+} as const;
+
 export const CLASSNAMES = {
     Inline: {
         Container: 'math-inline',

--- a/packages/editor/src/extensions/additional/Math/MathSpecs/index.ts
+++ b/packages/editor/src/extensions/additional/Math/MathSpecs/index.ts
@@ -1,9 +1,9 @@
 import {transform} from '@diplodoc/latex-extension';
 
-import type {ExtensionAuto} from '../../../../core';
-import {nodeTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {nodeTypeFactory} from 'src/utils/schema';
 
-import {CLASSNAMES, MathNode} from './const';
+import {CLASSNAMES, MathNode, MathToken} from './const';
 
 export {MathNode} from './const';
 export const mathIType = nodeTypeFactory(MathNode.Inline);
@@ -11,49 +11,50 @@ export const mathBType = nodeTypeFactory(MathNode.Block);
 
 export const MathSpecs: ExtensionAuto = (builder) => {
     builder.configureMd((md) => md.use(transform({bundle: false, validate: false}), {output: ''}));
+
     builder
-        .addNode(MathNode.Inline, () => ({
-            spec: {
-                group: 'inline math',
-                content: 'text*',
-                inline: true,
-                marks: '',
-                code: true,
-                toDOM: () => [
-                    'span',
-                    {class: CLASSNAMES.Inline.Container},
-                    ['span', {class: CLASSNAMES.Inline.Sharp, contenteditable: 'false'}, '$'],
-                    ['span', {class: CLASSNAMES.Inline.Content}, 0],
-                    ['span', {class: CLASSNAMES.Inline.Sharp, contenteditable: 'false'}, '$'],
-                ],
-                parseDOM: [{tag: `span.${CLASSNAMES.Inline.Content}`, priority: 200}],
-            },
-            fromMd: {
-                tokenName: 'math_inline',
-                tokenSpec: {name: MathNode.Inline, type: 'block', noCloseToken: true},
-            },
-            toMd: (state, node) => {
-                state.text(`$${node.textContent}$`, false);
-                state.closeBlock();
-            },
+        .addNodeSpec(MathNode.Inline, () => ({
+            group: 'inline math',
+            content: 'text*',
+            inline: true,
+            marks: '',
+            code: true,
+            toDOM: () => [
+                'span',
+                {class: CLASSNAMES.Inline.Container},
+                ['span', {class: CLASSNAMES.Inline.Sharp, contenteditable: 'false'}, '$'],
+                ['span', {class: CLASSNAMES.Inline.Content}, 0],
+                ['span', {class: CLASSNAMES.Inline.Sharp, contenteditable: 'false'}, '$'],
+            ],
+            parseDOM: [{tag: `span.${CLASSNAMES.Inline.Content}`, priority: 200}],
         }))
-        .addNode(MathNode.Block, () => ({
-            spec: {
-                group: 'block math',
-                content: 'text*',
-                marks: '',
-                code: true,
-                toDOM: () => ['div', {class: 'math-block'}, 0],
-                parseDOM: [{tag: 'div.math-block', priority: 200}],
-                selectable: true,
-            },
-            fromMd: {
-                tokenName: 'math_block',
-                tokenSpec: {name: MathNode.Block, type: 'block', noCloseToken: true},
-            },
-            toMd: (state, node) => {
-                state.text(`$$${node.textContent}$$\n\n`, false);
-                state.closeBlock();
-            },
-        }));
+        .addMarkdownTokenParserSpec(MathToken.Inline, () => ({
+            type: 'block',
+            name: MathNode.Inline,
+            noCloseToken: true,
+        }))
+        .addNodeSerializerSpec(MathNode.Inline, () => (state, node) => {
+            state.text(`$${node.textContent}$`, false);
+            state.closeBlock();
+        });
+
+    builder
+        .addNodeSpec(MathNode.Block, () => ({
+            group: 'block math',
+            content: 'text*',
+            marks: '',
+            code: true,
+            toDOM: () => ['div', {class: 'math-block'}, 0],
+            parseDOM: [{tag: 'div.math-block', priority: 200}],
+            selectable: true,
+        }))
+        .addMarkdownTokenParserSpec(MathToken.Block, () => ({
+            type: 'block',
+            name: MathNode.Block,
+            noCloseToken: true,
+        }))
+        .addNodeSerializerSpec(MathNode.Block, () => (state, node) => {
+            state.text(`$$${node.textContent}$$\n\n`, false);
+            state.closeBlock();
+        });
 };


### PR DESCRIPTION
Replace `builder.addNode(...)` in `MathSpecs ` with `addNodeSpec`, `addMarkdownTokenParserSpec` and `addNodeSerializerSpec`