### PR TITLE
fix(i18n): align Russian translation inconsistencies (step 1)

### DIFF
--- a/packages/editor/src/i18n/forms/ru.json
+++ b/packages/editor/src/i18n/forms/ru.json
@@ -1,5 +1,5 @@
 {
-  "common_action_cancel": "Отменить",
+  "common_action_cancel": "Отмена",
   "common_action_submit": "Сохранить",
   "common_action_upload": "Загрузить",
   "common_tab_attach": "Загрузить с устройства",

--- a/packages/editor/src/i18n/gpt/dialog/ru.json
+++ b/packages/editor/src/i18n/gpt/dialog/ru.json
@@ -11,6 +11,6 @@
   "refetch": "Попробовать ещё",
   "replace": "Заменить выделенный текст",
   "replace-disabled": "Вставить текст",
-  "try-again": "Иначе",
+  "try-again": "Повторить",
   "alert-gpt-presets-info": "Выделите текст, чтобы увидеть пресеты GPT"
 }

--- a/packages/editor/src/i18n/gpt/extension/ru.json
+++ b/packages/editor/src/i18n/gpt/extension/ru.json
@@ -1,5 +1,5 @@
 {
-  "confirm-cancel": "Отменить",
+  "confirm-cancel": "Отмена",
   "confirm-ok": "Закрыть",
   "confirm-title": "Хотите закрыть помощника GPT?",
   "help-with-text": "Помощь с текстом"

--- a/packages/editor/src/i18n/yfm-layout/ru.json
+++ b/packages/editor/src/i18n/yfm-layout/ru.json
@@ -8,7 +8,7 @@
   "action.align.right": "Вся секция по правому краю",
   "action.align.stretch": "Растягивать секцию на всю ширину",
   "action.remove": "Удалить",
-  "cell.preview": "Превью",
+  "cell.preview": "Предпросмотр",
   "cell.width": "Ширина",
   "cell.width.auto": "Автоматически",
   "cell.remove": "Удалить ячейку"


### PR DESCRIPTION
## Summary

Fixes translation inconsistencies identified in #1097 (Step 1).

- `common_action_cancel` / `confirm-cancel`: changed "Отменить" (verb) → "Отмена" (noun) for consistency across the editor
- `cell.preview` in `yfm-layout`: changed "Превью" → "Предпросмотр" (matches `common/ru.json`, `bundle/ru.json`)
- `try-again` in `gpt/dialog`: changed "Иначе" (Otherwise) → "Повторить" — the button uses `ArrowRotateLeft` icon and triggers `handleTryAgain` (retry same request), so "Повторить" matches both the intent and the `retry-button` convention in `gpt/errors/ru.json`

**Note on `refetch`:** This key exists in `gpt/dialog/ru.json` but is not referenced anywhere in the source code — left as-is for now (dead key cleanup can be a separate PR).

## Test plan

- [ ] Verify no TypeScript errors introduced (`pnpm build`)
- [ ] Verify unit tests pass (`pnpm test`)
- [ ] Visually check cancel buttons in forms and GPT dialog show "Отмена"
- [ ] Visually check yfm-layout cell preview label shows "Предпросмотр"
- [ ] Visually check GPT dialog "try again" button shows "Повторить"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct inconsistent Russian translations for cancel actions, preview labels, and GPT retry button text across editor modules.