### PR TITLE
refactor(core): unify node/mark/parser/serializer pipelines in ExtensionBuilder

### DIFF
--- a/packages/editor/src/core/ExtensionBuilder.test.ts
+++ b/packages/editor/src/core/ExtensionBuilder.test.ts
@@ -3,7 +3,7 @@ import {Plugin} from 'prosemirror-state';
 import {Logger2} from '../logger';
 
 import {ExtensionBuilder} from './ExtensionBuilder';
-import type {ExtensionDeps, ExtensionMarkSpec} from './types/extension';
+import type {ExtensionDeps, ExtensionMarkSpec, ExtensionNodeSpec} from './types/extension';
 
 const logger = new Logger2().nested({env: 'test'});
 
@@ -100,13 +100,13 @@ describe('ExtensionBuilder', () => {
         const marksList: {name: string; spec: ExtensionMarkSpec}[] = [];
         marksOrderedMap.forEach((name, spec) => marksList.push({name, spec}));
         expect(marksList[0].name).toBe('mark0');
-        expect(marksList[0].spec.spec).toBe(mark0.spec);
+        expect(marksList[0].spec === mark0).toBe(true);
         expect(marksList[1].name).toBe('mark1');
-        expect(marksList[1].spec.spec).toBe(mark1.spec);
+        expect(marksList[1].spec === mark1).toBe(true);
         expect(marksList[2].name).toBe('mark2');
-        expect(marksList[2].spec.spec).toBe(mark2.spec);
+        expect(marksList[2].spec === mark2).toBe(true);
         expect(marksList[3].name).toBe('mark3');
-        expect(marksList[3].spec.spec).toBe(mark3.spec);
+        expect(marksList[3].spec === mark3).toBe(true);
     });
 
     it('should add plugins', () => {
@@ -1385,6 +1385,156 @@ describe('ExtensionBuilder', () => {
                 .forEach((name) => markNames.push(name));
 
             expect(markNames).toEqual(['a', 'b', 'c']);
+        });
+    });
+
+    describe('regression', () => {
+        it('should throw when addMarkdownTokenParserSpec tokenName collides with addNode entity owning that token', () => {
+            const builder = new ExtensionBuilder(logger)
+                .addNode('foo', () => ({
+                    spec: {},
+                    fromMd: {tokenSpec: {type: 'block', name: 'foo'}},
+                    toMd: () => {},
+                }))
+                .addMarkdownTokenParserSpec('foo', () => ({name: 'bar', type: 'block'}))
+                .addNodeSpec('bar', () => ({}))
+                .addNodeSerializerSpec('bar', () => () => {});
+
+            expect(() => builder.build().nodes()).toThrow(/already owned/);
+        });
+
+        it('should throw when addMarkdownTokenParserSpec collides with an explicit fromMd.tokenName from addNode', () => {
+            const builder = new ExtensionBuilder(logger)
+                .addNode('foo', () => ({
+                    spec: {},
+                    fromMd: {tokenName: 'custom_tok', tokenSpec: {type: 'block', name: 'foo'}},
+                    toMd: () => {},
+                }))
+                .addMarkdownTokenParserSpec('custom_tok', () => ({name: 'bar', type: 'block'}))
+                .addNodeSpec('bar', () => ({}))
+                .addNodeSerializerSpec('bar', () => () => {});
+
+            expect(() => builder.build().nodes()).toThrow(/already owned/);
+        });
+
+        it('should allow addMarkdownTokenParserSpec targeting the same addNode entity (extra parser token)', () => {
+            const builder = new ExtensionBuilder(logger)
+                .addNode('code_block', () => ({
+                    spec: {group: 'block', code: true},
+                    fromMd: {tokenSpec: {type: 'block', name: 'code_block', noCloseToken: true}},
+                    toMd: () => {},
+                }))
+                .addMarkdownTokenParserSpec('fence', () => ({
+                    name: 'code_block',
+                    type: 'block',
+                    noCloseToken: true,
+                }));
+
+            const nodes = builder.build().nodes();
+            expect(nodes.get('code_block')).toBeTruthy();
+            expect(nodes.get('fence')).toBeTruthy();
+            expect(nodes.get('fence')!.fromMd.tokenSpec.name).toBe('code_block');
+        });
+
+        it('should preserve original object identity for addNode entries without overrides', () => {
+            const original: ExtensionNodeSpec = {
+                spec: {group: 'block'},
+                fromMd: {tokenSpec: {type: 'block', name: 'identity_node'}},
+                toMd: () => {},
+            };
+            const nodes = new ExtensionBuilder(logger)
+                .addNode('identity_node', () => original)
+                .build()
+                .nodes();
+
+            expect(nodes.get('identity_node')).toBe(original);
+        });
+
+        it('should preserve original object identity for addMark entries without overrides', () => {
+            const original: ExtensionMarkSpec = {
+                spec: {},
+                fromMd: {tokenSpec: {type: 'mark', name: 'identity_mark'}},
+                toMd: {open: '', close: ''},
+            };
+            const marks = new ExtensionBuilder(logger)
+                .addMark('identity_mark', () => original)
+                .build()
+                .marks();
+
+            expect(marks.get('identity_mark')).toBe(original);
+        });
+
+        it('should NOT preserve identity when overrideNodeSpec modifies the entry', () => {
+            const original: ExtensionNodeSpec = {
+                spec: {group: 'block'},
+                fromMd: {tokenSpec: {type: 'block', name: 'n'}},
+                toMd: () => {},
+            };
+            const nodes = new ExtensionBuilder(logger)
+                .addNode('n', () => original)
+                .overrideNodeSpec('n', (prev) => ({...prev, group: 'block custom'}))
+                .build()
+                .nodes();
+
+            expect(nodes.get('n')).not.toBe(original);
+            expect(nodes.get('n')!.spec.group).toBe('block custom');
+        });
+
+        it('should NOT preserve identity when overrideMarkdownTokenParserSpec modifies the primary token', () => {
+            const original: ExtensionNodeSpec = {
+                spec: {},
+                fromMd: {tokenSpec: {type: 'block', name: 'n'}},
+                toMd: () => {},
+            };
+            const nodes = new ExtensionBuilder(logger)
+                .addNode('n', () => original)
+                .overrideMarkdownTokenParserSpec('n', (prev) => ({...prev, noCloseToken: true}))
+                .build()
+                .nodes();
+
+            expect(nodes.get('n')).not.toBe(original);
+            expect(nodes.get('n')!.fromMd.tokenSpec.noCloseToken).toBe(true);
+        });
+
+        it('should preserve identity when overrideMarkdownTokenParserSpec modifies only an EXTRA parser token', () => {
+            const original: ExtensionNodeSpec = {
+                spec: {group: 'block'},
+                fromMd: {tokenSpec: {type: 'block', name: 'code_block'}},
+                toMd: () => {},
+            };
+            const nodes = new ExtensionBuilder(logger)
+                .addNode('code_block', () => original)
+                .addMarkdownTokenParserSpec('fence', () => ({
+                    name: 'code_block',
+                    type: 'block',
+                    noCloseToken: true,
+                }))
+                .overrideMarkdownTokenParserSpec('fence', (prev) => ({
+                    ...prev,
+                    noCloseToken: false,
+                }))
+                .build()
+                .nodes();
+
+            // The main entity is unchanged — its primary token 'code_block' was not overridden.
+            expect(nodes.get('code_block')).toBe(original);
+            // The extra parser-only entry reflects the override.
+            expect(nodes.get('fence')!.fromMd.tokenSpec.noCloseToken).toBe(false);
+        });
+
+        it('should NOT preserve identity when overrideNodeSerializerSpec modifies the entry', () => {
+            const original: ExtensionNodeSpec = {
+                spec: {},
+                fromMd: {tokenSpec: {type: 'block', name: 'n'}},
+                toMd: () => {},
+            };
+            const nodes = new ExtensionBuilder(logger)
+                .addNode('n', () => original)
+                .overrideNodeSerializerSpec('n', (prev) => prev)
+                .build()
+                .nodes();
+
+            expect(nodes.get('n')).not.toBe(original);
         });
     });
 });

--- a/packages/editor/src/core/ExtensionBuilder.test.ts
+++ b/packages/editor/src/core/ExtensionBuilder.test.ts
@@ -100,13 +100,13 @@ describe('ExtensionBuilder', () => {
         const marksList: {name: string; spec: ExtensionMarkSpec}[] = [];
         marksOrderedMap.forEach((name, spec) => marksList.push({name, spec}));
         expect(marksList[0].name).toBe('mark0');
-        expect(marksList[0].spec === mark0).toBe(true);
+        expect(marksList[0].spec.spec).toBe(mark0.spec);
         expect(marksList[1].name).toBe('mark1');
-        expect(marksList[1].spec === mark1).toBe(true);
+        expect(marksList[1].spec.spec).toBe(mark1.spec);
         expect(marksList[2].name).toBe('mark2');
-        expect(marksList[2].spec === mark2).toBe(true);
+        expect(marksList[2].spec.spec).toBe(mark2.spec);
         expect(marksList[3].name).toBe('mark3');
-        expect(marksList[3].spec === mark3).toBe(true);
+        expect(marksList[3].spec.spec).toBe(mark3.spec);
     });
 
     it('should add plugins', () => {
@@ -732,6 +732,72 @@ describe('ExtensionBuilder', () => {
                 new ExtensionBuilder(logger).overrideMarkSerializerSpec('unknown', (prev) => prev),
             ).toThrow(/not registered/);
         });
+
+        it('should chain multiple parser overrides receiving previous result as prev', () => {
+            const nodes = new ExtensionBuilder(logger)
+                .addNodeSpec('myNode', () => ({}))
+                .addMarkdownTokenParserSpec('my_tok', () => ({
+                    name: 'myNode',
+                    type: 'block',
+                }))
+                .addNodeSerializerSpec('myNode', () => () => {})
+                .overrideMarkdownTokenParserSpec('my_tok', (prev) => ({
+                    ...prev,
+                    noCloseToken: true,
+                }))
+                .overrideMarkdownTokenParserSpec('my_tok', (prev) => {
+                    // Must see the previous override applied
+                    expect(prev.noCloseToken).toBe(true);
+                    return {...prev, ignore: true};
+                })
+                .build()
+                .nodes();
+
+            const myNode = nodes.get('myNode');
+            expect(myNode!.fromMd.tokenSpec.noCloseToken).toBe(true);
+            expect(myNode!.fromMd.tokenSpec.ignore).toBe(true);
+        });
+
+        it('should chain multiple serializer overrides receiving previous result as prev', () => {
+            const firstToMd = jest.fn();
+            const secondToMd = jest.fn();
+
+            const nodes = new ExtensionBuilder(logger)
+                .addNode('node', () => ({
+                    spec: {},
+                    fromMd: {tokenSpec: {type: 'block', name: 'node'}},
+                    toMd: () => {},
+                }))
+                .overrideNodeSerializerSpec('node', () => firstToMd)
+                .overrideNodeSerializerSpec('node', (prev) => {
+                    // Must see the previous override result
+                    expect(prev).toBe(firstToMd);
+                    return secondToMd;
+                })
+                .build()
+                .nodes();
+
+            expect(nodes.get('node')!.toMd).toBe(secondToMd);
+        });
+
+        it('should apply multiple overrideNodeSpec cascades in order', () => {
+            const nodes = new ExtensionBuilder(logger)
+                .addNodeSpec('myNode', () => ({group: 'block'}))
+                .addMarkdownTokenParserSpec('my_tok', () => ({name: 'myNode', type: 'block'}))
+                .addNodeSerializerSpec('myNode', () => () => {})
+                .overrideNodeSpec('myNode', (prev) => ({...prev, content: 'inline*'}))
+                .overrideNodeSpec('myNode', (prev) => {
+                    expect(prev.content).toBe('inline*');
+                    return {...prev, marks: ''};
+                })
+                .build()
+                .nodes();
+
+            const myNode = nodes.get('myNode');
+            expect(myNode!.spec.group).toBe('block');
+            expect(myNode!.spec.content).toBe('inline*');
+            expect(myNode!.spec.marks).toBe('');
+        });
     });
 
     describe('addNode/addMark conflict with granular methods', () => {
@@ -1200,6 +1266,125 @@ describe('ExtensionBuilder', () => {
             expect(builder.hasMarkSpec('mark1')).toBe(true);
             expect(builder.hasMarkSpec('mark2')).toBe(true);
             expect(builder.hasMarkSpec('mark3')).toBe(false);
+        });
+    });
+
+    describe('insertion order preservation across APIs', () => {
+        it('should preserve insertion order across addNode and addNodeSpec', () => {
+            const nodeNames: string[] = [];
+            new ExtensionBuilder(logger)
+                .addNode('a', () => ({
+                    spec: {},
+                    fromMd: {tokenSpec: {type: 'block', name: 'a'}},
+                    toMd: () => {},
+                }))
+                .addNodeSpec('b', () => ({group: 'block'}))
+                .addMarkdownTokenParserSpec('b_tok', () => ({name: 'b', type: 'block'}))
+                .addNodeSerializerSpec('b', () => () => {})
+                .addNode('c', () => ({
+                    spec: {},
+                    fromMd: {tokenSpec: {type: 'block', name: 'c'}},
+                    toMd: () => {},
+                }))
+                .build()
+                .nodes()
+                .forEach((name) => nodeNames.push(name));
+
+            expect(nodeNames).toEqual(['a', 'b', 'c']);
+        });
+
+        it('should preserve insertion order among marks with same explicit priority', () => {
+            const markNames: string[] = [];
+            new ExtensionBuilder(logger)
+                .addMark(
+                    'a',
+                    () => ({
+                        spec: {},
+                        fromMd: {tokenSpec: {type: 'mark', name: 'a'}},
+                        toMd: {open: '', close: ''},
+                    }),
+                    ExtensionBuilder.Priority.High,
+                )
+                .addMark(
+                    'b',
+                    () => ({
+                        spec: {},
+                        fromMd: {tokenSpec: {type: 'mark', name: 'b'}},
+                        toMd: {open: '', close: ''},
+                    }),
+                    ExtensionBuilder.Priority.High,
+                )
+                .addMark(
+                    'c',
+                    () => ({
+                        spec: {},
+                        fromMd: {tokenSpec: {type: 'mark', name: 'c'}},
+                        toMd: {open: '', close: ''},
+                    }),
+                    ExtensionBuilder.Priority.High,
+                )
+                .build()
+                .marks()
+                .forEach((name) => markNames.push(name));
+
+            expect(markNames).toEqual(['a', 'b', 'c']);
+        });
+
+        it('should inherit entity priority for extra parser-only mark entries', () => {
+            const markNames: string[] = [];
+            new ExtensionBuilder(logger)
+                .addMark(
+                    'lowPriority',
+                    () => ({
+                        spec: {},
+                        fromMd: {tokenSpec: {type: 'mark', name: 'lowPriority'}},
+                        toMd: {open: '', close: ''},
+                    }),
+                    ExtensionBuilder.Priority.Low,
+                )
+                .addMark(
+                    'highPriority',
+                    () => ({
+                        spec: {},
+                        fromMd: {tokenSpec: {type: 'mark', name: 'highPriority'}},
+                        toMd: {open: '', close: ''},
+                    }),
+                    ExtensionBuilder.Priority.High,
+                )
+                // Extra parser-only token targeting the high-priority mark
+                // must inherit its priority and sort before the low-priority mark.
+                .addMarkdownTokenParserSpec('high_extra', () => ({
+                    name: 'highPriority',
+                    type: 'mark',
+                }))
+                .build()
+                .marks()
+                .forEach((name) => markNames.push(name));
+
+            expect(markNames).toEqual(['highPriority', 'high_extra', 'lowPriority']);
+        });
+
+        it('should preserve insertion order across addMark and addMarkSpec with equal priority', () => {
+            const markNames: string[] = [];
+            new ExtensionBuilder(logger)
+                .addMark('a', () => ({
+                    spec: {},
+                    fromMd: {tokenSpec: {type: 'mark', name: 'a'}},
+                    toMd: {open: '', close: ''},
+                }))
+                .addMarkSpec('b', () => ({}))
+                .addMarkdownTokenParserSpec('b_tok', () => ({name: 'b', type: 'mark'}))
+                .addMarkSerializerSpec('b', () => ({open: '', close: ''}))
+                .addMark('c', () => ({
+                    spec: {},
+                    fromMd: {tokenSpec: {type: 'mark', name: 'c'}},
+                    toMd: {open: '', close: ''},
+                }))
+                .build()
+                .marks()
+                .forEach((name) => markNames.push(name));
+
+            expect(markNames).toEqual(['a', 'b', 'c']);
         });
     });
 });

--- a/packages/editor/src/core/ExtensionBuilder.ts
+++ b/packages/editor/src/core/ExtensionBuilder.ts
@@ -43,6 +43,25 @@ type AddPmKeymapCallback = (deps: ExtensionDeps) => Keymap;
 type AddPmInputRulesCallback = (deps: ExtensionDeps) => InputRulesConfig;
 type AddActionCallback = (deps: ExtensionDeps) => ActionSpec;
 
+type EntityPipelineEntry<EntitySpec, SpecBody> =
+    | {type: 'addEntity'; name: string; cb: () => EntitySpec; priority: number}
+    | {type: 'addEntitySpec'; name: string; cb: () => SpecBody; priority: number}
+    | {type: 'overrideEntitySpec'; name: string; cb: (prev: SpecBody) => SpecBody};
+
+type NodePipelineEntry = EntityPipelineEntry<ExtensionNodeSpec, NodeSpec>;
+type MarkPipelineEntry = EntityPipelineEntry<ExtensionMarkSpec, MarkSpec>;
+
+type ParserPipelineEntry =
+    | {type: 'addParserSpec'; tokenName: string; cb: () => ParserToken}
+    | {type: 'overrideParserSpec'; tokenName: string; cb: (prev: ParserToken) => ParserToken};
+
+type SerializerPipelineEntry<SerializerToken> =
+    | {type: 'addSerializer'; name: string; cb: () => SerializerToken}
+    | {type: 'overrideSerializer'; name: string; cb: (prev: SerializerToken) => SerializerToken};
+
+type NodeSerializerPipelineEntry = SerializerPipelineEntry<SerializerNodeToken>;
+type MarkSerializerPipelineEntry = SerializerPipelineEntry<SerializerMarkToken>;
+
 enum Priority {
     Highest = 1_000_000,
     VeryHigh = 100_000,
@@ -67,42 +86,85 @@ declare global {
     }
 }
 
-function applyOverrides<T>(initial: T, overrides?: Array<(prev: T) => T>): T {
-    return overrides ? overrides.reduce((acc, fn) => fn(acc), initial) : initial;
-}
-
 type ResolvedParserEntry = {tokenName: string; tokenSpec: ParserToken};
-type ParserOverridesMap = Record<string, Array<(prev: ParserToken) => ParserToken>>;
 
-function resolveParserEntry(
-    entry: {tokenName: string; tokenSpec: ParserToken},
-    overrides: ParserOverridesMap,
-): ResolvedParserEntry {
-    return {
-        tokenName: entry.tokenName,
-        tokenSpec: applyOverrides(entry.tokenSpec, overrides[entry.tokenName]),
-    };
-}
+function resolveParserPipeline(
+    pipeline: ParserPipelineEntry[],
+    initialPrimaryTokens: Record<string, string>,
+    initialParsers: Record<string, ResolvedParserEntry>,
+) {
+    const primaryParserToken = {...initialPrimaryTokens};
+    const parsers = {...initialParsers};
+    const extraTokenNames: string[] = [];
 
-function resolveGranularParserEntries(
-    entityName: string,
-    entityType: 'node' | 'mark',
-    parserSpecsByEntity: Record<string, ResolvedParserEntry[]>,
-    overrides: ParserOverridesMap,
-): {primary: ResolvedParserEntry; extra: ResolvedParserEntry[]} {
-    const entries = parserSpecsByEntity[entityName];
-    if (!entries || entries.length === 0) {
-        throw new Error(
-            `Incomplete ${entityType} spec for "${entityName}": missing parser spec. ` +
-                `Use addMarkdownTokenParserSpec() to register a parser for this ${entityType}.`,
-        );
+    for (const entry of pipeline) {
+        if (entry.type === 'addParserSpec') {
+            const tokenSpec = entry.cb();
+            const entityName = tokenSpec.name;
+
+            if (primaryParserToken[entityName] === entry.tokenName) {
+                // Same-name token for addNode/addMark entity — skip, already covered
+                continue;
+            }
+
+            if (primaryParserToken[entityName]) {
+                // Extra parser-only token targeting an existing entity
+                extraTokenNames.push(entry.tokenName);
+            } else {
+                // Primary parser for a granular entity
+                primaryParserToken[entityName] = entry.tokenName;
+            }
+            parsers[entry.tokenName] = {tokenName: entry.tokenName, tokenSpec};
+        } else {
+            // overrideParserSpec
+            const existing = parsers[entry.tokenName];
+            if (existing) {
+                parsers[entry.tokenName] = {
+                    tokenName: existing.tokenName,
+                    tokenSpec: entry.cb(existing.tokenSpec),
+                };
+            }
+        }
     }
 
-    const [primaryRaw, ...extraRaw] = entries;
-    return {
-        primary: resolveParserEntry(primaryRaw, overrides),
-        extra: extraRaw.map((e) => resolveParserEntry(e, overrides)),
-    };
+    return {parsers, primaryParserToken, extraTokenNames};
+}
+
+function resolveSerializerPipeline<T>(
+    pipeline: SerializerPipelineEntry<T>[],
+    initialSerializers: Record<string, T>,
+): Record<string, T> {
+    const serializers = {...initialSerializers};
+    for (const entry of pipeline) {
+        if (entry.type === 'addSerializer') {
+            serializers[entry.name] = entry.cb();
+        } else {
+            serializers[entry.name] = entry.cb(serializers[entry.name]);
+        }
+    }
+    return serializers;
+}
+
+function validateGranularSpecs(
+    granularNames: Set<string>,
+    entityType: 'node' | 'mark',
+    primaryParserToken: Record<string, string>,
+    serializers: Record<string, unknown>,
+): void {
+    for (const name of granularNames) {
+        if (!primaryParserToken[name]) {
+            throw new Error(
+                `Incomplete ${entityType} spec for "${name}": missing parser spec. ` +
+                    `Use addMarkdownTokenParserSpec() to register a parser for this ${entityType}.`,
+            );
+        }
+        if (!serializers[name]) {
+            throw new Error(
+                `Incomplete ${entityType} spec for "${name}": missing serializer. ` +
+                    `Use add${entityType === 'node' ? 'Node' : 'Mark'}SerializerSpec() to register a serializer for this ${entityType}.`,
+            );
+        }
+    }
 }
 
 function buildParserOnlyNodeEntry(resolved: ResolvedParserEntry): ExtensionNodeSpec {
@@ -123,6 +185,90 @@ function buildParserOnlyMarkEntry(resolved: ResolvedParserEntry): ExtensionMarkS
     };
 }
 
+function processEntityPipeline<EntitySpec extends ExtensionNodeSpec | ExtensionMarkSpec>(
+    entityType: 'node' | 'mark',
+    entityPipeline: EntityPipelineEntry<EntitySpec, EntitySpec['spec']>[],
+    parserPipeline: ParserPipelineEntry[],
+    serializerPipeline: SerializerPipelineEntry<EntitySpec['toMd']>[],
+    buildParserOnlyEntry: (resolved: ResolvedParserEntry) => EntitySpec,
+): OrderedMap<EntitySpec> {
+    const order: {name: string; priority: number}[] = [];
+    const specs: Record<string, EntitySpec['spec']> = {};
+    const initParsers: Record<string, ResolvedParserEntry> = {};
+    const initSerializers: Record<string, EntitySpec['toMd']> = {};
+    const views: Record<string, EntitySpec['view']> = {};
+    const granularEntities = new Set<string>();
+    const initPrimaryTokens: Record<string, string> = {};
+    const priorityByEntity: Record<string, number> = {};
+
+    // Pass 1: entityPipeline → specs, order, raw parsers/serializers from addEntity
+    for (const entry of entityPipeline) {
+        const {name} = entry;
+
+        if (entry.type === 'addEntity') {
+            const base = entry.cb();
+            const tokenName = base.fromMd.tokenName ?? name;
+            order.push({name, priority: entry.priority});
+            specs[name] = base.spec;
+            initParsers[tokenName] = {tokenName, tokenSpec: base.fromMd.tokenSpec};
+            initPrimaryTokens[name] = tokenName;
+            priorityByEntity[name] = entry.priority;
+            initSerializers[name] = base.toMd;
+            views[name] = base.view;
+        } else if (entry.type === 'addEntitySpec') {
+            order.push({name, priority: entry.priority});
+            specs[name] = entry.cb();
+            priorityByEntity[name] = entry.priority;
+            granularEntities.add(name);
+        } else {
+            // overrideEntitySpec
+            specs[name] = entry.cb(specs[name]);
+        }
+    }
+
+    // Pass 2: parserPipeline → fill/override parsers, add extra parser-only entries
+    const {parsers, primaryParserToken, extraTokenNames} = resolveParserPipeline(
+        parserPipeline,
+        initPrimaryTokens,
+        initParsers,
+    );
+    for (const tokenName of extraTokenNames) {
+        // Inherit priority from the entity this token targets
+        const entityName = parsers[tokenName]?.tokenSpec.name;
+        const priority = entityName ? (priorityByEntity[entityName] ?? 0) : 0;
+        order.push({name: tokenName, priority});
+    }
+
+    // Pass 3: serializerPipeline → fill/override serializers
+    const serializers = resolveSerializerPipeline(serializerPipeline, initSerializers);
+
+    validateGranularSpecs(granularEntities, entityType, primaryParserToken, serializers);
+
+    if (entityType === 'mark') {
+        // The order of marks in schema is important when serializing pm-document to DOM or markup
+        // https://discuss.prosemirror.net/t/marks-priority/4463
+        order.sort((a, b) => b.priority - a.priority);
+    }
+
+    // Assemble
+    let map = OrderedMap.from<EntitySpec>({});
+    for (const {name} of order) {
+        const parserKey = primaryParserToken[name] ?? name;
+        map = map.addToEnd(
+            name,
+            serializers[name]
+                ? ({
+                      spec: specs[name] ?? {},
+                      fromMd: parsers[parserKey],
+                      toMd: serializers[name],
+                      ...(views[name] !== undefined && {view: views[name]}),
+                  } as EntitySpec)
+                : buildParserOnlyEntry(parsers[name]),
+        );
+    }
+    return map;
+}
+
 export class ExtensionBuilder {
     static createContext(): BuilderContext<WysiwygEditor.Context> {
         return new Map();
@@ -135,30 +281,22 @@ export class ExtensionBuilder {
 
     readonly #logger: Logger2.ILogger;
     #confMdCbs: {cb: ConfigureMdCallback; params: Required<ConfigureMdParams>}[] = [];
-    #nodeSpecs: Record<string, {name: string; cb: AddPmNodeCallback}> = {};
-    #markSpecs: Record<string, {name: string; cb: AddPmMarkCallback; priority: number}> = {};
     #plugins: {cb: AddPmPluginCallback; priority: number}[] = [];
     #actions: [string, AddActionCallback][] = [];
 
-    // Granular add storage
-    #rawNodeSpecs: Record<string, () => NodeSpec> = {};
-    #rawMarkSpecs: Record<string, {cb: () => MarkSpec; priority: number}> = {};
-    #rawParserSpecs: Record<string, {tokenName: string; cb: () => ParserToken}> = {};
-    #rawNodeSerializers: Record<string, () => SerializerNodeToken> = {};
-    #rawMarkSerializers: Record<string, () => SerializerMarkToken> = {};
+    // Unified pipelines — preserve registration order across legacy and granular APIs
+    #nodePipeline: NodePipelineEntry[] = [];
+    #nodeIndex: Record<string, {source: 'addNode' | 'addNodeSpec'}> = {};
+    #markPipeline: MarkPipelineEntry[] = [];
+    #markIndex: Record<string, {source: 'addMark' | 'addMarkSpec'}> = {};
 
-    // Override chains
-    #nodeSpecOverrides: Record<string, Array<(prev: NodeSpec) => NodeSpec>> = {};
-    #markSpecOverrides: Record<string, Array<(prev: MarkSpec) => MarkSpec>> = {};
-    #parserSpecOverrides: Record<string, Array<(prev: ParserToken) => ParserToken>> = {};
-    #nodeSerializerOverrides: Record<
-        string,
-        Array<(prev: SerializerNodeToken) => SerializerNodeToken>
-    > = {};
-    #markSerializerOverrides: Record<
-        string,
-        Array<(prev: SerializerMarkToken) => SerializerMarkToken>
-    > = {};
+    // Parser and serializer pipelines
+    #parserPipeline: ParserPipelineEntry[] = [];
+    #parserIndex = new Set<string>();
+    #nodeSerializerPipeline: NodeSerializerPipelineEntry[] = [];
+    #nodeSerializerIndex = new Set<string>();
+    #markSerializerPipeline: MarkSerializerPipelineEntry[] = [];
+    #markSerializerIndex = new Set<string>();
 
     readonly context: BuilderContext<WysiwygEditor.Context>;
 
@@ -190,11 +328,11 @@ export class ExtensionBuilder {
     }
 
     hasNodeSpec(name: string): boolean {
-        return Boolean(this.#nodeSpecs[name]) || Boolean(this.#rawNodeSpecs[name]);
+        return Boolean(this.#nodeIndex[name]);
     }
 
     hasMarkSpec(name: string): boolean {
-        return Boolean(this.#markSpecs[name]) || Boolean(this.#rawMarkSpecs[name]);
+        return Boolean(this.#markIndex[name]);
     }
 
     /**
@@ -202,22 +340,23 @@ export class ExtensionBuilder {
      * Use addNodeSpec() + addMarkdownTokenParserSpec() + addNodeSerializerSpec() instead.
      */
     addNode(name: string, cb: AddPmNodeCallback): this {
-        if (this.#nodeSpecs[name]) {
+        if (this.#nodeIndex[name]?.source === 'addNode') {
             throw new Error(`ProseMirror node with this name "${name}" already exist`);
         }
-        if (this.#rawNodeSpecs[name]) {
+        if (this.#nodeIndex[name]?.source === 'addNodeSpec') {
             throw new Error(
                 `Node with name "${name}" already registered via addNodeSpec. ` +
                     `Cannot use addNode for a node that already has granular registrations.`,
             );
         }
-        if (this.#rawNodeSerializers[name]) {
+        if (this.#nodeSerializerIndex.has(name)) {
             throw new Error(
                 `Node serializer for "${name}" already registered via addNodeSerializerSpec. ` +
                     `Cannot use addNode for a node that already has granular registrations.`,
             );
         }
-        this.#nodeSpecs[name] = {name, cb};
+        this.#nodePipeline.push({type: 'addEntity', name, cb, priority: 0});
+        this.#nodeIndex[name] = {source: 'addNode'};
         return this;
     }
 
@@ -226,22 +365,23 @@ export class ExtensionBuilder {
      * Use addMarkSpec() + addMarkdownTokenParserSpec() + addMarkSerializerSpec() instead.
      */
     addMark(name: string, cb: AddPmMarkCallback, priority = DEFAULT_PRIORITY): this {
-        if (this.#markSpecs[name]) {
+        if (this.#markIndex[name]?.source === 'addMark') {
             throw new Error(`ProseMirror mark with this name "${name}" already exist`);
         }
-        if (this.#rawMarkSpecs[name]) {
+        if (this.#markIndex[name]?.source === 'addMarkSpec') {
             throw new Error(
                 `Mark with name "${name}" already registered via addMarkSpec. ` +
                     `Cannot use addMark for a mark that already has granular registrations.`,
             );
         }
-        if (this.#rawMarkSerializers[name]) {
+        if (this.#markSerializerIndex.has(name)) {
             throw new Error(
                 `Mark serializer for "${name}" already registered via addMarkSerializerSpec. ` +
                     `Cannot use addMark for a mark that already has granular registrations.`,
             );
         }
-        this.#markSpecs[name] = {name, cb, priority};
+        this.#markPipeline.push({type: 'addEntity', name, cb, priority});
+        this.#markIndex[name] = {source: 'addMark'};
         return this;
     }
 
@@ -271,88 +411,93 @@ export class ExtensionBuilder {
     }
 
     addNodeSpec(name: string, cb: () => NodeSpec): this {
-        if (this.#rawNodeSpecs[name]) {
+        if (this.#nodeIndex[name]?.source === 'addNodeSpec') {
             throw new Error(`Node spec with name "${name}" already registered via addNodeSpec`);
         }
-        if (this.#nodeSpecs[name]) {
+        if (this.#nodeIndex[name]?.source === 'addNode') {
             throw new Error(
                 `Node with name "${name}" already registered via addNode. Use overrideNodeSpec to modify it.`,
             );
         }
-        this.#rawNodeSpecs[name] = cb;
+        this.#nodePipeline.push({type: 'addEntitySpec', name, cb, priority: 0});
+        this.#nodeIndex[name] = {source: 'addNodeSpec'};
         return this;
     }
 
     addMarkSpec(name: string, cb: () => MarkSpec, priority = DEFAULT_PRIORITY): this {
-        if (this.#rawMarkSpecs[name]) {
+        if (this.#markIndex[name]?.source === 'addMarkSpec') {
             throw new Error(`Mark spec with name "${name}" already registered via addMarkSpec`);
         }
-        if (this.#markSpecs[name]) {
+        if (this.#markIndex[name]?.source === 'addMark') {
             throw new Error(
                 `Mark with name "${name}" already registered via addMark. Use overrideMarkSpec to modify it.`,
             );
         }
-        this.#rawMarkSpecs[name] = {cb, priority};
+        this.#markPipeline.push({type: 'addEntitySpec', name, cb, priority});
+        this.#markIndex[name] = {source: 'addMarkSpec'};
         return this;
     }
 
     addMarkdownTokenParserSpec(tokenName: string, cb: () => ParserToken): this {
-        if (this.#rawParserSpecs[tokenName]) {
+        if (this.#parserIndex.has(tokenName)) {
             throw new Error(
                 `Parser spec for token "${tokenName}" already registered via addMarkdownTokenParserSpec`,
             );
         }
-        this.#rawParserSpecs[tokenName] = {tokenName, cb};
+        this.#parserPipeline.push({type: 'addParserSpec', tokenName, cb});
+        this.#parserIndex.add(tokenName);
         return this;
     }
 
     addNodeSerializerSpec(name: string, cb: () => SerializerNodeToken): this {
-        if (this.#rawNodeSerializers[name]) {
+        if (this.#nodeSerializerIndex.has(name)) {
             throw new Error(
                 `Node serializer for "${name}" already registered via addNodeSerializerSpec`,
             );
         }
-        if (this.#nodeSpecs[name]) {
+        if (this.#nodeIndex[name]?.source === 'addNode') {
             throw new Error(
                 `Node with name "${name}" already registered via addNode. Use overrideNodeSerializerSpec to modify it.`,
             );
         }
-        this.#rawNodeSerializers[name] = cb;
+        this.#nodeSerializerPipeline.push({type: 'addSerializer', name, cb});
+        this.#nodeSerializerIndex.add(name);
         return this;
     }
 
     addMarkSerializerSpec(name: string, cb: () => SerializerMarkToken): this {
-        if (this.#rawMarkSerializers[name]) {
+        if (this.#markSerializerIndex.has(name)) {
             throw new Error(
                 `Mark serializer for "${name}" already registered via addMarkSerializerSpec`,
             );
         }
-        if (this.#markSpecs[name]) {
+        if (this.#markIndex[name]?.source === 'addMark') {
             throw new Error(
                 `Mark with name "${name}" already registered via addMark. Use overrideMarkSerializerSpec to modify it.`,
             );
         }
-        this.#rawMarkSerializers[name] = cb;
+        this.#markSerializerPipeline.push({type: 'addSerializer', name, cb});
+        this.#markSerializerIndex.add(name);
         return this;
     }
 
     overrideNodeSpec(name: string, cb: (prev: NodeSpec) => NodeSpec): this {
-        if (!this.#nodeSpecs[name] && !this.#rawNodeSpecs[name]) {
+        if (!this.#nodeIndex[name]) {
             throw new Error(
                 `Cannot override node spec "${name}": not registered. Use addNode() or addNodeSpec() first.`,
             );
         }
-        (this.#nodeSpecOverrides[name] ??= []).push(cb);
+        this.#nodePipeline.push({type: 'overrideEntitySpec', name, cb});
         return this;
     }
 
     overrideMarkSpec(name: string, cb: (prev: MarkSpec) => MarkSpec): this {
-        if (!this.#markSpecs[name] && !this.#rawMarkSpecs[name]) {
+        if (!this.#markIndex[name]) {
             throw new Error(
                 `Cannot override mark spec "${name}": not registered. Use addMark() or addMarkSpec() first.`,
             );
         }
-        (this.#markSpecOverrides[name] ??= []).push(cb);
+        this.#markPipeline.push({type: 'overrideEntitySpec', name, cb});
         return this;
     }
 
@@ -361,16 +506,16 @@ export class ExtensionBuilder {
         cb: (prev: ParserToken) => ParserToken,
     ): this {
         if (
-            !this.#rawParserSpecs[tokenName] &&
-            !this.#nodeSpecs[tokenName] &&
-            !this.#markSpecs[tokenName]
+            !this.#parserIndex.has(tokenName) &&
+            !this.#nodeIndex[tokenName] &&
+            !this.#markIndex[tokenName]
         ) {
             throw new Error(
                 `Cannot override parser spec for token "${tokenName}": not registered. ` +
                     `Use addMarkdownTokenParserSpec(), addNode(), or addMark() first.`,
             );
         }
-        (this.#parserSpecOverrides[tokenName] ??= []).push(cb);
+        this.#parserPipeline.push({type: 'overrideParserSpec', tokenName, cb});
         return this;
     }
 
@@ -378,12 +523,12 @@ export class ExtensionBuilder {
         name: string,
         cb: (prev: SerializerNodeToken) => SerializerNodeToken,
     ): this {
-        if (!this.#nodeSpecs[name] && !this.#rawNodeSerializers[name]) {
+        if (this.#nodeIndex[name]?.source !== 'addNode' && !this.#nodeSerializerIndex.has(name)) {
             throw new Error(
                 `Cannot override node serializer "${name}": not registered. Use addNode() or addNodeSerializerSpec() first.`,
             );
         }
-        (this.#nodeSerializerOverrides[name] ??= []).push(cb);
+        this.#nodeSerializerPipeline.push({type: 'overrideSerializer', name, cb});
         return this;
     }
 
@@ -391,45 +536,24 @@ export class ExtensionBuilder {
         name: string,
         cb: (prev: SerializerMarkToken) => SerializerMarkToken,
     ): this {
-        if (!this.#markSpecs[name] && !this.#rawMarkSerializers[name]) {
+        if (this.#markIndex[name]?.source !== 'addMark' && !this.#markSerializerIndex.has(name)) {
             throw new Error(
                 `Cannot override mark serializer "${name}": not registered. Use addMark() or addMarkSerializerSpec() first.`,
             );
         }
-        (this.#markSerializerOverrides[name] ??= []).push(cb);
+        this.#markSerializerPipeline.push({type: 'overrideSerializer', name, cb});
         return this;
     }
 
     build(): ExtensionSpec {
         const confMd = this.#confMdCbs.slice();
-        const nodes = {...this.#nodeSpecs};
-        const marks = {...this.#markSpecs};
+        const nodePipeline = this.#nodePipeline.slice();
+        const markPipeline = this.#markPipeline.slice();
+        const parserPipeline = this.#parserPipeline.slice();
+        const nodeSerializerPipeline = this.#nodeSerializerPipeline.slice();
+        const markSerializerPipeline = this.#markSerializerPipeline.slice();
         const plugins = this.#plugins.slice();
         const actions = this.#actions.slice();
-
-        const rawNodeSpecs = {...this.#rawNodeSpecs};
-        const rawMarkSpecs = {...this.#rawMarkSpecs};
-        const rawParserSpecs = {...this.#rawParserSpecs};
-        const rawNodeSerializers = {...this.#rawNodeSerializers};
-        const rawMarkSerializers = {...this.#rawMarkSerializers};
-
-        const nodeSpecOverrides = {...this.#nodeSpecOverrides};
-        const markSpecOverrides = {...this.#markSpecOverrides};
-        const parserSpecOverrides = {...this.#parserSpecOverrides};
-        const nodeSerializerOverrides = {...this.#nodeSerializerOverrides};
-        const markSerializerOverrides = {...this.#markSerializerOverrides};
-
-        // Pre-build entity name → parser specs lookup for O(1) access
-        // Multiple markdown-it tokens can map to the same ProseMirror entity
-        // (e.g. both 'fence' and 'code_block' tokens → 'code_block' node)
-        const parserSpecsByEntity: Record<
-            string,
-            Array<{tokenName: string; tokenSpec: ParserToken}>
-        > = {};
-        for (const {tokenName, cb} of Object.values(rawParserSpecs)) {
-            const tokenSpec = cb();
-            (parserSpecsByEntity[tokenSpec.name] ??= []).push({tokenName, tokenSpec});
-        }
 
         return {
             configureMd: (md, parserType) =>
@@ -442,205 +566,22 @@ export class ExtensionBuilder {
                     }
                     return pMd;
                 }, md),
-            nodes: () => {
-                let map = OrderedMap.from<ExtensionNodeSpec>({});
-
-                // 1. Process addNode entries with overrides
-                for (const {name, cb} of Object.values(nodes)) {
-                    const base = cb();
-                    const tokenName = base.fromMd.tokenName ?? name;
-                    const hasOverrides =
-                        nodeSpecOverrides[name] ||
-                        parserSpecOverrides[tokenName] ||
-                        nodeSerializerOverrides[name];
-
-                    if (hasOverrides) {
-                        map = map.addToEnd(name, {
-                            spec: applyOverrides(base.spec, nodeSpecOverrides[name]),
-                            fromMd: {
-                                tokenName: base.fromMd.tokenName,
-                                tokenSpec: applyOverrides(
-                                    base.fromMd.tokenSpec,
-                                    parserSpecOverrides[tokenName],
-                                ),
-                            },
-                            toMd: applyOverrides(base.toMd, nodeSerializerOverrides[name]),
-                            view: base.view,
-                        });
-                    } else {
-                        map = map.addToEnd(name, base);
-                    }
-                }
-
-                // 1b. Add parser-only entries for rawParserSpecs tokens targeting addNode entities
-                for (const {name} of Object.values(nodes)) {
-                    const entries = parserSpecsByEntity[name];
-                    if (entries) {
-                        for (const entry of entries) {
-                            // Skip when tokenName matches the entity name —
-                            // the full spec was already added in step 1
-                            if (entry.tokenName === name) continue;
-                            map = map.addToEnd(
-                                entry.tokenName,
-                                buildParserOnlyNodeEntry(
-                                    resolveParserEntry(entry, parserSpecOverrides),
-                                ),
-                            );
-                        }
-                    }
-                }
-
-                // 2. Process granular-only nodes
-                for (const name of Object.keys(rawNodeSpecs)) {
-                    const spec = applyOverrides(rawNodeSpecs[name](), nodeSpecOverrides[name]);
-
-                    const {primary, extra} = resolveGranularParserEntries(
-                        name,
-                        'node',
-                        parserSpecsByEntity,
-                        parserSpecOverrides,
-                    );
-
-                    if (!rawNodeSerializers[name]) {
-                        throw new Error(
-                            `Incomplete node spec for "${name}": missing serializer. ` +
-                                `Use addNodeSerializerSpec() to register a serializer for this node.`,
-                        );
-                    }
-                    const toMd = applyOverrides(
-                        rawNodeSerializers[name](),
-                        nodeSerializerOverrides[name],
-                    );
-
-                    map = map.addToEnd(name, {
-                        spec,
-                        fromMd: {tokenName: primary.tokenName, tokenSpec: primary.tokenSpec},
-                        toMd,
-                    });
-
-                    for (const entry of extra) {
-                        map = map.addToEnd(entry.tokenName, buildParserOnlyNodeEntry(entry));
-                    }
-                }
-
-                return map;
-            },
-            marks: () => {
-                // The order of marks in schema is important when serializing pm-document to DOM or markup
-                // https://discuss.prosemirror.net/t/marks-priority/4463
-
-                // 1. Process addMark entries with overrides
-                const allMarks: {
-                    name: string;
-                    priority: number;
-                    buildSpec: () => ExtensionMarkSpec;
-                }[] = [];
-
-                for (const {name, cb, priority} of Object.values(marks)) {
-                    allMarks.push({
-                        name,
-                        priority,
-                        buildSpec: () => {
-                            const base = cb();
-                            const tokenName = base.fromMd.tokenName ?? name;
-                            const hasOverrides =
-                                markSpecOverrides[name] ||
-                                parserSpecOverrides[tokenName] ||
-                                markSerializerOverrides[name];
-
-                            if (hasOverrides) {
-                                return {
-                                    spec: applyOverrides(base.spec, markSpecOverrides[name]),
-                                    fromMd: {
-                                        tokenName: base.fromMd.tokenName,
-                                        tokenSpec: applyOverrides(
-                                            base.fromMd.tokenSpec,
-                                            parserSpecOverrides[tokenName],
-                                        ),
-                                    },
-                                    toMd: applyOverrides(base.toMd, markSerializerOverrides[name]),
-                                    view: base.view,
-                                };
-                            }
-                            return base;
-                        },
-                    });
-                }
-
-                // 1b. Add parser-only entries for rawParserSpecs tokens targeting addMark entities
-                for (const {name, priority} of Object.values(marks)) {
-                    const entries = parserSpecsByEntity[name];
-                    if (entries) {
-                        for (const entry of entries) {
-                            // Skip when tokenName matches the entity name —
-                            // the full spec was already added in step 1
-                            if (entry.tokenName === name) continue;
-                            allMarks.push({
-                                name: entry.tokenName,
-                                priority,
-                                buildSpec: () =>
-                                    buildParserOnlyMarkEntry(
-                                        resolveParserEntry(entry, parserSpecOverrides),
-                                    ),
-                            });
-                        }
-                    }
-                }
-
-                // 2. Process granular-only marks
-                for (const name of Object.keys(rawMarkSpecs)) {
-                    const {cb: specCb, priority} = rawMarkSpecs[name];
-
-                    const {primary, extra} = resolveGranularParserEntries(
-                        name,
-                        'mark',
-                        parserSpecsByEntity,
-                        parserSpecOverrides,
-                    );
-
-                    if (!rawMarkSerializers[name]) {
-                        throw new Error(
-                            `Incomplete mark spec for "${name}": missing serializer. ` +
-                                `Use addMarkSerializerSpec() to register a serializer for this mark.`,
-                        );
-                    }
-
-                    allMarks.push({
-                        name,
-                        priority,
-                        buildSpec: () => {
-                            const spec = applyOverrides(specCb(), markSpecOverrides[name]);
-                            const toMd = applyOverrides(
-                                rawMarkSerializers[name](),
-                                markSerializerOverrides[name],
-                            );
-                            return {
-                                spec,
-                                fromMd: {
-                                    tokenName: primary.tokenName,
-                                    tokenSpec: primary.tokenSpec,
-                                },
-                                toMd,
-                            };
-                        },
-                    });
-
-                    for (const entry of extra) {
-                        allMarks.push({
-                            name: entry.tokenName,
-                            priority,
-                            buildSpec: () => buildParserOnlyMarkEntry(entry),
-                        });
-                    }
-                }
-
-                allMarks.sort((a, b) => b.priority - a.priority);
-                let map = OrderedMap.from<ExtensionMarkSpec>({});
-                for (const {name, buildSpec} of allMarks) {
-                    map = map.addToEnd(name, buildSpec());
-                }
-                return map;
-            },
+            nodes: () =>
+                processEntityPipeline<ExtensionNodeSpec>(
+                    'node',
+                    nodePipeline,
+                    parserPipeline,
+                    nodeSerializerPipeline,
+                    buildParserOnlyNodeEntry,
+                ),
+            marks: () =>
+                processEntityPipeline<ExtensionMarkSpec>(
+                    'mark',
+                    markPipeline,
+                    parserPipeline,
+                    markSerializerPipeline,
+                    buildParserOnlyMarkEntry,
+                ),
             plugins: (deps) => {
                 return plugins
                     .sort((a, b) => b.priority - a.priority)

--- a/packages/editor/src/core/ExtensionBuilder.ts
+++ b/packages/editor/src/core/ExtensionBuilder.ts
@@ -96,6 +96,7 @@ function resolveParserPipeline(
     const primaryParserToken = {...initialPrimaryTokens};
     const parsers = {...initialParsers};
     const extraTokenNames: string[] = [];
+    const overriddenTokens = new Set<string>();
 
     for (const entry of pipeline) {
         if (entry.type === 'addParserSpec') {
@@ -105,6 +106,13 @@ function resolveParserPipeline(
             if (primaryParserToken[entityName] === entry.tokenName) {
                 // Same-name token for addNode/addMark entity — skip, already covered
                 continue;
+            }
+
+            if (entry.tokenName in initialParsers) {
+                throw new Error(
+                    `Parser token "${entry.tokenName}" is already owned by an entity registered via addNode/addMark. ` +
+                        `Use overrideMarkdownTokenParserSpec() to modify it, or choose a different tokenName.`,
+                );
             }
 
             if (primaryParserToken[entityName]) {
@@ -123,26 +131,29 @@ function resolveParserPipeline(
                     tokenName: existing.tokenName,
                     tokenSpec: entry.cb(existing.tokenSpec),
                 };
+                overriddenTokens.add(entry.tokenName);
             }
         }
     }
 
-    return {parsers, primaryParserToken, extraTokenNames};
+    return {parsers, primaryParserToken, extraTokenNames, overriddenTokens};
 }
 
 function resolveSerializerPipeline<T>(
     pipeline: SerializerPipelineEntry<T>[],
     initialSerializers: Record<string, T>,
-): Record<string, T> {
+): {serializers: Record<string, T>; overriddenNames: Set<string>} {
     const serializers = {...initialSerializers};
+    const overriddenNames = new Set<string>();
     for (const entry of pipeline) {
         if (entry.type === 'addSerializer') {
             serializers[entry.name] = entry.cb();
         } else {
             serializers[entry.name] = entry.cb(serializers[entry.name]);
+            overriddenNames.add(entry.name);
         }
     }
-    return serializers;
+    return {serializers, overriddenNames};
 }
 
 function validateGranularSpecs(
@@ -200,6 +211,10 @@ function processEntityPipeline<EntitySpec extends ExtensionNodeSpec | ExtensionM
     const granularEntities = new Set<string>();
     const initPrimaryTokens: Record<string, string> = {};
     const priorityByEntity: Record<string, number> = {};
+    // Originals from addEntity — preserved as-is in assembly when no overrides were applied.
+    // This keeps reference identity (and any extra fields) for unmodified entries.
+    const originals: Record<string, EntitySpec> = {};
+    const modified = new Set<string>();
 
     // Pass 1: entityPipeline → specs, order, raw parsers/serializers from addEntity
     for (const entry of entityPipeline) {
@@ -215,6 +230,7 @@ function processEntityPipeline<EntitySpec extends ExtensionNodeSpec | ExtensionM
             priorityByEntity[name] = entry.priority;
             initSerializers[name] = base.toMd;
             views[name] = base.view;
+            originals[name] = base;
         } else if (entry.type === 'addEntitySpec') {
             order.push({name, priority: entry.priority});
             specs[name] = entry.cb();
@@ -223,11 +239,12 @@ function processEntityPipeline<EntitySpec extends ExtensionNodeSpec | ExtensionM
         } else {
             // overrideEntitySpec
             specs[name] = entry.cb(specs[name]);
+            modified.add(name);
         }
     }
 
     // Pass 2: parserPipeline → fill/override parsers, add extra parser-only entries
-    const {parsers, primaryParserToken, extraTokenNames} = resolveParserPipeline(
+    const {parsers, primaryParserToken, extraTokenNames, overriddenTokens} = resolveParserPipeline(
         parserPipeline,
         initPrimaryTokens,
         initParsers,
@@ -238,9 +255,21 @@ function processEntityPipeline<EntitySpec extends ExtensionNodeSpec | ExtensionM
         const priority = entityName ? (priorityByEntity[entityName] ?? 0) : 0;
         order.push({name: tokenName, priority});
     }
+    // Map primary-token overrides back to their owning addEntity names
+    for (const entityName of Object.keys(originals)) {
+        if (overriddenTokens.has(initPrimaryTokens[entityName])) {
+            modified.add(entityName);
+        }
+    }
 
     // Pass 3: serializerPipeline → fill/override serializers
-    const serializers = resolveSerializerPipeline(serializerPipeline, initSerializers);
+    const {serializers, overriddenNames: overriddenSerializers} = resolveSerializerPipeline(
+        serializerPipeline,
+        initSerializers,
+    );
+    for (const name of overriddenSerializers) {
+        modified.add(name);
+    }
 
     validateGranularSpecs(granularEntities, entityType, primaryParserToken, serializers);
 
@@ -253,6 +282,11 @@ function processEntityPipeline<EntitySpec extends ExtensionNodeSpec | ExtensionM
     // Assemble
     let map = OrderedMap.from<EntitySpec>({});
     for (const {name} of order) {
+        // Fast path: unmodified addEntity registrations keep their original object reference.
+        if (originals[name] && !modified.has(name)) {
+            map = map.addToEnd(name, originals[name]);
+            continue;
+        }
         const parserKey = primaryParserToken[name] ?? name;
         map = map.addToEnd(
             name,


### PR DESCRIPTION
Merge registration APIs into shared generic pipelines (`EntityPipelineEntry`, `SerializerPipelineEntry`) processed by a single `processEntityPipeline()` helper. Unified pipeline preserves insertion order across `addNode`/`addNodeSpec` (and marks), enabling clean handling of specs, parsers, serializers and overrides in three independent passes.