### PR TITLE
refactor(Code): use new builder methods to register marks

### DIFF
--- a/packages/editor/src/extensions/markdown/Code/CodeSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Code/CodeSpecs/index.ts
@@ -1,38 +1,39 @@
 import type {Node} from 'prosemirror-model';
 
-import type {ExtensionAuto} from '../../../../core';
-import {markTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {markTypeFactory} from 'src/utils/schema';
 
 export const codeMarkName = 'code';
 export const codeType = markTypeFactory(codeMarkName);
 
 export const CodeSpecs: ExtensionAuto = (builder) => {
-    builder.addMark(
-        codeMarkName,
-        () => ({
-            spec: {
+    builder
+        .addMarkSpec(
+            codeMarkName,
+            () => ({
                 code: true,
                 parseDOM: [{tag: 'code'}],
                 toDOM() {
                     return ['code'];
                 },
+            }),
+            builder.Priority.Lowest,
+        )
+        .addMarkdownTokenParserSpec('code_inline', () => ({
+            name: codeMarkName,
+            type: 'mark',
+            code: true,
+            noCloseToken: true,
+        }))
+        .addMarkSerializerSpec(codeMarkName, () => ({
+            open(_state, _mark, parent, index) {
+                return backticksFor(parent.child(index), -1);
             },
-            toMd: {
-                open(_state, _mark, parent, index) {
-                    return backticksFor(parent.child(index), -1);
-                },
-                close(_state, _mark, parent, index) {
-                    return backticksFor(parent.child(index - 1), 1);
-                },
-                escape: false,
+            close(_state, _mark, parent, index) {
+                return backticksFor(parent.child(index - 1), 1);
             },
-            fromMd: {
-                tokenSpec: {name: codeMarkName, type: 'mark', code: true, noCloseToken: true},
-                tokenName: 'code_inline',
-            },
-        }),
-        builder.Priority.Lowest,
-    );
+            escape: false,
+        }));
 };
 
 function backticksFor(node: Node, side: number) {


### PR DESCRIPTION
## Summary by Sourcery

Refactor code mark registration to use the new builder APIs for mark specs and markdown integration.

Enhancements:
- Switch code mark configuration to the new addMarkSpec, addMarkdownTokenParserSpec, and addMarkSerializerSpec builder methods while preserving existing behavior.
- Update imports to use the new core and schema module paths.