### PR TITLE
refactor(HorizontalRule): use new builder methods to register nodes

### DIFF
--- a/packages/editor/src/extensions/markdown/HorizontalRule/HorizontalRuleSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/HorizontalRule/HorizontalRuleSpecs/index.ts
@@ -1,13 +1,13 @@
-import type {ExtensionAuto} from '../../../../core';
-import {nodeTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {nodeTypeFactory} from 'src/utils/schema';
 
 export const horizontalRuleNodeName = 'horizontal_rule';
 export const horizontalRuleMarkupAttr = 'markup';
 export const horizontalRuleType = nodeTypeFactory(horizontalRuleNodeName);
 
 export const HorizontalRuleSpecs: ExtensionAuto = (builder) => {
-    builder.addNode(horizontalRuleNodeName, () => ({
-        spec: {
+    builder
+        .addNodeSpec(horizontalRuleNodeName, () => ({
             attrs: {[horizontalRuleMarkupAttr]: {default: '---'}},
             group: 'block',
             parseDOM: [{tag: 'hr'}],
@@ -15,18 +15,14 @@ export const HorizontalRuleSpecs: ExtensionAuto = (builder) => {
                 return ['div', ['hr']];
             },
             selectable: true,
-        },
-        fromMd: {
-            tokenName: 'hr',
-            tokenSpec: {
-                name: horizontalRuleNodeName,
-                type: 'node',
-                getAttrs: (token) => ({[horizontalRuleMarkupAttr]: token.markup}),
-            },
-        },
-        toMd: (state, node) => {
+        }))
+        .addMarkdownTokenParserSpec('hr', () => ({
+            name: horizontalRuleNodeName,
+            type: 'node',
+            getAttrs: (token) => ({[horizontalRuleMarkupAttr]: token.markup}),
+        }))
+        .addNodeSerializerSpec(horizontalRuleNodeName, () => (state, node) => {
             state.write(node.attrs[horizontalRuleMarkupAttr]);
             state.closeBlock(node);
-        },
-    }));
+        });
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor horizontal rule markdown node to use the new builder APIs for node specs, markdown token parsing, and node serialization.

Enhancements:
- Switch horizontal rule extension to use addNodeSpec, addMarkdownTokenParserSpec, and addNodeSerializerSpec APIs.
- Update imports to use new core and schema module paths.