### PR TITLE
refactor(BaseSchema): use new builder methods to register nodes

### DIFF
--- a/packages/editor/src/extensions/base/BaseSchema/BaseSchemaSpecs/index.ts
+++ b/packages/editor/src/extensions/base/BaseSchema/BaseSchemaSpecs/index.ts
@@ -20,84 +20,83 @@ export type BaseSchemaSpecsOptions = {
 };
 
 export const BaseSchemaSpecs: ExtensionAuto<BaseSchemaSpecsOptions> = (builder, opts) => {
+    builder.addNodeSpec(BaseNode.Doc, () => ({
+        content: 'block+',
+    }));
+
+    // TODO: Remove unnecessary token and serializer specs when ExtensionBuilder and ExtensionManager are ready
     builder
-        .addNode(BaseNode.Doc, () => ({
-            spec: {
-                content: 'block+',
+        .addMarkdownTokenParserSpec(BaseNode.Doc, () => ({
+            name: BaseNode.Doc,
+            type: 'block',
+            ignore: true,
+        }))
+        .addNodeSerializerSpec(BaseNode.Doc, () => () => {
+            throw new Error('Unexpected toMd() call on doc node');
+        });
+
+    builder
+        .addNodeSpec(BaseNode.Text, () => ({
+            group: 'inline',
+        }))
+        // TODO: Remove unnecessary token specs when ExtensionBuilder and ExtensionManager are ready
+        .addMarkdownTokenParserSpec(BaseNode.Text, () => ({
+            name: BaseNode.Text,
+            type: 'node',
+            ignore: true,
+        }))
+        .addNodeSerializerSpec(BaseNode.Text, () => (state, node, parent) => {
+            const {escapeText} = parent.type.spec;
+            state.text(node.text ?? '', escapeText ?? !state.isAutolink);
+        });
+
+    builder
+        .addNodeSpec(BaseNode.Paragraph, () => ({
+            attrs: {[paragraphLineNumberAttr]: {default: null}},
+            content: 'inline*',
+            group: 'block',
+            parseDOM: [{tag: 'p'}],
+            toDOM(node) {
+                const lineNumber = node.attrs[paragraphLineNumberAttr];
+                return ['p', lineNumber === null ? {} : {[paragraphLineNumberAttr]: lineNumber}, 0];
             },
-            fromMd: {tokenSpec: {name: BaseNode.Doc, type: 'block', ignore: true}},
-            toMd: () => {
-                throw new Error('Unexpected toMd() call on doc node');
+            selectable: true,
+            placeholder: opts.paragraphPlaceholder
+                ? {
+                      content: opts.paragraphPlaceholder,
+                      alwaysVisible: false,
+                  }
+                : undefined,
+        }))
+        .addMarkdownTokenParserSpec('paragraph', () => ({
+            name: BaseNode.Paragraph,
+            type: 'block',
+            getAttrs(token) {
+                return Object.fromEntries(token.attrs || []);
             },
         }))
-        .addNode(BaseNode.Text, () => ({
-            spec: {
-                group: 'inline',
-            },
-            fromMd: {tokenSpec: {name: BaseNode.Text, type: 'node', ignore: true}},
-            toMd: (state, node, parent) => {
-                const {escapeText} = parent.type.spec;
-                state.text(node.text ?? '', escapeText ?? !state.isAutolink);
-            },
-        }))
-        .addNode(BaseNode.Paragraph, () => ({
-            spec: {
-                attrs: {[paragraphLineNumberAttr]: {default: null}},
-                content: 'inline*',
-                group: 'block',
-                parseDOM: [{tag: 'p'}],
-                toDOM(node) {
-                    const lineNumber = node.attrs[paragraphLineNumberAttr];
+        .addNodeSerializerSpec(BaseNode.Paragraph, () => (state, node, parent) => {
+            /*
+                An empty line is added only if there is some content in the parent element.
+                This is necessary in order to prevent an empty document with empty lines
+            */
+            if (opts.preserveEmptyRows && isEmptyString(node)) {
+                let isParentEmpty = true;
 
-                    return [
-                        'p',
-                        lineNumber === null ? {} : {[paragraphLineNumberAttr]: lineNumber},
-                        0,
-                    ];
-                },
-                selectable: true,
-                placeholder: opts.paragraphPlaceholder
-                    ? {
-                          content: opts.paragraphPlaceholder,
-                          alwaysVisible: false,
-                      }
-                    : undefined,
-            },
-            fromMd: {
-                tokenSpec: {
-                    name: BaseNode.Paragraph,
-                    type: 'block',
-                    getAttrs(token) {
-                        return Object.fromEntries(token.attrs || []);
-                    },
-                },
-            },
-            toMd: (state, node, parent) => {
-                /*
-                    An empty line is added only if there is some content in the parent element.
-                    This is necessary in order to prevent an empty document with empty lines
-                */
-                if (opts.preserveEmptyRows && isEmptyString(node)) {
-                    let isParentEmpty = true;
-
-                    for (let index = 0; index < parent.content.childCount; index++) {
-                        const parentChild = parent.content.child(index);
-                        if (
-                            parentChild.content.size !== 0 ||
-                            parentChild.type.name !== 'paragraph'
-                        ) {
-                            isParentEmpty = false;
-                        }
+                for (let index = 0; index < parent.content.childCount; index++) {
+                    const parentChild = parent.content.child(index);
+                    if (parentChild.content.size !== 0 || parentChild.type.name !== 'paragraph') {
+                        isParentEmpty = false;
                     }
-
-                    if (!isParentEmpty) {
-                        state.write('&nbsp;\n');
-                        state.write('\n');
-                    }
-                } else {
-                    state.renderInline(node);
-                    state.closeBlock(node);
                 }
-            },
-        }));
+
+                if (!isParentEmpty) {
+                    state.write('&nbsp;\n');
+                    state.write('\n');
+                }
+            } else {
+                state.renderInline(node);
+                state.closeBlock(node);
+            }
+        });
 };


### PR DESCRIPTION
Replace `builder.addNode(...)` in `BaseSchema` with `addNodeSpec`, `addMarkdownTokenParserSpec` and `addNodeSerializerSpec`

## Summary by Sourcery

Enhancements:
- Register doc, text, and paragraph nodes via separate node spec, markdown token parser spec, and node serializer spec builder methods instead of the legacy combined addNode API.