### PR TITLE
refactor(Table): use new builder methods to register nodes

### DIFF
--- a/packages/editor/src/extensions/markdown/Table/TableSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Table/TableSpecs/index.ts
@@ -1,42 +1,11 @@
-import type {ExtensionAuto} from '../../../../core';
+import type {ExtensionAuto} from '#core';
 
-import {TableNode} from './const';
-import {parserTokens} from './parser';
-import {schemaSpecs} from './schema';
-import {serializerTokens} from './serializer';
+import {TableParserSpecs} from './parser';
+import {TableSchemaSpecs} from './schema';
+import {TableSerializerSpecs} from './serializer';
 
 export {TableNode} from './const';
 
 export const TableSpecs: ExtensionAuto = (builder) => {
-    builder
-        .addNode(TableNode.Table, () => ({
-            spec: schemaSpecs[TableNode.Table],
-            toMd: serializerTokens[TableNode.Table],
-            fromMd: {tokenSpec: parserTokens[TableNode.Table]},
-        }))
-        .addNode(TableNode.Head, () => ({
-            spec: schemaSpecs[TableNode.Head],
-            toMd: serializerTokens[TableNode.Head],
-            fromMd: {tokenSpec: parserTokens[TableNode.Head]},
-        }))
-        .addNode(TableNode.Body, () => ({
-            spec: schemaSpecs[TableNode.Body],
-            toMd: serializerTokens[TableNode.Body],
-            fromMd: {tokenSpec: parserTokens[TableNode.Body]},
-        }))
-        .addNode(TableNode.Row, () => ({
-            spec: schemaSpecs[TableNode.Row],
-            toMd: serializerTokens[TableNode.Row],
-            fromMd: {tokenSpec: parserTokens[TableNode.Row]},
-        }))
-        .addNode(TableNode.HeaderCell, () => ({
-            spec: schemaSpecs[TableNode.HeaderCell],
-            toMd: serializerTokens[TableNode.HeaderCell],
-            fromMd: {tokenSpec: parserTokens[TableNode.HeaderCell]},
-        }))
-        .addNode(TableNode.DataCell, () => ({
-            spec: schemaSpecs[TableNode.DataCell],
-            toMd: serializerTokens[TableNode.DataCell],
-            fromMd: {tokenSpec: parserTokens[TableNode.DataCell]},
-        }));
+    builder.use(TableSchemaSpecs).use(TableParserSpecs).use(TableSerializerSpecs);
 };

--- a/packages/editor/src/extensions/markdown/Table/TableSpecs/parser.ts
+++ b/packages/editor/src/extensions/markdown/Table/TableSpecs/parser.ts
@@ -1,9 +1,10 @@
 import type Token from 'markdown-it/lib/token';
 
-import type {ParserToken} from '../../../../core';
+import type {ExtensionAuto, ParserToken} from '#core';
+
 import {CellAlign, TableAttrs, TableNode} from '../const';
 
-export const parserTokens: Record<TableNode, ParserToken> = {
+const parserTokens: Record<TableNode, ParserToken> = {
     [TableNode.Table]: {name: TableNode.Table, type: 'block'},
 
     [TableNode.Head]: {name: TableNode.Head, type: 'block'},
@@ -41,3 +42,13 @@ function getTableCellAttrs({attrs}: Token) {
 
     return {[TableAttrs.CellAlign]: align};
 }
+
+export const TableParserSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addMarkdownTokenParserSpec(TableNode.Table, () => parserTokens[TableNode.Table])
+        .addMarkdownTokenParserSpec(TableNode.Head, () => parserTokens[TableNode.Head])
+        .addMarkdownTokenParserSpec(TableNode.Body, () => parserTokens[TableNode.Body])
+        .addMarkdownTokenParserSpec(TableNode.Row, () => parserTokens[TableNode.Row])
+        .addMarkdownTokenParserSpec(TableNode.HeaderCell, () => parserTokens[TableNode.HeaderCell])
+        .addMarkdownTokenParserSpec(TableNode.DataCell, () => parserTokens[TableNode.DataCell]);
+};

--- a/packages/editor/src/extensions/markdown/Table/TableSpecs/schema.ts
+++ b/packages/editor/src/extensions/markdown/Table/TableSpecs/schema.ts
@@ -1,9 +1,11 @@
 import type {NodeSpec} from 'prosemirror-model';
 
-import {TableRole} from '../../../../table-utils';
+import type {ExtensionAuto} from '#core';
+import {TableRole} from 'src/table-utils';
+
 import {CellAlign, TableAttrs, TableNode} from '../const';
 
-export const schemaSpecs: Record<TableNode, NodeSpec> = {
+const schemaSpecs: Record<TableNode, NodeSpec> = {
     [TableNode.Table]: {
         group: 'block',
         content: `${TableNode.Head} ${TableNode.Body}`,
@@ -100,3 +102,13 @@ function cellTemplate(tag: 'th' | 'td'): NodeSpec {
         complex: 'leaf',
     };
 }
+
+export const TableSchemaSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addNodeSpec(TableNode.Table, () => schemaSpecs[TableNode.Table])
+        .addNodeSpec(TableNode.Head, () => schemaSpecs[TableNode.Head])
+        .addNodeSpec(TableNode.Body, () => schemaSpecs[TableNode.Body])
+        .addNodeSpec(TableNode.Row, () => schemaSpecs[TableNode.Row])
+        .addNodeSpec(TableNode.HeaderCell, () => schemaSpecs[TableNode.HeaderCell])
+        .addNodeSpec(TableNode.DataCell, () => schemaSpecs[TableNode.DataCell]);
+};

--- a/packages/editor/src/extensions/markdown/Table/TableSpecs/serializer.ts
+++ b/packages/editor/src/extensions/markdown/Table/TableSpecs/serializer.ts
@@ -1,7 +1,8 @@
-import type {SerializerNodeToken} from '../../../../core';
+import type {ExtensionAuto, SerializerNodeToken} from '#core';
+
 import {CellAlign, TableAttrs, TableNode} from '../const';
 
-export const serializerTokens: Record<TableNode, SerializerNodeToken> = {
+const serializerTokens: Record<TableNode, SerializerNodeToken> = {
     [TableNode.Table]: (state, node) => {
         state.ensureNewLine();
         state.write('\n');
@@ -65,4 +66,14 @@ export const serializerTokens: Record<TableNode, SerializerNodeToken> = {
         state.renderInline(node);
         state.closeBlock(node);
     },
+};
+
+export const TableSerializerSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addNodeSerializerSpec(TableNode.Table, () => serializerTokens[TableNode.Table])
+        .addNodeSerializerSpec(TableNode.Head, () => serializerTokens[TableNode.Head])
+        .addNodeSerializerSpec(TableNode.Body, () => serializerTokens[TableNode.Body])
+        .addNodeSerializerSpec(TableNode.Row, () => serializerTokens[TableNode.Row])
+        .addNodeSerializerSpec(TableNode.HeaderCell, () => serializerTokens[TableNode.HeaderCell])
+        .addNodeSerializerSpec(TableNode.DataCell, () => serializerTokens[TableNode.DataCell]);
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor markdown table extension to register schema, parser, and serializer via dedicated builder helper specs.

Enhancements:
- Introduce TableSchemaSpecs, TableParserSpecs, and TableSerializerSpecs helpers for table node registration.
- Update TableSpecs to use chained builder.use(...) calls for table-related specs.
- Align imports to use the new core and table-utils module paths.