### PR TITLE
feat: add `insert()` method to editor API

### DIFF
--- a/demo/src/components/Playground.tsx
+++ b/demo/src/components/Playground.tsx
@@ -431,6 +431,13 @@ export const Playground = memo<PlaygroundProps>((props) => {
                             }}
                         />
                         <DropdownMenu.Item
+                            text="Insert"
+                            action={() => {
+                                mdEditor.insert('> insert');
+                                mdEditor.focus();
+                            }}
+                        />
+                        <DropdownMenu.Item
                             text="Move cursor to start"
                             action={() => {
                                 mdEditor.moveCursor('start');

--- a/demo/src/components/Playground.tsx
+++ b/demo/src/components/Playground.tsx
@@ -438,6 +438,13 @@ export const Playground = memo<PlaygroundProps>((props) => {
                             }}
                         />
                         <DropdownMenu.Item
+                            text="Insert(inline)"
+                            action={() => {
+                                mdEditor.insert('insert(inline)');
+                                mdEditor.focus();
+                            }}
+                        />
+                        <DropdownMenu.Item
                             text="Move cursor to start"
                             action={() => {
                                 mdEditor.moveCursor('start');

--- a/packages/editor/src/bundle/Editor.ts
+++ b/packages/editor/src/bundle/Editor.ts
@@ -463,8 +463,8 @@ export class EditorImpl extends SafeEventEmitter<EventMapInt> implements EditorI
         return this.currentEditor.append(markup);
     }
 
-    insertAt(markup: MarkupString, index?: number): void {
-        return this.currentEditor.insertAt(markup, index);
+    insert(markup: MarkupString): void {
+        return this.currentEditor.insert(markup);
     }
 
     moveCursor(

--- a/packages/editor/src/bundle/Editor.ts
+++ b/packages/editor/src/bundle/Editor.ts
@@ -463,6 +463,10 @@ export class EditorImpl extends SafeEventEmitter<EventMapInt> implements EditorI
         return this.currentEditor.append(markup);
     }
 
+    insertAt(markup: MarkupString, index?: number): void {
+        return this.currentEditor.insertAt(markup, index);
+    }
+
     moveCursor(
         position:
             | 'start'

--- a/packages/editor/src/bundle/editor-public-types.ts
+++ b/packages/editor/src/bundle/editor-public-types.ts
@@ -1,6 +1,6 @@
 import type {EditorView as PMEditorView} from 'prosemirror-view';
 
-import type {CommonEditor} from '../common';
+import type {CommonEditor, MarkupString} from '../common';
 import type {Logger2} from '../logger';
 import type {Receiver} from '../utils';
 
@@ -19,6 +19,11 @@ export interface MarkdownEditorInstance extends Receiver<EventMap>, CommonEditor
     readonly toolbarVisible: boolean;
     setEditorMode(mode: MarkdownEditorMode, opts?: Pick<ChangeEditorModeOptions, 'emit'>): void;
     moveCursor(position: 'start' | 'end' | {line: number}): void;
+    /**
+     * Insert markup at the current cursor position.
+     * If `index` is provided, insert at that absolute position instead.
+     */
+    insertAt(markup: MarkupString, index?: number): void;
     /** @internal used in demo for dev-tools */
     readonly _wysiwygView?: PMEditorView;
 }

--- a/packages/editor/src/bundle/editor-public-types.ts
+++ b/packages/editor/src/bundle/editor-public-types.ts
@@ -19,11 +19,7 @@ export interface MarkdownEditorInstance extends Receiver<EventMap>, CommonEditor
     readonly toolbarVisible: boolean;
     setEditorMode(mode: MarkdownEditorMode, opts?: Pick<ChangeEditorModeOptions, 'emit'>): void;
     moveCursor(position: 'start' | 'end' | {line: number}): void;
-    /**
-     * Insert markup at the current cursor position.
-     * If `index` is provided, insert at that absolute position instead.
-     */
-    insertAt(markup: MarkupString, index?: number): void;
+    insert(markup: MarkupString): void;
     /** @internal used in demo for dev-tools */
     readonly _wysiwygView?: PMEditorView;
 }

--- a/packages/editor/src/common/index.ts
+++ b/packages/editor/src/common/index.ts
@@ -13,9 +13,5 @@ export interface ContentHandler {
     prepend(markup: MarkupString): void;
     append(markup: MarkupString): void;
     moveCursor(position: 'start' | 'end'): void;
-    /**
-     * Insert markup at the current cursor position.
-     * If `index` is provided, insert at that position instead.
-     */
-    insertAt(markup: MarkupString, index?: number): void;
+    insert(markup: MarkupString): void;
 }

--- a/packages/editor/src/common/index.ts
+++ b/packages/editor/src/common/index.ts
@@ -13,4 +13,9 @@ export interface ContentHandler {
     prepend(markup: MarkupString): void;
     append(markup: MarkupString): void;
     moveCursor(position: 'start' | 'end'): void;
+    /**
+     * Insert markup at the current cursor position.
+     * If `index` is provided, insert at that position instead.
+     */
+    insertAt(markup: MarkupString, index?: number): void;
 }

--- a/packages/editor/src/core/ContentHandler.test.ts
+++ b/packages/editor/src/core/ContentHandler.test.ts
@@ -13,11 +13,17 @@ const schema = new Schema({
         doc: {content: 'block+'},
         text: {group: 'inline'},
         paragraph: {group: 'block', content: 'text*', toDOM: () => ['p', 0]},
+        code_block: {
+            group: 'block',
+            content: 'text*',
+            code: true,
+            toDOM: () => ['pre', ['code', 0]],
+        },
     },
     marks: {},
 });
 
-const {doc, paragraph: p} = builders(schema);
+const {doc, paragraph: p, code_block: cb} = builders(schema);
 
 const fakeParser: Parser = {
     parse(markup) {
@@ -170,5 +176,22 @@ describe('WysiwygContentHandler', () => {
         const contentHandler = new WysiwygContentHandler(view, fakeParser);
         contentHandler.insert(' inserted');
         expect(view.state.doc.firstChild?.textContent).toBe('hello inserted world');
+    });
+
+    it('should insert as plain text when cursor is inside a code block', () => {
+        const document = doc(cb('existing code'));
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: document,
+                selection: TextSelection.create(document, 9),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.insert('![](https://example.com/img.png)');
+        expect(view.state.doc.childCount).toBe(1);
+        expect(view.state.doc.firstChild?.type.spec.code).toBe(true);
+        expect(view.state.doc.firstChild?.textContent).toBe(
+            'existing![](https://example.com/img.png) code',
+        );
     });
 });

--- a/packages/editor/src/core/ContentHandler.test.ts
+++ b/packages/editor/src/core/ContentHandler.test.ts
@@ -158,4 +158,43 @@ describe('WysiwygContentHandler', () => {
         });
         expect(fn).toThrow();
     });
+
+    it('should insertAt with negative index — insert at the beginning (prepend)', () => {
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: doc(p('hello')),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.insertAt('start', -1);
+        expect(view.state.doc.firstChild?.textContent).toBe('start');
+        expect(view.state.doc.textContent).toContain('hello');
+    });
+
+    it('should insertAt without index — insert inline at current cursor position', () => {
+        const document = doc(p('hello world'));
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: document,
+                selection: TextSelection.create(document, 6),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.insertAt(' inserted');
+        expect(view.state.doc.firstChild?.textContent).toBe('hello inserted world');
+    });
+
+    it('should insertAt with large index — insert at the end (append)', () => {
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: doc(p('hello')),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.insertAt('end', 9999);
+        expect(view.state.doc.textContent).toContain('hello');
+        expect(view.state.doc.textContent).toContain('end');
+        const text = view.state.doc.textContent;
+        expect(text.indexOf('hello')).toBeLessThan(text.indexOf('end'));
+    });
 });

--- a/packages/editor/src/core/ContentHandler.test.ts
+++ b/packages/editor/src/core/ContentHandler.test.ts
@@ -159,19 +159,7 @@ describe('WysiwygContentHandler', () => {
         expect(fn).toThrow();
     });
 
-    it('should insertAt with negative index — insert at the beginning (prepend)', () => {
-        const view = new EditorView(null, {
-            state: EditorState.create({
-                doc: doc(p('hello')),
-            }),
-        });
-        const contentHandler = new WysiwygContentHandler(view, fakeParser);
-        contentHandler.insertAt('start', -1);
-        expect(view.state.doc.firstChild?.textContent).toBe('start');
-        expect(view.state.doc.textContent).toContain('hello');
-    });
-
-    it('should insertAt without index — insert inline at current cursor position', () => {
+    it('should insert inline at current cursor position', () => {
         const document = doc(p('hello world'));
         const view = new EditorView(null, {
             state: EditorState.create({
@@ -180,21 +168,7 @@ describe('WysiwygContentHandler', () => {
             }),
         });
         const contentHandler = new WysiwygContentHandler(view, fakeParser);
-        contentHandler.insertAt(' inserted');
+        contentHandler.insert(' inserted');
         expect(view.state.doc.firstChild?.textContent).toBe('hello inserted world');
-    });
-
-    it('should insertAt with large index — insert at the end (append)', () => {
-        const view = new EditorView(null, {
-            state: EditorState.create({
-                doc: doc(p('hello')),
-            }),
-        });
-        const contentHandler = new WysiwygContentHandler(view, fakeParser);
-        contentHandler.insertAt('end', 9999);
-        expect(view.state.doc.textContent).toContain('hello');
-        expect(view.state.doc.textContent).toContain('end');
-        const text = view.state.doc.textContent;
-        expect(text.indexOf('hello')).toBeLessThan(text.indexOf('end'));
     });
 });

--- a/packages/editor/src/core/ContentHandler.test.ts
+++ b/packages/editor/src/core/ContentHandler.test.ts
@@ -13,6 +13,11 @@ const schema = new Schema({
         doc: {content: 'block+'},
         text: {group: 'inline'},
         paragraph: {group: 'block', content: 'text*', toDOM: () => ['p', 0]},
+        blockquote: {
+            group: 'block',
+            content: 'block+',
+            toDOM: () => ['blockquote', 0],
+        },
         code_block: {
             group: 'block',
             content: 'text*',
@@ -23,7 +28,7 @@ const schema = new Schema({
     marks: {},
 });
 
-const {doc, paragraph: p, code_block: cb} = builders(schema);
+const {doc, paragraph: p, blockquote: bq, code_block: cb} = builders(schema);
 
 const fakeParser: Parser = {
     parse(markup) {
@@ -176,6 +181,40 @@ describe('WysiwygContentHandler', () => {
         const contentHandler = new WysiwygContentHandler(view, fakeParser);
         contentHandler.insert(' inserted');
         expect(view.state.doc.firstChild?.textContent).toBe('hello inserted world');
+    });
+
+    it('should replace selected text on insert', () => {
+        const document = doc(p('hello world'));
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: document,
+                selection: TextSelection.create(document, 7, 12),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.insert('there');
+        expect(view.state.doc.firstChild?.textContent).toBe('hello there');
+    });
+
+    it('should insert block content at cursor position', () => {
+        const document = doc(p('before'), p('after'));
+        const blockParser: Parser = {
+            ...fakeParser,
+            parse(_markup) {
+                return doc(bq(p('quoted')));
+            },
+        };
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: document,
+                selection: TextSelection.create(document, 7),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, blockParser);
+        contentHandler.insert('> quoted');
+        expect(view.state.doc.childCount).toBe(3);
+        expect(view.state.doc.child(1).type.name).toBe('blockquote');
+        expect(view.state.doc.child(1).firstChild?.textContent).toBe('quoted');
     });
 
     it('should insert as plain text when cursor is inside a code block', () => {

--- a/packages/editor/src/core/ContentHandler.ts
+++ b/packages/editor/src/core/ContentHandler.ts
@@ -1,4 +1,4 @@
-import {Slice} from 'prosemirror-model';
+import {type Fragment, Slice} from 'prosemirror-model';
 import {AllSelection, TextSelection, type Transaction} from 'prosemirror-state';
 import type {EditorView} from 'prosemirror-view';
 
@@ -54,12 +54,21 @@ export class WysiwygContentHandler implements ContentHandler {
 
     insert(markup: MarkupString): void {
         const {state} = this.#view;
-        const pos = state.selection.from;
-        const inlineContent = this.#parser.parse(markup).firstChild?.content;
 
-        if (inlineContent && inlineContent.size > 0) {
-            this.#view.dispatch(state.tr.insert(pos, inlineContent));
+        const $from = state.selection.$from;
+        if ($from.parent.type.spec.code) {
+            const {tr} = state;
+            tr.replaceSelectionWith(state.schema.text(markup), true);
+            this.#view.dispatch(tr.scrollIntoView());
+            return;
         }
+
+        const content = this.#parser.parse(markup).content;
+
+        if (content.size === 0) return;
+
+        const slice = getSliceFromMarkupFragment(content);
+        this.#view.dispatch(state.tr.replaceSelection(slice).scrollIntoView());
     }
 
     moveCursor(position: 'start' | 'end'): void {
@@ -97,4 +106,16 @@ export class WysiwygContentHandler implements ContentHandler {
     private appendContentTr(tr: Transaction, markup: MarkupString) {
         return tr.insert(tr.doc.nodeSize - 2, this.#parser.parse(markup).content);
     }
+}
+
+function getSliceFromMarkupFragment(fragment: Fragment): Slice {
+    let start = 0;
+    let end = 0;
+    if (fragment.firstChild?.isTextblock) {
+        start = 1;
+        if (fragment.childCount === 1) {
+            end = 1;
+        }
+    }
+    return new Slice(fragment, start, end);
 }

--- a/packages/editor/src/core/ContentHandler.ts
+++ b/packages/editor/src/core/ContentHandler.ts
@@ -52,6 +52,35 @@ export class WysiwygContentHandler implements ContentHandler {
         this.#view.dispatch(tr);
     }
 
+    insertAt(markup: MarkupString, index?: number): void {
+        const {state} = this.#view;
+        const docSize = state.doc.nodeSize - 2;
+
+        if (index === undefined) {
+            const pos = state.selection.from;
+            const inlineContent = this.#parser.parse(markup).firstChild?.content;
+            if (inlineContent && inlineContent.size > 0) {
+                this.#view.dispatch(state.tr.insert(pos, inlineContent));
+            }
+            return;
+        }
+
+        if (index < 0) {
+            this.prepend(markup);
+            return;
+        }
+
+        if (index > docSize) {
+            this.append(markup);
+            return;
+        }
+
+        const inlineContent = this.#parser.parse(markup).firstChild?.content;
+        if (inlineContent && inlineContent.size > 0) {
+            this.#view.dispatch(state.tr.insert(index, inlineContent));
+        }
+    }
+
     moveCursor(position: 'start' | 'end'): void {
         switch (position) {
             case 'start': {

--- a/packages/editor/src/core/ContentHandler.ts
+++ b/packages/editor/src/core/ContentHandler.ts
@@ -52,32 +52,13 @@ export class WysiwygContentHandler implements ContentHandler {
         this.#view.dispatch(tr);
     }
 
-    insertAt(markup: MarkupString, index?: number): void {
+    insert(markup: MarkupString): void {
         const {state} = this.#view;
-        const docSize = state.doc.nodeSize - 2;
-
-        if (index === undefined) {
-            const pos = state.selection.from;
-            const inlineContent = this.#parser.parse(markup).firstChild?.content;
-            if (inlineContent && inlineContent.size > 0) {
-                this.#view.dispatch(state.tr.insert(pos, inlineContent));
-            }
-            return;
-        }
-
-        if (index < 0) {
-            this.prepend(markup);
-            return;
-        }
-
-        if (index > docSize) {
-            this.append(markup);
-            return;
-        }
-
+        const pos = state.selection.from;
         const inlineContent = this.#parser.parse(markup).firstChild?.content;
+
         if (inlineContent && inlineContent.size > 0) {
-            this.#view.dispatch(state.tr.insert(index, inlineContent));
+            this.#view.dispatch(state.tr.insert(pos, inlineContent));
         }
     }
 

--- a/packages/editor/src/core/Editor.ts
+++ b/packages/editor/src/core/Editor.ts
@@ -208,8 +208,8 @@ export class WysiwygEditor implements CommonEditor, ActionStorage {
         return this.#contentHandler.append(markup);
     }
 
-    insertAt(markup: MarkupString, index?: number): void {
-        return this.#contentHandler.insertAt(markup, index);
+    insert(markup: MarkupString): void {
+        return this.#contentHandler.insert(markup);
     }
 
     moveCursor(position: 'start' | 'end'): void {

--- a/packages/editor/src/core/Editor.ts
+++ b/packages/editor/src/core/Editor.ts
@@ -208,6 +208,10 @@ export class WysiwygEditor implements CommonEditor, ActionStorage {
         return this.#contentHandler.append(markup);
     }
 
+    insertAt(markup: MarkupString, index?: number): void {
+        return this.#contentHandler.insertAt(markup, index);
+    }
+
     moveCursor(position: 'start' | 'end'): void {
         return this.#contentHandler.moveCursor(position);
     }

--- a/packages/editor/src/markup/editor.test.ts
+++ b/packages/editor/src/markup/editor.test.ts
@@ -96,4 +96,36 @@ describe('MarkupContentHandler', () => {
         });
         expect(fn).toThrow();
     });
+
+    it('should insertAt with negative index — insert at the beginning (prepend)', () => {
+        const cm = new EditorView({
+            doc: 'hello',
+        });
+        const contentHandler = new Editor(cm);
+        contentHandler.insertAt('start\n\n', -1);
+        expect(cm.state.sliceDoc().startsWith('start')).toBe(true);
+        expect(cm.state.sliceDoc()).toContain('hello');
+    });
+
+    it('should insertAt without index — insert at current cursor position', () => {
+        const cm = new EditorView({
+            doc: 'hello world',
+            selection: {anchor: 5},
+        });
+        const contentHandler = new Editor(cm);
+        contentHandler.insertAt(' inserted');
+        expect(cm.state.sliceDoc()).toBe('hello inserted world');
+    });
+
+    it('should insertAt with large index — insert at the end (append)', () => {
+        const cm = new EditorView({
+            doc: 'hello',
+        });
+        const contentHandler = new Editor(cm);
+        contentHandler.insertAt('end', 9999);
+        expect(cm.state.sliceDoc()).toContain('hello');
+        expect(cm.state.sliceDoc()).toContain('end');
+        const doc = cm.state.sliceDoc();
+        expect(doc.indexOf('hello')).toBeLessThan(doc.indexOf('end'));
+    });
 });

--- a/packages/editor/src/markup/editor.test.ts
+++ b/packages/editor/src/markup/editor.test.ts
@@ -106,4 +106,24 @@ describe('MarkupContentHandler', () => {
         contentHandler.insert(' inserted');
         expect(cm.state.sliceDoc()).toBe('hello inserted world');
     });
+
+    it('should replace selected text on insert', () => {
+        const cm = new EditorView({
+            doc: 'hello world',
+            selection: {anchor: 6, head: 11}, // "world" selected
+        });
+        const contentHandler = new Editor(cm);
+        contentHandler.insert('there');
+        expect(cm.state.sliceDoc()).toBe('hello there');
+    });
+
+    it('should replace selected text with block markup on insert', () => {
+        const cm = new EditorView({
+            doc: 'hello world',
+            selection: {anchor: 6, head: 11}, // "world" selected
+        });
+        const contentHandler = new Editor(cm);
+        contentHandler.insert('> quoted\n\ntext');
+        expect(cm.state.sliceDoc()).toBe('hello > quoted\n\ntext');
+    });
 });

--- a/packages/editor/src/markup/editor.test.ts
+++ b/packages/editor/src/markup/editor.test.ts
@@ -97,35 +97,13 @@ describe('MarkupContentHandler', () => {
         expect(fn).toThrow();
     });
 
-    it('should insertAt with negative index — insert at the beginning (prepend)', () => {
-        const cm = new EditorView({
-            doc: 'hello',
-        });
-        const contentHandler = new Editor(cm);
-        contentHandler.insertAt('start\n\n', -1);
-        expect(cm.state.sliceDoc().startsWith('start')).toBe(true);
-        expect(cm.state.sliceDoc()).toContain('hello');
-    });
-
-    it('should insertAt without index — insert at current cursor position', () => {
+    it('should insert at current cursor position', () => {
         const cm = new EditorView({
             doc: 'hello world',
             selection: {anchor: 5},
         });
         const contentHandler = new Editor(cm);
-        contentHandler.insertAt(' inserted');
+        contentHandler.insert(' inserted');
         expect(cm.state.sliceDoc()).toBe('hello inserted world');
-    });
-
-    it('should insertAt with large index — insert at the end (append)', () => {
-        const cm = new EditorView({
-            doc: 'hello',
-        });
-        const contentHandler = new Editor(cm);
-        contentHandler.insertAt('end', 9999);
-        expect(cm.state.sliceDoc()).toContain('hello');
-        expect(cm.state.sliceDoc()).toContain('end');
-        const doc = cm.state.sliceDoc();
-        expect(doc.indexOf('hello')).toBeLessThan(doc.indexOf('end'));
     });
 });

--- a/packages/editor/src/markup/editor.ts
+++ b/packages/editor/src/markup/editor.ts
@@ -78,31 +78,11 @@ export class Editor implements CommonEditor, CodeEditor {
         this.#cm.dispatch({changes: {from: doc.length, insert}});
     }
 
-    insertAt(markup: MarkupString, index?: number): void {
-        const docLength = this.#cm.state.doc.length;
-
-        if (index === undefined) {
-            const pos = this.#cm.state.selection.main.head;
-            this.#cm.dispatch({
-                changes: {from: pos, insert: markup},
-                selection: {anchor: pos + markup.length},
-            });
-            return;
-        }
-
-        if (index < 0) {
-            this.prepend(markup);
-            return;
-        }
-
-        if (index > docLength) {
-            this.append(markup);
-            return;
-        }
-
+    insert(markup: MarkupString): void {
+        const pos = this.#cm.state.selection.main.head;
         this.#cm.dispatch({
-            changes: {from: index, insert: markup},
-            selection: {anchor: index + markup.length},
+            changes: {from: pos, insert: markup},
+            selection: {anchor: pos + markup.length},
         });
     }
 

--- a/packages/editor/src/markup/editor.ts
+++ b/packages/editor/src/markup/editor.ts
@@ -78,6 +78,34 @@ export class Editor implements CommonEditor, CodeEditor {
         this.#cm.dispatch({changes: {from: doc.length, insert}});
     }
 
+    insertAt(markup: MarkupString, index?: number): void {
+        const docLength = this.#cm.state.doc.length;
+
+        if (index === undefined) {
+            const pos = this.#cm.state.selection.main.head;
+            this.#cm.dispatch({
+                changes: {from: pos, insert: markup},
+                selection: {anchor: pos + markup.length},
+            });
+            return;
+        }
+
+        if (index < 0) {
+            this.prepend(markup);
+            return;
+        }
+
+        if (index > docLength) {
+            this.append(markup);
+            return;
+        }
+
+        this.#cm.dispatch({
+            changes: {from: index, insert: markup},
+            selection: {anchor: index + markup.length},
+        });
+    }
+
     moveCursor(position: 'start' | 'end'): void {
         let pos: number;
         switch (position) {

--- a/packages/editor/src/markup/editor.ts
+++ b/packages/editor/src/markup/editor.ts
@@ -79,11 +79,7 @@ export class Editor implements CommonEditor, CodeEditor {
     }
 
     insert(markup: MarkupString): void {
-        const pos = this.#cm.state.selection.main.head;
-        this.#cm.dispatch({
-            changes: {from: pos, insert: markup},
-            selection: {anchor: pos + markup.length},
-        });
+        this.#cm.dispatch(this.#cm.state.replaceSelection(markup));
     }
 
     moveCursor(position: 'start' | 'end'): void {


### PR DESCRIPTION
I added the isertAt method, which adds to the cursor if the parameter is not passed, and to the index if it is passed. If the index is out of range, it uses the standard isert and prepend methods.

## Summary by Sourcery

Add support for inserting markup at a specific position or at the current cursor across editor implementations.

New Features:
- Expose an insertAt(markup, index?) API on the public Markdown editor and underlying editors to insert markup at the cursor or at a given absolute position.

Documentation:
- Document the new insertAt method on the public editor and content handler interfaces.

Tests:
- Add unit tests covering insertAt behavior for negative indices (prepend), in-range indices, out-of-range indices (append), and default cursor-based insertion in both Wysiwyg and markup editors.