### PR TITLE
docs: add LLM-ready README and validate README workflow

### DIFF
--- a/.github/workflows/validate-readme.yml
+++ b/.github/workflows/validate-readme.yml
@@ -1,0 +1,20 @@
+name: Validate README
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - README.md
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gravity-ui/readme-validator@v1
+        with:
+          type: package

--- a/README.md
+++ b/README.md
@@ -85,3 +85,30 @@ Don't forget to call `configure()` from [UIKit](https://github.com/gravity-ui/ui
 ### Contributing
 
 - [Contributor Guidelines](https://preview.gravity-ui.com/md-editor/?path=/docs/docs-contributing--docs)
+
+## License
+
+Distributed under the MIT License. See [LICENSE](LICENSE.txt) for details.
+
+## For AI agents
+
+A dual-mode Markdown editor for React that combines a WYSIWYG mode (ProseMirror) and a raw markup mode (CodeMirror), with support for basic Markdown and YFM.
+
+### When to use
+
+- Editing Markdown/YFM content with a switchable visual (WYSIWYG) and source (markup) view.
+- You need an extensible editor: custom marks, nodes, toolbar items, and extensions (HTML, LaTeX, Mermaid, GPT) via the ProseMirror/CodeMirror engines.
+- Rendering the editor UI: create the instance with `useMarkdownEditor` and render it with `MarkdownEditorView`.
+
+### When not to use
+
+- Read-only rendering of Markdown to HTML with no editing — transform it with [`@diplodoc/transform`](https://github.com/diplodoc-platform/transform) and render the output instead.
+- Plain multiline text input — use `TextArea` from [`@gravity-ui/uikit`](https://github.com/gravity-ui/uikit).
+- Rich-text that is not Markdown/YFM — this editor is Markdown-first.
+
+### Common pitfalls
+
+- **It is a hook plus a view, not one component.** Create the instance with `useMarkdownEditor(...)` and pass it to `<MarkdownEditorView editor={editor} />`; there is no single `<MarkdownEditor>` you render directly.
+- **Read the value via the instance, not a controlled `value` prop.** Call `editor.getValue()` (e.g. on the `submit` event) to serialize to Markdown; the editor manages its own state.
+- **Peer dependencies are required.** Your project must provide `@diplodoc/transform`, `@gravity-ui/uikit`, `@gravity-ui/components`, `react`, and `react-dom` — check the `peerDependencies` in `package.json`.
+- **Styles and i18n come from uikit.** Set up theming/styles per the uikit docs and call `configure({lang})` from both this package and `@gravity-ui/uikit`.


### PR DESCRIPTION
## What

- Adds a **Validate README** GitHub Action (`.github/workflows/validate-readme.yml`) that runs [`gravity-ui/readme-validator@v1`](https://github.com/gravity-ui/readme-validator) on the root `README.md` in CI.
- Brings the `README.md` up to the Gravity UI **LLM-ready template**: adds the missing `## License` section and a `## For AI agents` block (single-sentence positioning + *When to use* / *When not to use* / *Common pitfalls*).

## Why

The README is the source of truth for the generated `llms.txt` that coding agents read. The `## For AI agents` block gives agents crisp positioning, cross-links to the right neighbor packages, and the real hallucination traps (wrong prop/component names → correct ones). The workflow keeps the contract enforced on every PR.

Part of the Gravity UI LLM-adoption effort (DATAUI-3745).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add automated validation of the README and align the README content with the Gravity UI LLM-ready template.

CI:
- Introduce a Validate README GitHub Action that runs gravity-ui/readme-validator on README changes in pull requests.

Documentation:
- Update README with License section and AI-agent-focused usage guidance aligned to the LLM-ready template.