### PR TITLE
fix(CodeBlock): preserve code content containing fence sequences

### DIFF
--- a/packages/editor/src/extensions/markdown/CodeBlock/CodeBlock.test.ts
+++ b/packages/editor/src/extensions/markdown/CodeBlock/CodeBlock.test.ts
@@ -23,7 +23,7 @@ const {doc, p, cb} = builders<'doc' | 'p' | 'cb'>(schema, {
     cb: {nodeType: codeBlockNodeName},
 });
 
-const {same, parse} = createMarkupChecker({parser, serializer});
+const {same, parse, serialize} = createMarkupChecker({parser, serializer});
 
 function createMockDataTransfer(data: Record<string, string>): DataTransfer {
     const types = Object.keys(data);
@@ -69,6 +69,39 @@ describe('CodeBlock extension', () => {
 
     it('should support different markup', () =>
         same('~~~\n123\n~~~', doc(cb({[CodeBlockNodeAttr.Markup]: '~~~'}, '123'))));
+
+    it('should serialize a code block whose content contains ``` using a longer fence', () =>
+        serialize(
+            doc(cb('foo bar baz\n\n```\n\nbaz bar foo')),
+            '````\nfoo bar baz\n\n```\n\nbaz bar foo\n````',
+        ));
+
+    it('should roundtrip a code block whose content contains ```', () =>
+        same(
+            '````\nfoo bar baz\n\n```\n\nbaz bar foo\n````',
+            doc(cb({[CodeBlockNodeAttr.Markup]: '````'}, 'foo bar baz\n\n```\n\nbaz bar foo')),
+        ));
+
+    it('should serialize a code block whose content contains ```` using an even longer fence', () =>
+        serialize(doc(cb('a\n````\nb')), '`````\na\n````\nb\n`````'));
+
+    it('should serialize a code block whose content contains ~~~ using a longer fence', () =>
+        serialize(
+            doc(cb({[CodeBlockNodeAttr.Markup]: '~~~'}, 'foo bar baz\n\n~~~\n\nbaz bar foo')),
+            '~~~~\nfoo bar baz\n\n~~~\n\nbaz bar foo\n~~~~',
+        ));
+
+    it('should roundtrip a code block whose content contains ~~~', () =>
+        same(
+            '~~~~\nfoo bar baz\n\n~~~\n\nbaz bar foo\n~~~~',
+            doc(cb({[CodeBlockNodeAttr.Markup]: '~~~~'}, 'foo bar baz\n\n~~~\n\nbaz bar foo')),
+        ));
+
+    it('should not extend a backtick fence when content contains only ~~~', () =>
+        same('```\n~~~\n```', doc(cb('~~~'))));
+
+    it('should not extend a tilde fence when content contains only ```', () =>
+        same('~~~\n```\n~~~', doc(cb({[CodeBlockNodeAttr.Markup]: '~~~'}, '```'))));
 });
 
 describe('CodeBlock paste handling', () => {

--- a/packages/editor/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
@@ -105,7 +105,6 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
         },
         toMd: (state, node) => {
             const lang: string = node.attrs[CodeBlockNodeAttr.Lang];
-            const markup: string = node.attrs[CodeBlockNodeAttr.Markup];
             const showLineNumbers: string = opts.lineNumbers?.enabled
                 ? node.attrs[CodeBlockNodeAttr.ShowLineNumbers]
                 : '';
@@ -116,11 +115,18 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
                 info += ' showLineNumbers';
             }
 
-            state.write(markup + info + '\n');
+            // The fence must be longer than any run of the same fence character
+            // in the content, otherwise such a run would close the block early.
+            const fence = getCodeBlockFence(
+                node.attrs[CodeBlockNodeAttr.Markup] || '',
+                node.textContent,
+            );
+
+            state.write(fence + info + '\n');
             state.text(node.textContent, false);
             // Add a newline to the current content before adding closing marker
             state.write('\n');
-            state.write(markup);
+            state.write(fence);
             state.closeBlock(node);
         },
     }));
@@ -167,4 +173,27 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
 
 function removeNewLineAtEnd(content: string): string {
     return content.endsWith('\n') ? content.slice(0, content.length - 1) : content;
+}
+
+/**
+ * Builds a fence that is guaranteed not to be closed by its own content.
+ *
+ * A fenced code block is closed by a line consisting of a run of the fence
+ * character that is at least as long as the opening fence. So if the content
+ * contains such a run, the fence must be made longer than the longest run.
+ */
+function getCodeBlockFence(markup: string, content: string): string {
+    markup = markup.trim() || '```';
+    const fenceChar = markup.startsWith('~') ? '~' : '`';
+    let length = Math.max(markup.length, 3);
+
+    const match = content.match(fenceChar === '~' ? /~{3,}/g : /`{3,}/g);
+    if (match) {
+        const longest = match.reduce((max, run) => Math.max(max, run.length), 0);
+        if (longest >= length) {
+            length = longest + 1;
+        }
+    }
+
+    return fenceChar.repeat(length);
 }


### PR DESCRIPTION
## Summary
- Code blocks whose content contains ` ``` ` or `~~~` were serialized incorrectly — the inner fence sequence would close the block prematurely, corrupting the rest of the document
- The serializer now automatically extends the opening/closing fence to be longer than any matching sequence found in the content (e.g. uses ` ```` ` to wrap content containing ` ``` `)
- Works for both backtick and tilde fences

## Summary by Sourcery

Ensure fenced code blocks are serialized with fences that do not prematurely close when the content contains matching fence sequences.

Bug Fixes:
- Fix incorrect serialization of code blocks whose content includes backtick or tilde fence sequences, preventing premature block closure.

Enhancements:
- Automatically adjust the opening and closing fence length for code blocks based on their content to guarantee safe Markdown serialization.

Tests:
- Add serialization and roundtrip tests for code blocks containing inner backtick and tilde fence sequences, including cases that should not trigger fence extension.

## Summary by Sourcery

Preserve fenced code block content that includes fence-like sequences by computing a safe fence length during Markdown serialization and validating the behavior with targeted tests.

Bug Fixes:
- Fix Markdown code block serialization when content includes backtick or tilde fence sequences to prevent premature block closure.

Enhancements:
- Derive fence length dynamically from code block markup and content to ensure fences are always longer than any matching sequence inside the block.

Tests:
- Add serialization and roundtrip tests for code blocks containing inner backtick and tilde fence sequences, including cases where fences should and should not be extended.