### PR TITLE
refactor(Mark): use new builder methods to register marks

### DIFF
--- a/packages/editor/src/extensions/markdown/Mark/MarkSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Mark/MarkSpecs/index.ts
@@ -9,24 +9,20 @@ export const markMarkType = markTypeFactory(markMarkName);
 export const MarkSpecs: ExtensionAuto = (builder) => {
     builder
         .configureMd((md) => md.use(markPlugin))
-        .addMark(markMarkName, () => ({
-            spec: {
-                parseDOM: [{tag: 'mark'}],
-                toDOM() {
-                    return ['mark'];
-                },
+        .addMarkSpec(markMarkName, () => ({
+            parseDOM: [{tag: 'mark'}],
+            toDOM() {
+                return ['mark'];
             },
-            fromMd: {
-                tokenSpec: {
-                    name: markMarkName,
-                    type: 'mark',
-                },
-            },
-            toMd: {
-                open: '==',
-                close: '==',
-                mixable: true,
-                expelEnclosingWhitespace: true,
-            },
+        }))
+        .addMarkdownTokenParserSpec('mark', () => ({
+            name: markMarkName,
+            type: 'mark',
+        }))
+        .addMarkSerializerSpec(markMarkName, () => ({
+            open: '==',
+            close: '==',
+            mixable: true,
+            expelEnclosingWhitespace: true,
         }));
 };


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Split mark registration into separate mark spec, markdown token parser spec, and mark serializer spec using the updated builder API.