### PR TITLE
feat(YfmTable): inherit cell background on row/column add

### DIFF
--- a/demo/tests/visual-tests/playground/YfmTable.visual.test.tsx
+++ b/demo/tests/visual-tests/playground/YfmTable.visual.test.tsx
@@ -1210,5 +1210,129 @@ test.describe('YfmTable', () => {
             await wait.timeout(500);
             await expectScreenshot();
         });
+
+        test('should inherit bg when adding row after', async ({wait, mount, editor}) => {
+            const initial = dd`
+            #|
+            ||::{bg="yellow"} one  |::{bg="blue"} two ||
+            ||::{bg="green"} three | four             ||
+            |#
+            `;
+
+            await mount(<Playground initial={initial} yfmMods={yfmMods} />);
+
+            const tableLocator = (
+                await editor.yfmTable.getTable(editor.locators.contenteditable)
+            ).first();
+            const cellsLocator = await editor.yfmTable.getCells(tableLocator);
+            const firstCell = cellsLocator.first();
+            const rowButton = (await editor.yfmTable.getRowButtons(tableLocator)).first();
+
+            await editor.yfmTable.focusFirstCell(tableLocator);
+            await firstCell.hover(); // first row
+            await wait.timeout(200);
+            await rowButton.click();
+            await editor.yfmTable.doCellAction('row', 'add-row-after');
+
+            await expect(cellsLocator).toHaveCount(6);
+            await expect(cellsLocator.nth(2)).toHaveAttribute('data-bg', 'yellow');
+            await expect(cellsLocator.nth(3)).toHaveAttribute('data-bg', 'blue');
+            await expect(cellsLocator.nth(4)).toHaveAttribute('data-bg', 'green');
+            await expect(cellsLocator.nth(5)).not.toHaveAttribute('data-bg');
+        });
+
+        test('should inherit bg when adding row before', async ({wait, mount, editor}) => {
+            const initial = dd`
+            #|
+            ||::{bg="yellow"} one  |::{bg="blue"} two ||
+            ||::{bg="green"} three | four             ||
+            |#
+            `;
+
+            await mount(<Playground initial={initial} yfmMods={yfmMods} />);
+
+            const tableLocator = (
+                await editor.yfmTable.getTable(editor.locators.contenteditable)
+            ).first();
+            const cellsLocator = await editor.yfmTable.getCells(tableLocator);
+            const rowButton = (await editor.yfmTable.getRowButtons(tableLocator)).nth(1);
+
+            await editor.yfmTable.focusFirstCell(tableLocator);
+            await cellsLocator.nth(2).hover(); // second row
+            await wait.timeout(200);
+            await rowButton.click();
+            await editor.yfmTable.doCellAction('row', 'add-row-before');
+
+            await expect(cellsLocator).toHaveCount(6);
+            await expect(cellsLocator.nth(0)).toHaveAttribute('data-bg', 'yellow');
+            await expect(cellsLocator.nth(1)).toHaveAttribute('data-bg', 'blue');
+            await expect(cellsLocator.nth(2)).toHaveAttribute('data-bg', 'green');
+            await expect(cellsLocator.nth(3)).not.toHaveAttribute('data-bg');
+            await expect(cellsLocator.nth(4)).toHaveAttribute('data-bg', 'green');
+            await expect(cellsLocator.nth(5)).not.toHaveAttribute('data-bg');
+        });
+
+        test('should inherit bg when adding column after', async ({wait, mount, editor}) => {
+            const initial = dd`
+            #|
+            ||::{bg="yellow"} one  |::{bg="blue"} two ||
+            ||::{bg="green"} three | four             ||
+            |#
+            `;
+
+            await mount(<Playground initial={initial} yfmMods={yfmMods} />);
+
+            const tableLocator = (
+                await editor.yfmTable.getTable(editor.locators.contenteditable)
+            ).first();
+            const cellsLocator = await editor.yfmTable.getCells(tableLocator);
+            const firstCell = cellsLocator.first();
+            const columnButton = (await editor.yfmTable.getColumnButtons(tableLocator)).first();
+
+            await editor.yfmTable.focusFirstCell(tableLocator);
+            await firstCell.hover(); // first column
+            await wait.timeout(200);
+            await columnButton.click();
+            await editor.yfmTable.doCellAction('column', 'add-column-after');
+
+            await expect(cellsLocator).toHaveCount(6);
+            await expect(cellsLocator.nth(0)).toHaveAttribute('data-bg', 'yellow');
+            await expect(cellsLocator.nth(1)).toHaveAttribute('data-bg', 'yellow');
+            await expect(cellsLocator.nth(2)).toHaveAttribute('data-bg', 'blue');
+            await expect(cellsLocator.nth(3)).toHaveAttribute('data-bg', 'green');
+            await expect(cellsLocator.nth(4)).toHaveAttribute('data-bg', 'green');
+            await expect(cellsLocator.nth(5)).not.toHaveAttribute('data-bg');
+        });
+
+        test('should inherit bg when adding column before', async ({wait, mount, editor}) => {
+            const initial = dd`
+            #|
+            ||::{bg="yellow"} one  |::{bg="blue"} two ||
+            ||::{bg="green"} three | four             ||
+            |#
+            `;
+
+            await mount(<Playground initial={initial} yfmMods={yfmMods} />);
+
+            const tableLocator = (
+                await editor.yfmTable.getTable(editor.locators.contenteditable)
+            ).first();
+            const cellsLocator = await editor.yfmTable.getCells(tableLocator);
+            const columnButton = (await editor.yfmTable.getColumnButtons(tableLocator)).nth(1);
+
+            await editor.yfmTable.focusFirstCell(tableLocator);
+            await cellsLocator.nth(1).hover(); // second column
+            await wait.timeout(200);
+            await columnButton.click();
+            await editor.yfmTable.doCellAction('column', 'add-column-before');
+
+            await expect(cellsLocator).toHaveCount(6);
+            await expect(cellsLocator.nth(0)).toHaveAttribute('data-bg', 'yellow');
+            await expect(cellsLocator.nth(1)).toHaveAttribute('data-bg', 'blue');
+            await expect(cellsLocator.nth(2)).toHaveAttribute('data-bg', 'blue');
+            await expect(cellsLocator.nth(3)).toHaveAttribute('data-bg', 'green');
+            await expect(cellsLocator.nth(4)).not.toHaveAttribute('data-bg');
+            await expect(cellsLocator.nth(5)).not.toHaveAttribute('data-bg');
+        });
     });
 });

--- a/demo/tests/visual-tests/playground/YfmTable.visual.test.tsx
+++ b/demo/tests/visual-tests/playground/YfmTable.visual.test.tsx
@@ -1255,7 +1255,7 @@ test.describe('YfmTable', () => {
                 await editor.yfmTable.getTable(editor.locators.contenteditable)
             ).first();
             const cellsLocator = await editor.yfmTable.getCells(tableLocator);
-            const rowButton = (await editor.yfmTable.getRowButtons(tableLocator)).nth(1);
+            const rowButton = (await editor.yfmTable.getRowButtons(tableLocator)).first();
 
             await editor.yfmTable.focusFirstCell(tableLocator);
             await cellsLocator.nth(2).hover(); // second row
@@ -1318,7 +1318,7 @@ test.describe('YfmTable', () => {
                 await editor.yfmTable.getTable(editor.locators.contenteditable)
             ).first();
             const cellsLocator = await editor.yfmTable.getCells(tableLocator);
-            const columnButton = (await editor.yfmTable.getColumnButtons(tableLocator)).nth(1);
+            const columnButton = (await editor.yfmTable.getColumnButtons(tableLocator)).first();
 
             await editor.yfmTable.focusFirstCell(tableLocator);
             await cellsLocator.nth(1).hover(); // second column

--- a/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/actions.ts
+++ b/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/actions.ts
@@ -1,7 +1,5 @@
 import type {CommandWithAttrs} from '#core';
 import type {Node} from '#pm/model';
-import {appendColumn, appendRow, removeColumn, removeRow} from 'src/table-utils';
-import {defineActions} from 'src/utils/actions';
 import {removeNode} from 'src/utils/remove-node';
 
 export const removeYfmTable: CommandWithAttrs<{
@@ -22,25 +20,3 @@ export const removeYfmTable: CommandWithAttrs<{
 
     return true;
 };
-export const controlActions = defineActions({
-    deleteRow: {
-        isEnable: removeRow,
-        run: removeRow,
-    },
-    deleteColumn: {
-        isEnable: removeColumn,
-        run: removeColumn,
-    },
-    appendColumn: {
-        isEnable: appendColumn,
-        run: appendColumn,
-    },
-    appendRow: {
-        isEnable: appendRow,
-        run: appendRow,
-    },
-    deleteTable: {
-        isEnable: removeYfmTable,
-        run: removeYfmTable,
-    },
-});

--- a/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/commands/insert-empty-column.ts
+++ b/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/commands/insert-empty-column.ts
@@ -8,10 +8,13 @@ import {
 } from 'src/table-utils/table-desc';
 
 import {yfmTableCellType} from '../../../YfmTableSpecs';
+import {YfmTableAttr} from '../../../YfmTableSpecs/const';
+import {getCellBg} from '../utils';
 
 export type InsertEmptyColumnParams = {
     tablePos: number;
     colIndex: number;
+    sourceColIndex?: number;
 };
 
 export const insertEmptyColumn = (params: InsertEmptyColumnParams): Command => {
@@ -23,28 +26,43 @@ export const insertEmptyColumn = (params: InsertEmptyColumnParams): Command => {
         const colIdx = Math.min(Math.max(params.colIndex, 0), tableDesc.cols);
 
         if (dispatch) {
-            const posToInsert: number[] = [];
+            const cellsToInsert: {pos: number; bg: string | null}[] = [];
             const incrementColspan: [number, number][] = [];
+            const {sourceColIndex} = params;
 
             if (colIdx === 0) {
-                posToInsert.push(
-                    ...tableDesc.getPosForColumn(0).map((pos) => getCellPos(pos, 'start')),
-                );
+                tableDesc.getPosForColumn(0).forEach((pos, rowIdx) => {
+                    cellsToInsert.push({
+                        pos: getCellPos(pos, 'start'),
+                        bg:
+                            typeof sourceColIndex === 'number'
+                                ? getCellBg(tableDesc.base, rowIdx, sourceColIndex)
+                                : null,
+                    });
+                });
             } else if (colIdx === tableDesc.cols) {
-                posToInsert.push(
-                    ...tableDesc
-                        .getPosForColumn(tableDesc.cols - 1)
-                        .map((pos) => getCellPos(pos, 'end')),
-                );
+                tableDesc.getPosForColumn(tableDesc.cols - 1).forEach((pos, rowIdx) => {
+                    cellsToInsert.push({
+                        pos: getCellPos(pos, 'end'),
+                        bg:
+                            typeof sourceColIndex === 'number'
+                                ? getCellBg(tableDesc.base, rowIdx, sourceColIndex)
+                                : null,
+                    });
+                });
             } else {
                 for (let rowIdx = 0; rowIdx < tableDesc.rows; rowIdx++) {
                     const cell = tableDesc.base.rowsDesc[rowIdx].cells[colIdx];
                     if (cell.type === 'virtual' && cell.colspan && cell.colspan[1] !== colIdx) {
                         incrementColspan.push(cell.colspan);
                     } else {
-                        posToInsert.push(
-                            getCellPos(tableDesc.getPosForCell(rowIdx, colIdx), 'start'),
-                        );
+                        cellsToInsert.push({
+                            pos: getCellPos(tableDesc.getPosForCell(rowIdx, colIdx), 'start'),
+                            bg:
+                                typeof sourceColIndex === 'number'
+                                    ? getCellBg(tableDesc.base, rowIdx, sourceColIndex)
+                                    : null,
+                        });
                     }
                 }
             }
@@ -56,10 +74,13 @@ export const insertEmptyColumn = (params: InsertEmptyColumnParams): Command => {
                 const cellPos = tableDesc.getPosForCell(rowIdx, colIdx) as RealCellPos;
                 tr.setNodeAttribute(cellPos.from, 'colspan', cell.colspan! + 1);
             }
-            for (const pos of posToInsert) {
-                tr.insert(tr.mapping.map(pos), td.createAndFill()!);
+            for (const {pos, bg} of cellsToInsert) {
+                tr.insert(
+                    tr.mapping.map(pos),
+                    td.createAndFill(bg ? {[YfmTableAttr.CellBg]: bg} : undefined)!,
+                );
             }
-            tr.setSelection(TextSelection.near(tr.doc.resolve(posToInsert[0]), 1));
+            tr.setSelection(TextSelection.near(tr.doc.resolve(cellsToInsert[0].pos), 1));
             dispatch(tr.scrollIntoView());
         }
 

--- a/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/commands/insert-empty-row.ts
+++ b/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/commands/insert-empty-row.ts
@@ -1,14 +1,16 @@
 import type {Schema} from '#pm/model';
 import {type Command, TextSelection} from '#pm/state';
-import {isEqual, range, uniqWith} from 'src/lodash';
+import {isEqual, uniqWith} from 'src/lodash';
 import {type RealCellPos, type TableCellRealDesc, TableDesc} from 'src/table-utils/table-desc';
 
 import {yfmTableCellType, yfmTableRowType} from '../../../YfmTableSpecs';
 import {YfmTableAttr} from '../../../YfmTableSpecs/const';
+import {getCellBg} from '../utils';
 
 export type InsertEmptyRowParams = {
     tablePos: number;
     rowIndex: number;
+    sourceRowIndex?: number;
 };
 
 export const insertEmptyRow = (params: InsertEmptyRowParams): Command => {
@@ -21,22 +23,27 @@ export const insertEmptyRow = (params: InsertEmptyRowParams): Command => {
 
         if (dispatch) {
             let posToInsert: number;
-            let newCellsCount: number = tableDesc.cols;
+            const newCellBgs: (string | null)[] = [];
             const incrementRowspan: [number, number][] = [];
+            const {sourceRowIndex} = params;
 
             if (rowIdx === 0 || rowIdx === tableDesc.rows) {
                 posToInsert =
                     rowIdx === 0
                         ? tableDesc.getPosForRow(0).from
                         : tableDesc.getPosForRow(tableDesc.rows - 1).to;
+                for (let colIdx = 0; colIdx < tableDesc.cols; colIdx++) {
+                    newCellBgs.push(getBg(tableDesc.base, sourceRowIndex, colIdx));
+                }
             } else {
                 posToInsert = tableDesc.getPosForRow(rowIdx).from;
 
                 for (let colIdx = 0; colIdx < tableDesc.cols; colIdx++) {
                     const cell = tableDesc.base.rowsDesc[rowIdx].cells[colIdx];
                     if (cell.type === 'virtual' && cell.rowspan) {
-                        newCellsCount--;
                         incrementRowspan.push(cell.rowspan);
+                    } else {
+                        newCellBgs.push(getBg(tableDesc.base, sourceRowIndex, colIdx));
                     }
                 }
             }
@@ -47,7 +54,7 @@ export const insertEmptyRow = (params: InsertEmptyRowParams): Command => {
                 const cellPos = tableDesc.getPosForCell(rowIdx, colIdx) as RealCellPos;
                 tr.setNodeAttribute(cellPos.from, 'rowspan', cell.rowspan! + 1);
             }
-            tr.insert(posToInsert, createSimpleRow(state.schema, newCellsCount));
+            tr.insert(posToInsert, createSimpleRow(state.schema, newCellBgs));
             tr.setSelection(TextSelection.near(tr.doc.resolve(posToInsert), 1));
 
             // If the new row is inserted inside the header-rows block, shrink the block
@@ -63,11 +70,17 @@ export const insertEmptyRow = (params: InsertEmptyRowParams): Command => {
     };
 };
 
-const createSimpleRow = (schema: Schema, cols: number) => {
+function getBg(base: TableDesc, sourceRowIndex: number | undefined, colIdx: number): string | null {
+    if (sourceRowIndex === undefined) return null;
+    return getCellBg(base, sourceRowIndex, colIdx);
+}
+
+const createSimpleRow = (schema: Schema, cellBgs: (string | null)[]) => {
     const tr = yfmTableRowType(schema);
     const td = yfmTableCellType(schema);
     return tr.create(
         null,
-        range(0, cols).map(() => td.createAndFill()!),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        cellBgs.map((bg) => td.createAndFill(bg ? {[YfmTableAttr.CellBg]: bg} : undefined)!),
     );
 };

--- a/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/nodeviews/yfm-table-cell-view.tsx
+++ b/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/nodeviews/yfm-table-cell-view.tsx
@@ -395,7 +395,7 @@ class YfmTableCellView implements NodeView {
         const info = this._getCellInfo();
         if (info) {
             const rowRange = info.tableDesc.base.getRowRangeByRowIdx(info.cell.row);
-            this._insertRow(info.tableDesc, rowRange.startIdx);
+            this._insertRow(info.tableDesc, rowRange.startIdx, rowRange.startIdx);
         }
 
         this._view.focus();
@@ -407,14 +407,14 @@ class YfmTableCellView implements NodeView {
         const info = this._getCellInfo();
         if (info) {
             const rowRange = info.tableDesc.base.getRowRangeByRowIdx(info.cell.row);
-            this._insertRow(info.tableDesc, rowRange.endIdx + 1);
+            this._insertRow(info.tableDesc, rowRange.endIdx + 1, rowRange.endIdx);
         }
 
         this._view.focus();
     };
 
-    private _insertRow(tableDesc: TableDescBinded, rowIndex: number) {
-        insertEmptyRow({tablePos: tableDesc.pos, rowIndex})(
+    private _insertRow(tableDesc: TableDescBinded, rowIndex: number, sourceRowIndex: number) {
+        insertEmptyRow({tablePos: tableDesc.pos, rowIndex, sourceRowIndex})(
             this._view.state,
             this._view.dispatch,
             this._view,
@@ -427,7 +427,7 @@ class YfmTableCellView implements NodeView {
         const info = this._getCellInfo();
         if (info) {
             const colRange = info.tableDesc.base.getColumnRangeByColumnIdx(info.cell.column);
-            this._insertColumn(info.tableDesc, colRange.startIdx);
+            this._insertColumn(info.tableDesc, colRange.startIdx, colRange.startIdx);
         }
 
         this._view.focus();
@@ -439,14 +439,14 @@ class YfmTableCellView implements NodeView {
         const info = this._getCellInfo();
         if (info) {
             const colRange = info.tableDesc.base.getColumnRangeByColumnIdx(info.cell.column);
-            this._insertColumn(info.tableDesc, colRange.endIdx + 1);
+            this._insertColumn(info.tableDesc, colRange.endIdx + 1, colRange.endIdx);
         }
 
         this._view.focus();
     };
 
-    private _insertColumn(tableDesc: TableDescBinded, colIndex: number) {
-        insertEmptyColumn({tablePos: tableDesc.pos, colIndex})(
+    private _insertColumn(tableDesc: TableDescBinded, colIndex: number, sourceColIndex: number) {
+        insertEmptyColumn({tablePos: tableDesc.pos, colIndex, sourceColIndex})(
             this._view.state,
             this._view.dispatch,
             this._view,

--- a/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/nodeviews/yfm-table-view.tsx
+++ b/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/nodeviews/yfm-table-view.tsx
@@ -127,7 +127,7 @@ class YfmTableNewView implements NodeView {
         const tableDesc = this._getTableDesc();
         if (!tableDesc) return;
 
-        insertEmptyRow({tablePos: tableDesc.pos, rowIndex: rowIdx + 1})(
+        insertEmptyRow({tablePos: tableDesc.pos, rowIndex: rowIdx + 1, sourceRowIndex: rowIdx})(
             this._view.state,
             this._view.dispatch,
         );
@@ -141,10 +141,11 @@ class YfmTableNewView implements NodeView {
         const tableDesc = this._getTableDesc();
         if (!tableDesc) return;
 
-        insertEmptyColumn({tablePos: tableDesc.pos, colIndex: colIdx + 1})(
-            this._view.state,
-            this._view.dispatch,
-        );
+        insertEmptyColumn({
+            tablePos: tableDesc.pos,
+            colIndex: colIdx + 1,
+            sourceColIndex: colIdx,
+        })(this._view.state, this._view.dispatch);
 
         this._view.focus();
     };

--- a/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/utils.ts
+++ b/packages/editor/src/extensions/yfm/YfmTable/plugins/YfmTableControls/utils.ts
@@ -1,9 +1,12 @@
 import type {
     TableCellRealDesc,
     TableColumnRange,
+    TableDesc,
     TableDescBinded,
     TableRowRange,
 } from 'src/table-utils/table-desc';
+
+import {YfmTableAttr} from '../../YfmTableSpecs/const';
 
 import type {SelectedCellPos} from './plugins/dnd-plugin';
 
@@ -67,4 +70,23 @@ function getSelectedCellPos(
     }
 
     return cell;
+}
+
+export function getCellBg(tableDesc: TableDesc, rowIdx: number, colIdx: number): string | null {
+    const cell = tableDesc.rowsDesc[rowIdx]?.cells[colIdx];
+    if (!cell) return null;
+
+    if (cell.type === 'real') {
+        return cell.node.attrs[YfmTableAttr.CellBg] ?? null;
+    }
+
+    const ref = cell.rowspan ?? cell.colspan;
+    if (!ref) return null;
+
+    const realCell = tableDesc.rowsDesc[ref[0]]?.cells[ref[1]];
+    if (realCell?.type === 'real') {
+        return realCell.node.attrs[YfmTableAttr.CellBg] ?? null;
+    }
+
+    return null;
 }


### PR DESCRIPTION
When inserting a new row or column, its cells now inherit the background color from the cells from which the insertion was initiated. This makes table styling faster by automatically preserving the visual style of the inserted elements.

## Summary by Sourcery

Support background color inheritance when inserting YfmTable rows and columns based on the source row/column, including for merged cells.

New Features:
- Enable newly inserted table rows and columns to inherit cell background colors from the row or column where the insertion is initiated.

Enhancements:
- Introduce utilities to read cell background from real and merged cells and propagate it into newly created cells during row/column insertion.
- Simplify YfmTable control actions by removing unused append/delete helpers from the controls module.

Tests:
- Add visual regression tests to verify background color inheritance for row/column insertion before and after the selected row/column in YfmTable.