### PR TITLE
refactor(Blockquote): use new builder methods to register nodes

### DIFF
--- a/packages/editor/src/extensions/markdown/Blockquote/BlockquoteSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Blockquote/BlockquoteSpecs/index.ts
@@ -1,15 +1,15 @@
 import type {Node} from 'prosemirror-model';
 
-import type {ExtensionAuto} from '../../../../core';
-import {nodeTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {nodeTypeFactory} from 'src/utils/schema';
 
 export const blockquoteNodeName = 'blockquote';
 export const blockquoteType = nodeTypeFactory(blockquoteNodeName);
 export const isBlockqouteNode = (node: Node) => node.type.name === blockquoteNodeName;
 
 export const BlockquoteSpecs: ExtensionAuto = (builder) => {
-    builder.addNode(blockquoteNodeName, () => ({
-        spec: {
+    builder
+        .addNodeSpec(blockquoteNodeName, () => ({
             content: 'block+',
             group: 'block',
             defining: true,
@@ -19,10 +19,12 @@ export const BlockquoteSpecs: ExtensionAuto = (builder) => {
             },
             selectable: true,
             selectAll: 'node',
-        },
-        fromMd: {tokenSpec: {name: blockquoteNodeName, type: 'block'}},
-        toMd: (state, node) => {
+        }))
+        .addMarkdownTokenParserSpec(blockquoteNodeName, () => ({
+            name: blockquoteNodeName,
+            type: 'block',
+        }))
+        .addNodeSerializerSpec(blockquoteNodeName, () => (state, node) => {
             state.wrapBlock('> ', null, node, () => state.renderContent(node));
-        },
-    }));
+        });
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Blockquote markdown extension to use the new builder APIs for node specs, markdown token parsing, and node serialization.

Enhancements:
- Update Blockquote extension to register its node, markdown token parser, and serializer via the new builder methods.
- Adjust Blockquote-related imports to use the updated core and schema module paths.