### PR TITLE
test: fix YFM HTML test timeout

### DIFF
--- a/demo/tests/visual-tests/YfmExtensions.visual.test.tsx
+++ b/demo/tests/visual-tests/YfmExtensions.visual.test.tsx
@@ -26,7 +26,7 @@ test.describe('Extensions, YFM', () => {
     test('YFM HTML', async ({mount, expectScreenshot, page}) => {
         await mount(<YFMStories.YfmHtmlBlock />);
 
-        await page.waitForTimeout(700);
+        await page.waitForTimeout(2000);
         await expectScreenshot();
     });
     test('YFM File', async ({mount, expectScreenshot}) => {


### PR DESCRIPTION
## Summary by Sourcery

Increase rendering wait time in the YFM HTML visual test to reduce flakiness and timeouts.

Bug Fixes:
- Reduce flakiness in the YFM HTML visual screenshot test by increasing the pre-screenshot wait duration.

Tests:
- Adjust the YFM HTML visual test timing to allow more time for the component to render before capturing a screenshot.