### PR TITLE
test: fix YFM HTML test stability

### DIFF
--- a/demo/tests/playwright/core/types.ts
+++ b/demo/tests/playwright/core/types.ts
@@ -57,7 +57,6 @@ export interface WaitFixture {
     visible(selector: Locator): Promise<void>;
     hidden(selector: Locator): Promise<void>;
     timeout(delay?: number): Promise<void>;
-    markupRendered(delay?: number, stableThreshold?: number): Promise<void>;
 }
 
 export interface CaptureScreenshotParams extends PageScreenshotOptions {

--- a/demo/tests/playwright/core/wait.ts
+++ b/demo/tests/playwright/core/wait.ts
@@ -3,10 +3,6 @@ import type {Locator} from '@playwright/test';
 import type {PlaywrightFixture, WaitFixture} from './types';
 
 const DEFAULT_DELAY = 100;
-const MAX_STABLE_CHECKS = 50;
-const REQUIRED_STABLE_COUNT = 2;
-
-type Snapshot = {text: string; height: number};
 
 export const wait: PlaywrightFixture<WaitFixture> = async ({page}, use) => {
     await use({
@@ -27,36 +23,5 @@ export const wait: PlaywrightFixture<WaitFixture> = async ({page}, use) => {
         timeout: async (delay = DEFAULT_DELAY) => {
             await page.waitForTimeout(delay);
         },
-        markupRendered: async (delay = DEFAULT_DELAY, stableThreshold = REQUIRED_STABLE_COUNT) => {
-            const locator = page.locator('.playground__markup');
-            await locator.waitFor({state: 'visible'});
-
-            let prev: Snapshot = {text: '', height: 0};
-            let stableCount = 0;
-
-            for (let i = 0; i < MAX_STABLE_CHECKS; i++) {
-                const curr = await getMarkupPreviewMetrics(locator);
-
-                if (isStable(prev, curr)) {
-                    stableCount++;
-                    if (stableCount >= stableThreshold) break;
-                } else {
-                    stableCount = 0;
-                    prev = curr;
-                }
-
-                await page.waitForTimeout(delay);
-            }
-        },
     });
 };
-
-async function getMarkupPreviewMetrics(locator: Locator): Promise<Snapshot> {
-    const text = (await locator.textContent())?.trim() ?? '';
-    const height = (await locator.boundingBox())?.height ?? 0;
-    return {text, height};
-}
-
-function isStable(prev: Snapshot, curr: Snapshot): boolean {
-    return Boolean(curr.text) && prev.text === curr.text && prev.height === curr.height;
-}

--- a/demo/tests/visual-tests/YfmExtensions.visual.test.tsx
+++ b/demo/tests/visual-tests/YfmExtensions.visual.test.tsx
@@ -23,10 +23,10 @@ test.describe('Extensions, YFM', () => {
         await mount(<YFMStories.YfmTabs />);
         await expectScreenshot();
     });
-    test('YFM HTML', async ({mount, expectScreenshot, wait}) => {
+    test('YFM HTML', async ({mount, expectScreenshot, page}) => {
         await mount(<YFMStories.YfmHtmlBlock />);
 
-        await wait.markupRendered(1000, 3);
+        await page.waitForTimeout(700);
         await expectScreenshot();
     });
     test('YFM File', async ({mount, expectScreenshot}) => {


### PR DESCRIPTION
## Summary by Sourcery

Adjust YFM HTML visual test to use a simple timeout instead of custom markup stability waiting logic and remove the unused wait helper API.

Enhancements:
- Remove the markupRendered wait utility and its associated types from the Playwright wait fixture as it is no longer used.

Tests:
- Simplify YFM HTML visual test synchronization by replacing the custom markupRendered helper with a fixed page timeout.