### PR TITLE
ci(github): change commit prefix for github-actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    commit-message:
+      prefix: "ci(github)"
 
   # npm — root
   - package-ecosystem: npm


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure Dependabot GitHub Actions updates to use the "ci(github)" commit message prefix.