### PR TITLE
fix(YfmHtmlBlock): preserve nested html block serialization

### DIFF
--- a/packages/editor/src/extensions/additional/YfmHtmlBlock/YfmHtmlBlock.test.ts
+++ b/packages/editor/src/extensions/additional/YfmHtmlBlock/YfmHtmlBlock.test.ts
@@ -1,8 +1,17 @@
 import {builders} from 'prosemirror-test-builder';
+import dd from 'ts-dedent';
 
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
 import {ExtensionsManager} from '../../../core';
-import {BaseNode, BaseSchemaSpecs} from '../../specs';
+import {
+    BaseNode,
+    BaseSchemaSpecs,
+    BlockquoteSpecs,
+    ListNode,
+    ListsAttr,
+    ListsSpecs,
+    blockquoteNodeName,
+} from '../../specs';
 
 import {YfmHtmlBlockSpecs} from './YfmHtmlBlockSpecs';
 import {YfmHtmlBlockAttrs, yfmHtmlBlockNodeName} from './const';
@@ -16,13 +25,24 @@ const {
     markupParser: parser,
     serializer,
 } = new ExtensionsManager({
-    extensions: (builder) => builder.use(BaseSchemaSpecs, {}).use(YfmHtmlBlockSpecs, {}),
+    extensions: (builder) =>
+        builder
+            .use(BaseSchemaSpecs, {})
+            .use(BlockquoteSpecs)
+            .use(ListsSpecs)
+            .use(YfmHtmlBlockSpecs, {}),
 }).buildDeps();
 
-const {doc, yfmHtmlBlock} = builders<'doc' | 'yfmHtmlBlock'>(schema, {
-    doc: {nodeType: BaseNode.Doc},
-    yfmHtmlBlock: {nodeType: yfmHtmlBlockNodeName},
-});
+const {doc, q, li, ul, yfmHtmlBlock} = builders<'doc' | 'q' | 'li' | 'ul' | 'yfmHtmlBlock'>(
+    schema,
+    {
+        doc: {nodeType: BaseNode.Doc},
+        q: {nodeType: blockquoteNodeName},
+        li: {nodeType: ListNode.ListItem},
+        ul: {nodeType: ListNode.BulletList},
+        yfmHtmlBlock: {nodeType: yfmHtmlBlockNodeName},
+    },
+);
 
 const {same} = createMarkupChecker({parser, serializer});
 
@@ -37,4 +57,84 @@ describe('YfmHtmlBlock extension', () => {
                 }),
             ),
         ));
+
+    it('should serialize multiline yfmHtmlBlock inside blockquote', () => {
+        const srcdoc = '<div>one</div>\n<div>two</div>\n';
+        const markup = dd`
+        > ::: html
+        > <div>one</div>
+        > <div>two</div>
+        > :::
+        `.trim();
+
+        same(
+            markup,
+            doc(
+                q(
+                    yfmHtmlBlock({
+                        [YfmHtmlBlockAttrs.srcdoc]: srcdoc,
+                        [YfmHtmlBlockAttrs.EntityId]: 'yfm_html_block-8bca-mocked-7abc',
+                    }),
+                ),
+            ),
+        );
+    });
+
+    it('should preserve trailing blank line in blockquoted yfmHtmlBlock content', () => {
+        const srcdoc = '<div>one</div>\n\n';
+        const markup = ['> ::: html', '> <div>one</div>', '> ', '> :::'].join('\n');
+
+        same(
+            markup,
+            doc(
+                q(
+                    yfmHtmlBlock({
+                        [YfmHtmlBlockAttrs.srcdoc]: srcdoc,
+                        [YfmHtmlBlockAttrs.EntityId]: 'yfm_html_block-8bca-mocked-7abc',
+                    }),
+                ),
+            ),
+        );
+    });
+
+    it('should preserve trailing blank line in yfmHtmlBlock content', () => {
+        const srcdoc = '<div>one</div>\n\n';
+        const markup = ['::: html', '<div>one</div>', '', ':::'].join('\n');
+
+        same(
+            markup,
+            doc(
+                yfmHtmlBlock({
+                    [YfmHtmlBlockAttrs.srcdoc]: srcdoc,
+                    [YfmHtmlBlockAttrs.EntityId]: 'yfm_html_block-8bca-mocked-7abc',
+                }),
+            ),
+        );
+    });
+
+    it('should serialize multiline yfmHtmlBlock inside list item', () => {
+        const srcdoc = '<div>one</div>\n<div>two</div>\n';
+        const markup = dd`
+        * ::: html
+          <div>one</div>
+          <div>two</div>
+          :::
+        `.trim();
+
+        same(
+            markup,
+            doc(
+                ul(
+                    {[ListsAttr.Markup]: '*', [ListsAttr.Tight]: false},
+                    li(
+                        {[ListsAttr.Markup]: '*'},
+                        yfmHtmlBlock({
+                            [YfmHtmlBlockAttrs.srcdoc]: srcdoc,
+                            [YfmHtmlBlockAttrs.EntityId]: 'yfm_html_block-8bca-mocked-7abc',
+                        }),
+                    ),
+                ),
+            ),
+        );
+    });
 });

--- a/packages/editor/src/extensions/additional/YfmHtmlBlock/YfmHtmlBlockSpecs/index.tsx
+++ b/packages/editor/src/extensions/additional/YfmHtmlBlock/YfmHtmlBlockSpecs/index.tsx
@@ -56,10 +56,24 @@ const YfmHtmlBlockSpecsExtension: ExtensionAuto<YfmHtmlBlockSpecsOptions> = (
                 toDOM: (node) => ['iframe', node.attrs],
             },
             toMd: (state, node) => {
+                // The parser includes the line break before closing ::: in srcdoc.
+                // Drop only that structural newline; any remaining trailing newline is content.
+                const srcdoc = String(
+                    node.attrs[YfmHtmlBlockConsts.NodeAttrs.srcdoc] || '',
+                ).replace(/\n$/, '');
+
                 state.write('::: html');
-                state.write('\n');
-                state.write(node.attrs[YfmHtmlBlockConsts.NodeAttrs.srcdoc]);
                 state.ensureNewLine();
+
+                if (srcdoc) {
+                    state.text(srcdoc, false);
+                    // At top level, state.text() has no visible delimiter for a final empty line.
+                    if (srcdoc.endsWith('\n') && state.atBlank()) {
+                        state.write('\n');
+                    }
+                    state.ensureNewLine();
+                }
+
                 state.write(':::');
                 state.closeBlock(node);
             },


### PR DESCRIPTION
## Summary
- Serialize YFM HTML block srcdoc line-by-line so nested blockquote and list delimiters are preserved.
- Treat the parser-provided final newline as structural while preserving intentional trailing blank content.
- Add regression coverage for blockquote, list item, and trailing blank-line serialization.

## Test Plan
- Containerized targeted Jest: `pnpm --filter @gravity-ui/markdown-editor test -- src/extensions/additional/YfmHtmlBlock/YfmHtmlBlock.test.ts`
- Containerized ESLint: `pnpm exec eslint packages/editor/src/extensions/additional/YfmHtmlBlock/YfmHtmlBlock.test.ts packages/editor/src/extensions/additional/YfmHtmlBlock/YfmHtmlBlockSpecs/index.tsx`
- `git diff --check`

## Notes
- Verified the regression by reverting only the serializer change in an isolated container copy and confirming the new nested serialization tests fail.

## Summary by Sourcery

Preserve correct markdown serialization of YFM HTML blocks, including nested usage and trailing blank lines.

Bug Fixes:
- Fix markdown serializer to keep nested YFM HTML blocks inside blockquotes and list items from breaking blockquote/list delimiters.
- Fix markdown serializer to retain intentional trailing blank lines in YFM HTML block content.

Tests:
- Add regression tests covering multiline YFM HTML blocks within blockquotes and list items and cases with trailing blank lines in content.