### PR TITLE
refactor(Html): use new builder methods to register nodes

### DIFF
--- a/packages/editor/src/extensions/markdown/Html/index.ts
+++ b/packages/editor/src/extensions/markdown/Html/index.ts
@@ -1,10 +1,9 @@
-import type {ExtensionAuto} from '../../../core';
-import {globalLogger} from '../../../logger';
+import type {ExtensionAuto} from '#core';
+import {globalLogger} from 'src/logger';
 
-import {HtmlNode} from './const';
-import {parserTokens} from './parser';
-import {schemaSpecs} from './schema';
-import {serializerTokens} from './serializer';
+import {HtmlParserSpecs} from './parser';
+import {HtmlSchemaSpecs} from './schema';
+import {HtmlSerializerSpecs} from './serializer';
 
 export {HtmlAttr, HtmlNode} from './const';
 
@@ -15,17 +14,7 @@ export const Html: ExtensionAuto = (builder) => {
         return;
     }
 
-    builder.addNode(HtmlNode.Block, () => ({
-        spec: schemaSpecs[HtmlNode.Block],
-        fromMd: {tokenSpec: parserTokens[HtmlNode.Block]},
-        toMd: serializerTokens[HtmlNode.Block],
-    }));
-
-    builder.addNode(HtmlNode.Inline, () => ({
-        spec: schemaSpecs[HtmlNode.Inline],
-        fromMd: {tokenSpec: parserTokens[HtmlNode.Inline]},
-        toMd: serializerTokens[HtmlNode.Inline],
-    }));
+    builder.use(HtmlSchemaSpecs).use(HtmlParserSpecs).use(HtmlSerializerSpecs);
 };
 
 declare global {

--- a/packages/editor/src/extensions/markdown/Html/parser.ts
+++ b/packages/editor/src/extensions/markdown/Html/parser.ts
@@ -1,8 +1,8 @@
-import type {ParserToken} from '../../../core';
+import type {ExtensionAuto, ParserToken} from '#core';
 
 import {HtmlAttr, HtmlNode} from './const';
 
-export const parserTokens: Record<HtmlNode, ParserToken> = {
+const parserTokens: Record<HtmlNode, ParserToken> = {
     [HtmlNode.Block]: {
         name: HtmlNode.Block,
         type: 'node',
@@ -20,4 +20,10 @@ export const parserTokens: Record<HtmlNode, ParserToken> = {
             [HtmlAttr.Content]: token.content,
         }),
     },
+};
+
+export const HtmlParserSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addMarkdownTokenParserSpec(HtmlNode.Block, () => parserTokens[HtmlNode.Block])
+        .addMarkdownTokenParserSpec(HtmlNode.Inline, () => parserTokens[HtmlNode.Inline]);
 };

--- a/packages/editor/src/extensions/markdown/Html/schema.ts
+++ b/packages/editor/src/extensions/markdown/Html/schema.ts
@@ -1,5 +1,6 @@
 import type {NodeSpec} from 'prosemirror-model';
 
+import type {ExtensionAuto} from '#core';
 import {getSanitize} from 'src/utils/getSanitize';
 
 import {HtmlAttr, HtmlNode} from './const';
@@ -11,7 +12,7 @@ enum DomAttr {
 
 const sanitize = getSanitize('Html');
 
-export const schemaSpecs: Record<HtmlNode, NodeSpec> = {
+const schemaSpecs: Record<HtmlNode, NodeSpec> = {
     [HtmlNode.Block]: {
         atom: true,
         group: 'block',
@@ -59,4 +60,10 @@ export const schemaSpecs: Record<HtmlNode, NodeSpec> = {
             return elem;
         },
     },
+};
+
+export const HtmlSchemaSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addNodeSpec(HtmlNode.Block, () => schemaSpecs[HtmlNode.Block])
+        .addNodeSpec(HtmlNode.Inline, () => schemaSpecs[HtmlNode.Inline]);
 };

--- a/packages/editor/src/extensions/markdown/Html/serializer.ts
+++ b/packages/editor/src/extensions/markdown/Html/serializer.ts
@@ -1,8 +1,8 @@
-import type {SerializerNodeToken} from '../../../core';
+import type {ExtensionAuto, SerializerNodeToken} from '#core';
 
 import {HtmlAttr, HtmlNode} from './const';
 
-export const serializerTokens: Record<HtmlNode, SerializerNodeToken> = {
+const serializerTokens: Record<HtmlNode, SerializerNodeToken> = {
     [HtmlNode.Block]: (state, node) => {
         state.write(node.attrs[HtmlAttr.Content]);
         state.ensureNewLine();
@@ -12,4 +12,10 @@ export const serializerTokens: Record<HtmlNode, SerializerNodeToken> = {
     [HtmlNode.Inline]: (state, node) => {
         state.write(node.attrs[HtmlAttr.Content]);
     },
+};
+
+export const HtmlSerializerSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addNodeSerializerSpec(HtmlNode.Block, () => serializerTokens[HtmlNode.Block])
+        .addNodeSerializerSpec(HtmlNode.Inline, () => serializerTokens[HtmlNode.Inline]);
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Html markdown extension to use new builder-based registration for schema, parser, and serializer specs while updating core imports.

Enhancements:
- Introduce HtmlSchemaSpecs, HtmlParserSpecs, and HtmlSerializerSpecs extension factories and wire them into the Html extension via the builder.use API.
- Encapsulate HTML schema, parser, and serializer token maps in their respective modules and expose them through builder registration methods.
- Update imports to use the new core alias paths for editor types and logging.