### PR TITLE
feat: allow to use latex-extension v2

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -290,7 +290,7 @@
     "@diplodoc/file-extension": "^0.2.1",
     "@diplodoc/folding-headings-extension": "^0.1.0",
     "@diplodoc/html-extension": "^2.3.2",
-    "@diplodoc/latex-extension": "^1.0.3",
+    "@diplodoc/latex-extension": "^1.0.3 || ^2.0.0",
     "@diplodoc/mermaid-extension": "^1.0.0 || ^2.0.0",
     "@diplodoc/quote-link-extension": "^0.1.3",
     "@diplodoc/tabs-extension": "^3.5.1",

--- a/packages/latex-extension/package.json
+++ b/packages/latex-extension/package.json
@@ -69,6 +69,7 @@
     "tslib": "catalog:ts"
   },
   "devDependencies": {
+    "@diplodoc/latex-extension": "catalog:peer-diplodoc",
     "@markdown-editor/gulp-tasks": "workspace:*",
     "@markdown-editor/tsconfig": "workspace:*",
     "gulp-cli": "catalog:",
@@ -76,7 +77,7 @@
     "typescript": "catalog:ts"
   },
   "peerDependencies": {
-    "@diplodoc/latex-extension": "^1.0.3",
+    "@diplodoc/latex-extension": "^1.0.3 || ^2.0.0",
     "@gravity-ui/markdown-editor": "workspace:^15.38.1",
     "@gravity-ui/uikit": "^7.1.0",
     "katex": "^0.16.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ catalogs:
       specifier: ^2.9.6
       version: 2.9.6
     '@diplodoc/latex-extension':
-      specifier: ^1.4.1
-      version: 1.4.1
+      specifier: ^2.0.2
+      version: 2.0.2
     '@diplodoc/mermaid-extension':
       specifier: ^2.0.0
       version: 2.0.0
@@ -157,7 +157,7 @@ importers:
         version: 2.9.6(@diplodoc/transform@4.75.1(@types/markdown-it@13.0.9)(highlight.js@11.11.1)(react@18.2.0))(@types/markdown-it@13.0.9)(markdown-it@13.0.2)(react@18.2.0)
       '@diplodoc/latex-extension':
         specifier: catalog:peer-diplodoc
-        version: 1.4.1(katex@0.16.27)(markdown-it@13.0.2)(react@18.2.0)
+        version: 2.0.2(katex@0.16.27)(markdown-it@13.0.2)(react@18.2.0)
       '@diplodoc/mermaid-extension':
         specifier: catalog:peer-diplodoc
         version: 2.0.0(markdown-it@13.0.2)(react@18.2.0)
@@ -545,7 +545,7 @@ importers:
         version: 2.9.6(@diplodoc/transform@4.75.1(@types/markdown-it@13.0.9)(highlight.js@11.8.0)(react@18.2.0))(@types/markdown-it@13.0.9)(markdown-it@13.0.2)(react@18.2.0)
       '@diplodoc/latex-extension':
         specifier: catalog:peer-diplodoc
-        version: 1.4.1(katex@0.16.27)(markdown-it@13.0.2)(react@18.2.0)
+        version: 2.0.2(katex@0.16.27)(markdown-it@13.0.2)(react@18.2.0)
       '@diplodoc/mermaid-extension':
         specifier: catalog:peer-diplodoc
         version: 2.0.0(markdown-it@13.0.2)(react@18.2.0)
@@ -678,9 +678,6 @@ importers:
 
   packages/latex-extension:
     dependencies:
-      '@diplodoc/latex-extension':
-        specifier: ^1.0.3
-        version: 1.4.1(katex@0.16.27)(markdown-it@13.0.2)(react@18.2.0)
       '@gravity-ui/markdown-editor':
         specifier: workspace:^15.38.1
         version: link:../editor
@@ -703,6 +700,9 @@ importers:
         specifier: catalog:ts
         version: 2.8.1
     devDependencies:
+      '@diplodoc/latex-extension':
+        specifier: catalog:peer-diplodoc
+        version: 2.0.2(katex@0.16.27)(markdown-it@13.0.2)(react@18.2.0)
       '@markdown-editor/gulp-tasks':
         specifier: workspace:*
         version: link:../../infra/gulp-tasks
@@ -1698,8 +1698,8 @@ packages:
       react:
         optional: true
 
-  '@diplodoc/latex-extension@1.4.1':
-    resolution: {integrity: sha512-F9quiizhqc7LdDVI1CHGbGBPzeQYWpcoNjJW7nQeLdBjthRRL8yZ6CuvQtWU8bS7v5hFrHRMk55cf+8tm/5kKA==}
+  '@diplodoc/latex-extension@2.0.2':
+    resolution: {integrity: sha512-zxzFS2TSxM9rGDj47uwnslWpk+F9IRUfsaMsPVT7iu5iAZEOnCTfhs79itnLOaxTH1e4TPKe+HFzrvXoNWdaFw==}
     peerDependencies:
       katex: ^0.16.9
       markdown-it: ^13.0.0
@@ -10377,7 +10377,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/markdown-it'
 
-  '@diplodoc/latex-extension@1.4.1(katex@0.16.27)(markdown-it@13.0.2)(react@18.2.0)':
+  '@diplodoc/latex-extension@2.0.2(katex@0.16.27)(markdown-it@13.0.2)(react@18.2.0)':
     dependencies:
       katex: 0.16.27
       markdown-it: 13.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalogs:
     '@diplodoc/file-extension': ^0.2.1
     '@diplodoc/folding-headings-extension': ^0.1.2
     '@diplodoc/html-extension': ^2.9.6
-    '@diplodoc/latex-extension': ^1.4.1
+    '@diplodoc/latex-extension': ^2.0.2
     '@diplodoc/mermaid-extension': ^2.0.0
     '@diplodoc/page-constructor-extension': ^0.13.3
     '@diplodoc/quote-link-extension': 0.1.3


### PR DESCRIPTION
## Summary by Sourcery

Relax latex-extension dependency constraints across editor and latex-extension packages and update workspace catalog to the new major version.

Build:
- Allow editor and latex-extension packages to use either v1 or v2 of @diplodoc/latex-extension via updated peer and direct dependency ranges.
- Update pnpm workspace catalog to target @diplodoc/latex-extension v2.0.x as the default version.