### PR TITLE
test(e2e): stabilize link form screenshot

### DIFF
--- a/demo/tests/visual-tests/playground/Link.visual.test.tsx
+++ b/demo/tests/visual-tests/playground/Link.visual.test.tsx
@@ -143,15 +143,20 @@ test.describe('Link', () => {
     }) => {
         test.skip(browserName === 'webkit', 'fillFocused does not work correctly in webkit');
 
+        const markupPreview = page.locator('.playground__markup');
+
         await editor.fill('Lorem ipsum dolor sit amet, \nconsectetur adipiscing elit. \n');
 
         await actions.pressFocused('ArrowUp', 2);
         await actions.pressFocused('Enter');
         await actions.pressFocused('ArrowUp');
+        await expect(markupPreview).toHaveText(
+            /Lorem ipsum dolor sit ame\s+t,\s+consectetur adipiscing elit\.\s*/,
+        );
 
         await editor.clickMainToolbarButton('Link');
         await editor.link.assertFormToBeVisible();
-        await wait.timeout(500);
+        await wait.timeout(300);
 
         await actions.fillFocused('gravity-ui.com');
 


### PR DESCRIPTION
#### Stabilize link form screenshot

- Added waiting for rendered markdown preview before screenshot capture.
- Reduced fixed waiting after the link form is opened.

## Summary by Sourcery

Stabilize the Link playground visual regression test for the link form screenshot.

Tests:
- Wait for the markdown preview content to render before capturing the Link form screenshot in the visual test.
- Reduce the fixed delay after opening the Link form in the visual test to speed up execution while maintaining stability.