### PR TITLE
refactor(Subscript): use new builder methods to register marks

### DIFF
--- a/packages/editor/src/extensions/markdown/Subscript/SubscriptSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Subscript/SubscriptSpecs/index.ts
@@ -1,7 +1,7 @@
 import subPlugin from 'markdown-it-sub';
 
-import type {ExtensionAuto} from '../../../../core';
-import {markTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {markTypeFactory} from 'src/utils/schema';
 
 export const subscriptMarkName = 'sub';
 export const subscriptType = markTypeFactory(subscriptMarkName);
@@ -9,26 +9,27 @@ export const subscriptType = markTypeFactory(subscriptMarkName);
 export const SubscriptSpecs: ExtensionAuto = (builder) => {
     builder
         .configureMd((md) => md.use(subPlugin))
-        .addMark(subscriptMarkName, () => ({
-            spec: {
-                excludes: '_',
-                parseDOM: [{tag: 'sub'}],
-                toDOM() {
-                    return ['sub'];
-                },
+        .addMarkSpec(subscriptMarkName, () => ({
+            excludes: '_',
+            parseDOM: [{tag: 'sub'}],
+            toDOM() {
+                return ['sub'];
             },
-            toMd: {
-                open: (state) => {
-                    state.escapeWhitespace = true;
-                    return '~';
-                },
-                close: (state) => {
-                    state.escapeWhitespace = false;
-                    return '~';
-                },
-                mixable: false,
-                expelEnclosingWhitespace: true,
+        }))
+        .addMarkdownTokenParserSpec('sub', () => ({
+            name: subscriptMarkName,
+            type: 'mark',
+        }))
+        .addMarkSerializerSpec(subscriptMarkName, () => ({
+            open: (state) => {
+                state.escapeWhitespace = true;
+                return '~';
             },
-            fromMd: {tokenSpec: {name: subscriptMarkName, type: 'mark'}},
+            close: (state) => {
+                state.escapeWhitespace = false;
+                return '~';
+            },
+            mixable: false,
+            expelEnclosingWhitespace: true,
         }));
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Subscript markdown extension to use the newer builder APIs for marks and serializers while updating module import paths.

Enhancements:
- Split subscript mark configuration into separate mark spec, markdown token parser spec, and mark serializer spec using the new builder methods.
- Update core and schema utility imports to use the project’s aliased module paths.