### PR TITLE
fix(YfmTable): fix color propagation to already colored cells

### DIFF
--- a/demo/tests/visual-tests/playground/YfmTable.visual.test.tsx
+++ b/demo/tests/visual-tests/playground/YfmTable.visual.test.tsx
@@ -968,6 +968,74 @@ test.describe('YfmTable', () => {
             await expect(cellsLocator.nth(1)).toHaveAttribute('data-bg', 'green');
         });
 
+        test('should propagate row background when first cell already has target color', async ({
+            mount,
+            editor,
+        }) => {
+            const initial = dd`
+            #|
+            ||::{bg="yellow"} one   | two  ||
+            ||                three | four ||
+            |#
+            `;
+
+            await mount(<Playground initial={initial} yfmMods={yfmMods} />);
+
+            const tableLocator = (
+                await editor.yfmTable.getTable(editor.locators.contenteditable)
+            ).first();
+            const cellsLocator = await editor.yfmTable.getCells(tableLocator);
+            const firstCell = cellsLocator.first();
+            const rowButton = (await editor.yfmTable.getRowButtons(tableLocator)).first();
+
+            await expect(cellsLocator.nth(0)).toHaveAttribute('data-bg', 'yellow');
+            await expect(cellsLocator.nth(1)).not.toHaveAttribute('data-bg');
+
+            await editor.yfmTable.focusFirstCell(tableLocator);
+            await firstCell.hover();
+            await rowButton.click();
+            await editor.yfmTable.selectCellBg('row', 'Yellow');
+
+            await expect(cellsLocator.nth(0)).toHaveAttribute('data-bg', 'yellow');
+            await expect(cellsLocator.nth(1)).toHaveAttribute('data-bg', 'yellow');
+            await expect(cellsLocator.nth(2)).not.toHaveAttribute('data-bg');
+            await expect(cellsLocator.nth(3)).not.toHaveAttribute('data-bg');
+        });
+
+        test('should propagate column background when first cell already has target color', async ({
+            mount,
+            editor,
+        }) => {
+            const initial = dd`
+            #|
+            ||::{bg="blue"} one   | two  ||
+            ||              three | four ||
+            |#
+            `;
+
+            await mount(<Playground initial={initial} yfmMods={yfmMods} />);
+
+            const tableLocator = (
+                await editor.yfmTable.getTable(editor.locators.contenteditable)
+            ).first();
+            const cellsLocator = await editor.yfmTable.getCells(tableLocator);
+            const firstCell = cellsLocator.first();
+            const columnButton = (await editor.yfmTable.getColumnButtons(tableLocator)).first();
+
+            await expect(cellsLocator.nth(0)).toHaveAttribute('data-bg', 'blue');
+            await expect(cellsLocator.nth(2)).not.toHaveAttribute('data-bg');
+
+            await editor.yfmTable.focusFirstCell(tableLocator);
+            await firstCell.hover();
+            await columnButton.click();
+            await editor.yfmTable.selectCellBg('column', 'Blue');
+
+            await expect(cellsLocator.nth(0)).toHaveAttribute('data-bg', 'blue');
+            await expect(cellsLocator.nth(2)).toHaveAttribute('data-bg', 'blue');
+            await expect(cellsLocator.nth(1)).not.toHaveAttribute('data-bg');
+            await expect(cellsLocator.nth(3)).not.toHaveAttribute('data-bg');
+        });
+
         test('should apply column color independently from row color', async ({
             page,
             wait,

--- a/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/commands/set-cell-bg.ts
+++ b/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/commands/set-cell-bg.ts
@@ -21,16 +21,13 @@ export const setCellBg = (params: SetCellBgParams): Command => {
         if (!dispatch) return true;
 
         const {tr} = state;
+        const newBgValue = params.bg || null;
 
         const apply = (cellPos: ReturnType<typeof tableDesc.getPosForRowCells>[number]) => {
             if (cellPos.type !== 'real') return;
             const node = state.doc.nodeAt(cellPos.from);
-            if (!node) return;
-            tr.setNodeAttribute(
-                tr.mapping.map(cellPos.from),
-                YfmTableAttr.CellBg,
-                params.bg || null,
-            );
+            if (!node || node.attrs[YfmTableAttr.CellBg] === newBgValue) return;
+            tr.setNodeAttribute(tr.mapping.map(cellPos.from), YfmTableAttr.CellBg, newBgValue);
         };
 
         if (params.rows) {

--- a/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/components/CellBgPalette/CellBgPalette.tsx
+++ b/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/components/CellBgPalette/CellBgPalette.tsx
@@ -20,7 +20,6 @@ export const CellBgPalette: React.FC<CellBgPaletteProps> = function YfmTableCell
     onSelect,
 }) {
     const handleClick = (swatchValue: string) => {
-        if (swatchValue === value || (swatchValue === NO_COLOR_VALUE && !value)) return;
         onSelect(swatchValue === NO_COLOR_VALUE ? null : swatchValue);
     };
 


### PR DESCRIPTION
When the first cell already had a background color applied, assigning a new color to other cells in the same row or column required multiple clicks (workaround: assign a different color first, then the desired one).

Now the background color can be assigned to multiple cells in a row or column with a single click.

## Summary by Sourcery

Fix table cell background color propagation when applying a row or column color to cells where the first cell already has that color, and add regression tests for these scenarios.

Bug Fixes:
- Ensure row background color is applied to all selected cells even if the first cell already has the target color.
- Ensure column background color is applied to all selected cells even if the first cell already has the target color.

Tests:
- Add visual tests covering row and column background color propagation when the first cell already has the selected background color.