### PR TITLE
fix(bundle): fixed opening of drop-down list in ToolbarSelect component

### DIFF
--- a/packages/editor/src/bundle/toolbar/ToolbarSelect.tsx
+++ b/packages/editor/src/bundle/toolbar/ToolbarSelect.tsx
@@ -41,7 +41,9 @@ export const ToolbarSelect: React.FC<ToolbarSelectProps> = ({
                 view="clear"
                 className={className}
                 disablePortal={disablePortal}
-                onOpenChange={focus}
+                onOpenChange={(open) => {
+                    if (!open) focus();
+                }}
                 value={activeItem ? [activeItem.id] : undefined}
                 options={items.map<SelectOption>((item) => ({
                     data: item,


### PR DESCRIPTION
fixed onOpenChange for ToolbarSelect

## Summary by Sourcery

Bug Fixes:
- Ensure ToolbarSelect only calls focus when the dropdown is closed in onOpenChange.