### PR TITLE
refactor(Deflist): use new builder methods to register nodes

### DIFF
--- a/packages/editor/src/extensions/markdown/Deflist/DeflistSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Deflist/DeflistSpecs/index.ts
@@ -1,13 +1,10 @@
-import deflistPlugin from '@diplodoc/transform/lib/plugins/deflist.js';
-
 import type {ExtensionAuto} from '../../../../core';
 import {nodeTypeFactory} from '../../../../utils/schema';
 
 import {DeflistNode} from './const';
-import {parserTokens} from './parser';
-import {getSchemaSpecs} from './schema';
-import type {DeflistSchemaOptions} from './schema';
-import {serializerTokens} from './serializer';
+import {DeflistParserSpecs} from './parser';
+import {type DeflistSchemaOptions, DeflistSchemaSpecs} from './schema';
+import {DeflistSerializerSpecs} from './serializer';
 
 export {DeflistNode} from './const';
 export const defListType = nodeTypeFactory(DeflistNode.List);
@@ -19,23 +16,5 @@ export type {DeflistSchemaOptions} from './schema';
 export type DeflistSpecsOptions = DeflistSchemaOptions & {};
 
 export const DeflistSpecs: ExtensionAuto<DeflistSpecsOptions> = (builder, opts) => {
-    const schemaSpecs = getSchemaSpecs(opts, builder.context.get('placeholder'));
-
-    builder.configureMd((md) => md.use(deflistPlugin));
-    builder
-        .addNode(DeflistNode.List, () => ({
-            spec: schemaSpecs[DeflistNode.List],
-            fromMd: {tokenSpec: parserTokens[DeflistNode.List]},
-            toMd: serializerTokens[DeflistNode.List],
-        }))
-        .addNode(DeflistNode.Term, () => ({
-            spec: schemaSpecs[DeflistNode.Term],
-            fromMd: {tokenSpec: parserTokens[DeflistNode.Term]},
-            toMd: serializerTokens[DeflistNode.Term],
-        }))
-        .addNode(DeflistNode.Desc, () => ({
-            spec: schemaSpecs[DeflistNode.Desc],
-            fromMd: {tokenSpec: parserTokens[DeflistNode.Desc]},
-            toMd: serializerTokens[DeflistNode.Desc],
-        }));
+    builder.use(DeflistSchemaSpecs, opts).use(DeflistParserSpecs).use(DeflistSerializerSpecs);
 };

--- a/packages/editor/src/extensions/markdown/Deflist/DeflistSpecs/parser.ts
+++ b/packages/editor/src/extensions/markdown/Deflist/DeflistSpecs/parser.ts
@@ -1,8 +1,10 @@
-import type {ParserToken} from '../../../../core';
+import deflistPlugin from '@diplodoc/transform/lib/plugins/deflist.js';
+
+import type {ExtensionAuto, ParserToken} from '../../../../core';
 
 import {DeflistAttr, DeflistNode} from './const';
 
-export const parserTokens: Record<DeflistNode, ParserToken> = {
+const parserTokens: Record<DeflistNode, ParserToken> = {
     [DeflistNode.List]: {name: DeflistNode.List, type: 'block'},
 
     [DeflistNode.Term]: {
@@ -16,4 +18,12 @@ export const parserTokens: Record<DeflistNode, ParserToken> = {
     },
 
     [DeflistNode.Desc]: {name: DeflistNode.Desc, type: 'block'},
+};
+
+export const DeflistParserSpecs: ExtensionAuto = (builder) => {
+    builder
+        .configureMd((md) => md.use(deflistPlugin))
+        .addMarkdownTokenParserSpec(DeflistNode.List, () => parserTokens[DeflistNode.List])
+        .addMarkdownTokenParserSpec(DeflistNode.Term, () => parserTokens[DeflistNode.Term])
+        .addMarkdownTokenParserSpec(DeflistNode.Desc, () => parserTokens[DeflistNode.Desc]);
 };

--- a/packages/editor/src/extensions/markdown/Deflist/DeflistSpecs/schema.ts
+++ b/packages/editor/src/extensions/markdown/Deflist/DeflistSpecs/schema.ts
@@ -1,6 +1,7 @@
 import type {NodeSpec} from 'prosemirror-model';
 
-import type {PlaceholderOptions} from '../../../../utils/placeholder';
+import type {ExtensionAuto} from '#core';
+import type {PlaceholderOptions} from 'src/utils/placeholder';
 
 import {DeflistAttr, DeflistNode} from './const';
 
@@ -20,7 +21,7 @@ const DEFAULT_PLACEHOLDERS = {
     Desc: 'Definition description',
 };
 
-export const getSchemaSpecs = (
+const getSchemaSpecs = (
     opts?: DeflistSchemaOptions,
     placeholder?: PlaceholderOptions,
 ): Record<DeflistNode, NodeSpec> => ({
@@ -79,3 +80,12 @@ export const getSchemaSpecs = (
         complex: 'leaf',
     },
 });
+
+export const DeflistSchemaSpecs: ExtensionAuto<DeflistSchemaOptions> = (builder, opts) => {
+    const schemaSpecs = getSchemaSpecs(opts, builder.context.get('placeholder'));
+
+    builder
+        .addNodeSpec(DeflistNode.List, () => schemaSpecs[DeflistNode.List])
+        .addNodeSpec(DeflistNode.Term, () => schemaSpecs[DeflistNode.Term])
+        .addNodeSpec(DeflistNode.Desc, () => schemaSpecs[DeflistNode.Desc]);
+};

--- a/packages/editor/src/extensions/markdown/Deflist/DeflistSpecs/serializer.ts
+++ b/packages/editor/src/extensions/markdown/Deflist/DeflistSpecs/serializer.ts
@@ -1,8 +1,8 @@
-import type {SerializerNodeToken} from '../../../../core';
+import type {ExtensionAuto, SerializerNodeToken} from '../../../../core';
 
 import {DeflistNode} from './const';
 
-export const serializerTokens: Record<DeflistNode, SerializerNodeToken> = {
+const serializerTokens: Record<DeflistNode, SerializerNodeToken> = {
     [DeflistNode.List]: (state, node) => {
         state.renderContent(node);
     },
@@ -17,4 +17,11 @@ export const serializerTokens: Record<DeflistNode, SerializerNodeToken> = {
             state.renderContent(node);
         });
     },
+};
+
+export const DeflistSerializerSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addNodeSerializerSpec(DeflistNode.List, () => serializerTokens[DeflistNode.List])
+        .addNodeSerializerSpec(DeflistNode.Term, () => serializerTokens[DeflistNode.Term])
+        .addNodeSerializerSpec(DeflistNode.Desc, () => serializerTokens[DeflistNode.Desc]);
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor Deflist markdown extension to use modular schema, parser, and serializer builder specs for node registration.

Enhancements:
- Introduce DeflistSchemaSpecs, DeflistParserSpecs, and DeflistSerializerSpecs helpers to register Deflist nodes via the new builder methods.
- Adjust Deflist schema, parser, and serializer wiring to rely on extension auto-spec functions instead of inline node configuration in DeflistSpecs.