### PR TITLE
fix(i18n): fix English copy issues (step 3)

### DIFF
--- a/packages/editor/src/i18n/bundle/en.json
+++ b/packages/editor/src/i18n/bundle/en.json
@@ -3,7 +3,7 @@
   "settings_wysiwyg": "Visual Editor (wysiwyg)",
   "settings_markup": "Markdown markup",
   "settings_menubar": "Toolbar",
-  "settings_hint": "You can disable the top menu and invoke all commands with ‘/’ or the «+» button.",
+  "settings_hint": "You can disable the top menu and invoke all commands with ‘/’ or the \"+\" button.",
   "settings_split-mode": "Split mode",
   "split-mode-text": "Preview",
   "settings_split-mode-hint": "Splitting the editor into two windows: preview and editing",

--- a/packages/editor/src/i18n/forms/en.json
+++ b/packages/editor/src/i18n/forms/en.json
@@ -8,7 +8,7 @@
   "common_sizes": "Size, px",
   "image_name": "Title",
   "image_link_href": "Image link",
-  "image_link_href_help": "Adress the image link leads to.",
+  "image_link_href_help": "Address the image link leads to.",
   "image_alt": "Alt text",
   "image_alt_help": "Alt text is displayed if the image cannot be loaded.",
   "image_upload_help": "JPEG, GIF or PNG image no larger than 1 MB.",

--- a/packages/editor/src/i18n/gpt/errors/en.json
+++ b/packages/editor/src/i18n/gpt/errors/en.json
@@ -1,5 +1,5 @@
 {
   "error-text": "An error occurred while generating a reply, please retry the request",
   "retry-button": "Try again",
-  "start-again-button": "To the beginning"
+  "start-again-button": "Start over"
 }

--- a/packages/editor/src/i18n/menubar/en.json
+++ b/packages/editor/src/i18n/menubar/en.json
@@ -43,7 +43,7 @@
   "math_inline": "Inline math",
   "mermaid": "Mermaid",
   "mono": "Monospace",
-  "more_action": "More action",
+  "more_action": "More actions",
   "move_list": "Move list item",
   "note": "Note",
   "olist": "Ordered list",


### PR DESCRIPTION
Part of #1097

- fix English copy issues in editor i18n
- correct the typo in `forms`, pluralize `more_action`, rename the GPT CTA to `Start over`, and replace guillemets in `bundle`

## Summary by Sourcery

Improve English copy consistency in the editor’s i18n resources.

Bug Fixes:
- Correct English wording and typos in editor form labels and messages.
- Pluralize the `more_action` label to better reflect multiple actions.
- Rename the GPT call-to-action label to `Start over` for clearer user guidance.
- Replace guillemets in bundle strings with standard English punctuation.