### PR TITLE
fix(markup): do not bind Opt+Shift+A to block comment

### DIFF
--- a/packages/editor/src/markup/codemirror/create.test.ts
+++ b/packages/editor/src/markup/codemirror/create.test.ts
@@ -42,9 +42,9 @@ function dispatchDropWithFiles(view: EditorView, files: File[]) {
     view.contentDOM.dispatchEvent(event);
 }
 
-function createView(uploadHandler: (file: File) => Promise<{url: string}>) {
+function createView(uploadHandler: (file: File) => Promise<{url: string}>, doc = '') {
     return createCodemirror({
-        doc: '',
+        doc,
         placeholder: '',
         logger: new Logger2(),
         onCancel: () => undefined,
@@ -89,6 +89,32 @@ describe('createCodemirror file upload integration', () => {
         expect(uploadHandler).toHaveBeenCalledTimes(1);
         expect(uploadHandler).toHaveBeenCalledWith(file);
         expect(view.state.sliceDoc()).toBe(' ');
+
+        view.destroy();
+    });
+});
+
+describe('createCodemirror keymap', () => {
+    it('should not handle Opt+Shift+A: it is a printable character on macOS', () => {
+        const view = createView(() => Promise.resolve({url: ''}), 'text');
+        view.focus();
+
+        // macOS US layout: Opt+Shift+A produces "Å" while reporting keyCode 65,
+        // which CodeMirror resolves to its default "Alt-A" (toggleBlockComment) binding.
+        const event = new KeyboardEvent('keydown', {
+            key: 'Å',
+            code: 'KeyA',
+            keyCode: 65,
+            altKey: true,
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true,
+        });
+
+        view.contentDOM.dispatchEvent(event);
+
+        expect(view.state.sliceDoc()).toBe('text');
+        expect(event.defaultPrevented).toBe(false);
 
         view.destroy();
     });

--- a/packages/editor/src/markup/codemirror/create.ts
+++ b/packages/editor/src/markup/codemirror/create.ts
@@ -6,6 +6,7 @@ import {
     indentWithTab,
     insertNewlineKeepIndent,
     insertTab,
+    toggleBlockComment,
 } from '@codemirror/commands';
 import {syntaxHighlighting} from '@codemirror/language';
 import type {Extension, StateCommand} from '@codemirror/state';
@@ -171,7 +172,11 @@ export function createCodemirror(params: CreateCodemirrorParams) {
                 shift: insertNewlineKeepIndent,
             },
             indentWithTab,
-            ...defaultKeymap,
+            // CodeMirror binds toggleBlockComment to Alt-A, i.e. Opt+Shift+A, which on macOS
+            // is a printable character (Å) — the binding makes it untypable in markup mode.
+            // Block comments stay available via Mod-/: markdown has no line comment syntax,
+            // so toggleComment falls back to block comments.
+            ...defaultKeymap.filter(({run}) => run !== toggleBlockComment),
             ...(disabledExtensions.history ? [] : historyKeymap),
             ...keymaps,
         ]),


### PR DESCRIPTION
## Problem

In markup mode, pressing <kbd>Opt</kbd>+<kbd>Shift</kbd>+<kbd>A</kbd> inserts `<!--  -->` instead of typing a character.

On the macOS US layout that combination is a printable character — `Å`. It is shadowed by a binding the editor never declares itself: `defaultKeymap` from `@codemirror/commands` contains

```js
{ key: "Alt-A", run: toggleBlockComment },
```

and `"Alt-A"` means Alt+**Shift**+A (an uppercase letter implies Shift). `defaultKeymap` is spread into the markup keymap in `create.ts`, so the binding is active in every editor instance.

It also cannot be worked around downstream: the `keymaps` parameter is spread *after* `defaultKeymap`, so consumer bindings for the same key run second and never get a chance to override it.

## Fix

Filter that one binding out of `defaultKeymap`.

Nothing is lost: markdown has no line comment syntax, so `toggleComment` (<kbd>Mod</kbd>+<kbd>/</kbd>, also part of `defaultKeymap`) already falls back to block comments and produces exactly the same `<!--  -->`.

The filter matches on the command reference rather than the key string, so it degrades to a no-op if CodeMirror ever rebinds it.

## Test

Added a case to `create.test.ts` that dispatches the real macOS event shape (`key: 'Å'`, `keyCode: 65`, `altKey`, `shiftKey`) and asserts the document is untouched and the event is not `preventDefault`ed.

Verified it reproduces the bug on `main`:

```
● createCodemirror keymap › should not handle Opt+Shift+A: it is a printable character on macOS

    Expected: "text"
    Received: "<!--  -->text"
```

and passes with the fix. `pnpm typecheck`, eslint and prettier are clean.

## Summary by Sourcery

Prevent the markup editor from intercepting the Opt+Shift+A key combination so it remains a printable character on macOS layouts.

Bug Fixes:
- Remove the Alt-A (Opt+Shift+A) block comment binding from the markup keymap to avoid inserting HTML comments when typing Å on macOS.

Tests:
- Add a keymap test that simulates the macOS Opt+Shift+A keyboard event and asserts the document is unchanged and the event is not prevented.