### PR TITLE
test: skip YFM HTML test

### DIFF
--- a/demo/tests/visual-tests/YfmExtensions.visual.test.tsx
+++ b/demo/tests/visual-tests/YfmExtensions.visual.test.tsx
@@ -23,7 +23,9 @@ test.describe('Extensions, YFM', () => {
         await mount(<YFMStories.YfmTabs />);
         await expectScreenshot();
     });
-    test('YFM HTML', async ({mount, expectScreenshot, page}) => {
+    // TODO: investigate and fix, unskip after fixing
+    //  Now screenshot in .playground__preview has text cut off (as if overlapped);
+    test.skip('YFM HTML', async ({mount, expectScreenshot, page}) => {
         await mount(<YFMStories.YfmHtmlBlock />);
 
         await page.waitForTimeout(2000);


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Mark the YFM HTML visual test as skipped and document the current screenshot text clipping issue.