### PR TITLE
fix(markup): keep Opt+Shift+A typable on macOS

### DIFF
--- a/packages/editor/src/markup/codemirror/create.ts
+++ b/packages/editor/src/markup/codemirror/create.ts
@@ -28,6 +28,7 @@ import {Action as A, formatter as f} from '../../shortcuts';
 import type {Receiver} from '../../utils';
 import {DataTransferType, shouldSkipHtmlConversion} from '../../utils/clipboard';
 import type {DirectiveSyntaxContext} from '../../utils/directive';
+import {isMac} from '../../utils/platform';
 import type {ParseInsertedUrlAsImage} from '../../utils/upload';
 import {
     insertEmptyRow,
@@ -171,7 +172,19 @@ export function createCodemirror(params: CreateCodemirrorParams) {
                 shift: insertNewlineKeepIndent,
             },
             indentWithTab,
-            ...defaultKeymap,
+            // Temporary workaround, to be dropped once CodeMirror gives Alt-A a mac override
+            // upstream (tracker: https://code.haverbeke.berlin/codemirror/dev/issues).
+            //
+            // Opt+Shift+A types a printable character on macOS ("Å" on the US layout), and key
+            // resolution there goes by key code for Alt combinations, so a binding on it shadows
+            // the character. Upstream gives every other Alt+letter binding a mac override
+            // (Alt-l -> Ctrl-l, Alt-ArrowLeft -> Ctrl-ArrowLeft); Alt-A, bound to
+            // toggleBlockComment, is the only one left without. Its command stays reachable via
+            // Mod-/, since markdown has no line comment syntax and toggleComment then falls back
+            // to block comments.
+            ...defaultKeymap.filter(
+                (binding) => !(isMac() && (binding.mac || binding.key) === 'Alt-A'),
+            ),
             ...(disabledExtensions.history ? [] : historyKeymap),
             ...keymaps,
         ]),

--- a/packages/editor/src/markup/codemirror/keymap-macos.test.ts
+++ b/packages/editor/src/markup/codemirror/keymap-macos.test.ts
@@ -1,0 +1,66 @@
+import type {EditorView} from '@codemirror/view';
+
+import type {ReactRenderStorage as ReactRenderStorageClass} from '../../extensions';
+import type {Logger2 as Logger2Class} from '../../logger';
+import type {DirectiveSyntaxContext as DirectiveSyntaxContextClass} from '../../utils/directive';
+
+import type {createCodemirror as createCodemirrorFn} from './create';
+
+// @codemirror/view and w3c-keyname both read navigator.platform once, at module evaluation time,
+// to decide how a key combination is resolved. It has to be stubbed before the module graph is
+// loaded, hence the explicit requires below instead of top-level imports.
+Object.defineProperty(window.navigator, 'platform', {value: 'MacIntel', configurable: true});
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const ReactRenderStorage: typeof ReactRenderStorageClass =
+    require('../../extensions').ReactRenderStorage;
+const Logger2: typeof Logger2Class = require('../../logger').Logger2;
+const DirectiveSyntaxContext: typeof DirectiveSyntaxContextClass =
+    require('../../utils/directive').DirectiveSyntaxContext;
+
+const createCodemirror: typeof createCodemirrorFn = require('./create').createCodemirror;
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+function createView(doc: string): EditorView {
+    return createCodemirror({
+        doc,
+        placeholder: '',
+        logger: new Logger2(),
+        onCancel: () => undefined,
+        onSubmit: () => undefined,
+        onChange: () => undefined,
+        onDocChange: () => undefined,
+        onScroll: () => undefined,
+        reactRenderer: new ReactRenderStorage(),
+        directiveSyntax: new DirectiveSyntaxContext(undefined),
+        preserveEmptyRows: false,
+        searchPanel: false,
+    });
+}
+
+describe('markup editor keymap on macOS', () => {
+    it('should leave Opt+Shift+A to the browser: it types "Å" on macOS layouts', () => {
+        const view = createView('text');
+        view.focus();
+
+        // macOS reports the composed character in event.key, so CodeMirror resolves Alt
+        // combinations by key code instead. That turns this event into the "Alt-A" binding of
+        // defaultKeymap (toggleBlockComment) and inserts an HTML comment over the character.
+        const event = new KeyboardEvent('keydown', {
+            key: 'Å',
+            code: 'KeyA',
+            keyCode: 65,
+            altKey: true,
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true,
+        });
+
+        view.contentDOM.dispatchEvent(event);
+
+        expect(view.state.sliceDoc()).toBe('text');
+        expect(event.defaultPrevented).toBe(false);
+
+        view.destroy();
+    });
+});


### PR DESCRIPTION
## Problem

In markup mode on macOS, <kbd>Opt</kbd>+<kbd>Shift</kbd>+<kbd>A</kbd> inserts `<!--  -->` instead of typing a character. On the US layout that combination produces `Å`, so the character is simply not typable in the editor.

The binding comes from `defaultKeymap` in `@codemirror/commands`:

```js
{ key: "Alt-A", run: toggleBlockComment },
```

It is not shadowed by accident of key naming — macOS reports the composed character in `event.key`, so `w3c-keyname` deliberately falls back to the key code for Alt combinations:

```js
var brokenModifierNames = mac || chrome && +chrome[1] < 57;
var ignoreKey = brokenModifierNames && (event.ctrlKey || event.altKey || event.metaKey) || ...
var name = (!ignoreKey && event.key) || (event.shiftKey ? shift : base)[event.keyCode] || ...
```

`keyName` therefore returns `"A"`, `runHandlers` looks up `"Alt-A"` and hits the binding directly. That is by design — it is what makes Alt combinations bindable on macOS at all, and the CodeMirror maintainer has declined to make it configurable ([codemirror/dev#1621](https://github.com/codemirror/dev/issues/1621), [#1655](https://github.com/codemirror/dev/issues/1655)).

Consumers cannot work around it either: `keymaps` is spread *after* `defaultKeymap` into the same `keymap.of([...])`, and same-key bindings run in array order, so the default always wins.

## Fix

Skip that one combination on macOS.

Worth noting that upstream already applies this convention everywhere else — every other Alt+letter binding in `defaultKeymap` carries a mac override (`Alt-l` → `Ctrl-l`, `Alt-ArrowLeft` → `Ctrl-ArrowLeft`). `Alt-A` is the only one left without, which looks like an oversight rather than a decision.

Reported upstream as [codemirror/dev#1734](https://code.haverbeke.berlin/codemirror/dev/issues/1734). Once that lands, this filter turns into a no-op and should be removed.

The filter compares the key rather than the command, and resolves it the same way `buildKeymap` does (`b[platform] || b.key`), so a binding that upstream later gives a mac override is left alone.

Other platforms are untouched: `Alt+Shift+A` is not a printable character there, and the binding matches VS Code.

Nothing is lost on macOS either — `Mod-/` (`toggleComment`, also part of `defaultKeymap`) produces exactly the same `<!--  -->`, because markdown has no line comment syntax and `toggleComment` falls back to block comments.

## Test

`keymap-macos.test.ts` stubs `navigator.platform` before the module graph is loaded (both `@codemirror/view` and `w3c-keyname` read it once, at evaluation time) and dispatches the real macOS event shape (`key: 'Å'`, `keyCode: 65`, `altKey`, `shiftKey`).

Verified it reproduces the bug on `main`:

```
● markup editor keymap on macOS › should leave Opt+Shift+A to the browser

    Expected: "text"
    Received: "<!--  -->text"
```

and passes with the fix. Full unit suite (86 suites / 817 tests), `typecheck`, eslint and prettier are clean.

## Summary by Sourcery

Skip the CodeMirror Alt-A block comment keybinding on macOS in markup mode so Opt+Shift+A remains a typable character, and add coverage to ensure the macOS keymap defers this combo to the browser.

Bug Fixes:
- Prevent Opt+Shift+A on macOS from triggering block comment insertion in the markup editor so the Å character can be typed.

Tests:
- Add a macOS-specific keymap test that stubs navigator.platform and verifies Opt+Shift+A no longer triggers the Alt-A block comment binding.
