### PR TITLE
refactor(Lists): use new builder methods to register nodes

### DIFF
--- a/packages/editor/src/extensions/markdown/Lists/ListsSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Lists/ListsSpecs/index.ts
@@ -1,10 +1,10 @@
-import type {ExtensionAuto} from '../../../../core';
-import {nodeTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {nodeTypeFactory} from 'src/utils/schema';
 
 import {ListNode} from './const';
-import {parserTokens} from './parser';
-import {schemaSpecs} from './schema';
-import {serializerTokens} from './serializer';
+import {ListsParserSpecs} from './parser';
+import {ListsSchemaSpecs} from './schema';
+import {ListsSerializerSpecs} from './serializer';
 
 export {ListsAttr, ListNode} from './const';
 export const liType = nodeTypeFactory(ListNode.ListItem);
@@ -12,20 +12,5 @@ export const blType = nodeTypeFactory(ListNode.BulletList);
 export const olType = nodeTypeFactory(ListNode.OrderedList);
 
 export const ListsSpecs: ExtensionAuto = (builder) => {
-    builder
-        .addNode(ListNode.ListItem, () => ({
-            spec: schemaSpecs[ListNode.ListItem],
-            toMd: serializerTokens[ListNode.ListItem],
-            fromMd: {tokenSpec: parserTokens[ListNode.ListItem]},
-        }))
-        .addNode(ListNode.BulletList, () => ({
-            spec: schemaSpecs[ListNode.BulletList],
-            toMd: serializerTokens[ListNode.BulletList],
-            fromMd: {tokenSpec: parserTokens[ListNode.BulletList]},
-        }))
-        .addNode(ListNode.OrderedList, () => ({
-            spec: schemaSpecs[ListNode.OrderedList],
-            toMd: serializerTokens[ListNode.OrderedList],
-            fromMd: {tokenSpec: parserTokens[ListNode.OrderedList]},
-        }));
+    builder.use(ListsSchemaSpecs).use(ListsParserSpecs).use(ListsSerializerSpecs);
 };

--- a/packages/editor/src/extensions/markdown/Lists/ListsSpecs/parser.ts
+++ b/packages/editor/src/extensions/markdown/Lists/ListsSpecs/parser.ts
@@ -1,10 +1,10 @@
 import type Token from 'markdown-it/lib/token';
 
-import type {ParserToken} from '../../../../core';
+import type {ExtensionAuto, ParserToken} from '#core';
 
 import {ListNode, ListsAttr} from './const';
 
-export const parserTokens: Record<ListNode, ParserToken> = {
+const parserTokens: Record<ListNode, ParserToken> = {
     [ListNode.ListItem]: {
         name: ListNode.ListItem,
         type: 'block',
@@ -40,3 +40,10 @@ function listIsTight(tokens: Token[], i: number) {
     }
     return false;
 }
+
+export const ListsParserSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addMarkdownTokenParserSpec('list_item', () => parserTokens[ListNode.ListItem])
+        .addMarkdownTokenParserSpec('bullet_list', () => parserTokens[ListNode.BulletList])
+        .addMarkdownTokenParserSpec('ordered_list', () => parserTokens[ListNode.OrderedList]);
+};

--- a/packages/editor/src/extensions/markdown/Lists/ListsSpecs/schema.ts
+++ b/packages/editor/src/extensions/markdown/Lists/ListsSpecs/schema.ts
@@ -1,8 +1,10 @@
 import type {NodeSpec} from 'prosemirror-model';
 
+import type {ExtensionAuto} from '#core';
+
 import {ListNode, ListsAttr, Markup} from './const';
 
-export const schemaSpecs: Record<ListNode, NodeSpec> = {
+const schemaSpecs: Record<ListNode, NodeSpec> = {
     [ListNode.ListItem]: {
         attrs: {
             [ListsAttr.Markup]: {default: null},
@@ -78,4 +80,11 @@ export const schemaSpecs: Record<ListNode, NodeSpec> = {
         allowSelection: false,
         complex: 'root',
     },
+};
+
+export const ListsSchemaSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addNodeSpec(ListNode.ListItem, () => schemaSpecs[ListNode.ListItem])
+        .addNodeSpec(ListNode.BulletList, () => schemaSpecs[ListNode.BulletList])
+        .addNodeSpec(ListNode.OrderedList, () => schemaSpecs[ListNode.OrderedList]);
 };

--- a/packages/editor/src/extensions/markdown/Lists/ListsSpecs/serializer.ts
+++ b/packages/editor/src/extensions/markdown/Lists/ListsSpecs/serializer.ts
@@ -1,10 +1,10 @@
 import type {Node} from 'prosemirror-model';
 
-import type {SerializerNodeToken} from '../../../../core';
+import type {ExtensionAuto, SerializerNodeToken} from '#core';
 
 import {ListNode, ListsAttr, Markup} from './const';
 
-export const serializerTokens: Record<ListNode, SerializerNodeToken> = {
+const serializerTokens: Record<ListNode, SerializerNodeToken> = {
     [ListNode.ListItem]: (state, node) => {
         state.renderContent(node);
     },
@@ -43,3 +43,10 @@ function getMarkup({
     if (!defs.values.includes(value)) value = defs.default;
     return value;
 }
+
+export const ListsSerializerSpecs: ExtensionAuto = (builder) => {
+    builder
+        .addNodeSerializerSpec(ListNode.ListItem, () => serializerTokens[ListNode.ListItem])
+        .addNodeSerializerSpec(ListNode.BulletList, () => serializerTokens[ListNode.BulletList])
+        .addNodeSerializerSpec(ListNode.OrderedList, () => serializerTokens[ListNode.OrderedList]);
+};


### PR DESCRIPTION
## Summary by Sourcery

Refactor markdown list extension registration to use dedicated schema, parser, and serializer builder specs.

Enhancements:
- Extract list schema, parser, and serializer specs into separate ExtensionAuto modules and register them via the builder.use API.
- Update list-related imports to use new core and utils module aliases instead of relative paths.