### PR TITLE
fix(view): avoid UI freeze when gallery processes data URI links

### DIFF
--- a/packages/editor/src/view/hooks/useFilesGallery/helpers.ts
+++ b/packages/editor/src/view/hooks/useFilesGallery/helpers.ts
@@ -37,8 +37,7 @@ export function buildLinkObject(elem: Element): LinkObject | null {
     return obj;
 }
 
-const dataUriMimetypeRegex = /^data:([^;,]+)/;
-function getMimetypeFromDataUri(link: string): string | null {
-    if (!link.startsWith('data:')) return null;
-    return link.match(dataUriMimetypeRegex)?.[1] ?? null;
+const dataUriMimetypeRegex = /^data:([^;,]+)/i;
+function getMimetypeFromDataUri(link: string) {
+    return link.match(dataUriMimetypeRegex)?.[1];
 }

--- a/packages/editor/src/view/hooks/useFilesGallery/helpers.ts
+++ b/packages/editor/src/view/hooks/useFilesGallery/helpers.ts
@@ -30,5 +30,15 @@ export function buildLinkObject(elem: Element): LinkObject | null {
         }
     }
 
+    if (obj && !obj.mimetype) {
+        obj.mimetype = getMimetypeFromDataUri(obj.link);
+    }
+
     return obj;
+}
+
+const dataUriMimetypeRegex = /^data:([^;,]+)/;
+function getMimetypeFromDataUri(link: string): string | null {
+    if (!link.startsWith('data:')) return null;
+    return link.match(dataUriMimetypeRegex)?.[1] ?? null;
 }

--- a/packages/editor/src/view/hooks/useFilesGallery/useFilesGallery.tsx
+++ b/packages/editor/src/view/hooks/useFilesGallery/useFilesGallery.tsx
@@ -97,7 +97,10 @@ export function useFilesGallery(
                     if (linkObj?.link && !customFiles?.some((item) => item.url === linkObj.link)) {
                         const extension =
                             linkObj.mimetype?.match(extensionRegex)?.[0] ||
-                            linkObj.link.match(extensionRegex)?.[0] ||
+                            // skip regex on data URIs to avoid catastrophic backtracking
+                            (linkObj.link.startsWith('data:')
+                                ? ''
+                                : linkObj.link.match(extensionRegex)?.[0]) ||
                             '';
 
                         if (linkObj.type === 'image' || supportedExtensions.includes(extension)) {

--- a/packages/editor/src/view/hooks/useFilesGallery/useFilesGallery.tsx
+++ b/packages/editor/src/view/hooks/useFilesGallery/useFilesGallery.tsx
@@ -98,7 +98,7 @@ export function useFilesGallery(
                         const extension =
                             linkObj.mimetype?.match(extensionRegex)?.[0] ||
                             // skip regex on data URIs to avoid catastrophic backtracking
-                            (linkObj.link.startsWith('data:')
+                            (/^data:/i.test(linkObj.link)
                                 ? ''
                                 : linkObj.link.match(extensionRegex)?.[0]) ||
                             '';


### PR DESCRIPTION
## Summary by Sourcery

Handle data URI links more safely in the files gallery to prevent UI freezes when deriving file metadata.

Bug Fixes:
- Avoid catastrophic regex backtracking on data URI links when extracting file extensions in the files gallery.

Enhancements:
- Infer missing MIME types from data URI links when building link objects in the files gallery.