### PR TITLE
fix: clear stale enriched docs before docs build

### DIFF
--- a/scripts/docs/index.mjs
+++ b/scripts/docs/index.mjs
@@ -1,3 +1,4 @@
+import {existsSync, rmSync} from 'node:fs';
 import process from 'node:process';
 
 import {Assembler} from './assembler.mjs';
@@ -80,10 +81,20 @@ function runAssemble() {
     new Assembler(DOCS_GEN_DIR, DOCS_SRC_DIR).run();
 }
 
+function clearEnrichedDocs() {
+    const enrichedDir = `${DOCS_GEN_DIR}/enriched`;
+
+    if (existsSync(enrichedDir)) {
+        logger.info(`Removing stale enriched docs from ${enrichedDir}/`);
+        rmSync(enrichedDir, {recursive: true, force: true});
+    }
+}
+
 /**
  * Full pipeline: generate -> extract -> assemble
  */
 function runBuild() {
+    clearEnrichedDocs();
     runGenerate();
     runExtract();
     runAssemble();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove any existing enriched docs directory before generating documentation to avoid stale content being included in builds.