### PR TITLE
fix: remove text about file size from image_upload_help

### DIFF
--- a/packages/editor/src/i18n/forms/en.json
+++ b/packages/editor/src/i18n/forms/en.json
@@ -11,7 +11,7 @@
   "image_link_href_help": "Address the image link leads to.",
   "image_alt": "Alt text",
   "image_alt_help": "Alt text is displayed if the image cannot be loaded.",
-  "image_upload_help": "JPEG, GIF or PNG image no larger than 1 MB.",
+  "image_upload_help": "JPEG, GIF or PNG image.",
   "image_upload_failed": "Image failed to upload",
   "image_size_width": "Width",
   "image_size_height": "Height",

--- a/packages/editor/src/i18n/forms/ru.json
+++ b/packages/editor/src/i18n/forms/ru.json
@@ -11,7 +11,7 @@
   "image_link_href_help": "Адрес, на который ведет картинка.",
   "image_alt": "Альтернативный текст",
   "image_alt_help": "Текст будет отображаться, если не удастся загрузить изображение.",
-  "image_upload_help": "Изображение в формате JPEG, GIF и PNG размером не более 1 МБ.",
+  "image_upload_help": "Изображение в формате JPEG, GIF и PNG.",
   "image_upload_failed": "Не удалось загрузить изображение",
   "image_size_width": "Ширина",
   "image_size_height": "Высота",


### PR DESCRIPTION
Current text in image_upload_help contains information about maximum file size. My suggestion is to make it more common for everyone.

## Summary by Sourcery

Documentation:
- Revise image_upload_help copy in en and ru locales to use more generic guidance without mentioning a specific file size limit.