### PR TITLE
refactor(Strike): use new builder methods to register marks

### DIFF
--- a/packages/editor/src/extensions/markdown/Strike/StrikeSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Strike/StrikeSpecs/index.ts
@@ -1,24 +1,25 @@
-import type {ExtensionAuto} from '../../../../core';
-import {markTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {markTypeFactory} from 'src/utils/schema';
 
 export const strikeMarkName = 'strike';
 export const strikeType = markTypeFactory(strikeMarkName);
 
 export const StrikeSpecs: ExtensionAuto = (builder) => {
-    builder.addMark(strikeMarkName, () => ({
-        spec: {
+    builder
+        .addMarkSpec(strikeMarkName, () => ({
             parseDOM: [{tag: 'strike'}, {tag: 's'}],
             toDOM() {
                 return ['strike'];
             },
-        },
-        fromMd: {
-            tokenSpec: {
-                name: strikeMarkName,
-                type: 'mark',
-            },
-            tokenName: 's',
-        },
-        toMd: {open: '~~', close: '~~', mixable: true, expelEnclosingWhitespace: true},
-    }));
+        }))
+        .addMarkdownTokenParserSpec('s', () => ({
+            name: strikeMarkName,
+            type: 'mark',
+        }))
+        .addMarkSerializerSpec(strikeMarkName, () => ({
+            open: '~~',
+            close: '~~',
+            mixable: true,
+            expelEnclosingWhitespace: true,
+        }));
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Strike markdown extension to use the newer builder APIs for mark specs, token parsing, and mark serialization.

Enhancements:
- Update Strike mark registration to use addMarkSpec, addMarkdownTokenParserSpec, and addMarkSerializerSpec builder methods.
- Switch Strike extension imports to use the new core and schema module path aliases.