### PR TITLE
refactor(Superscript): use new builder methods to register marks

### DIFF
--- a/packages/editor/src/extensions/markdown/Superscript/SuperscriptSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Superscript/SuperscriptSpecs/index.ts
@@ -1,8 +1,8 @@
 import {log} from '@diplodoc/transform/lib/log.js';
 import sup from '@diplodoc/transform/lib/plugins/sup.js';
 
-import type {ExtensionAuto} from '../../../../core';
-import {markTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {markTypeFactory} from 'src/utils/schema';
 
 export const superscriptMarkName = 'sup';
 export const superscriptType = markTypeFactory(superscriptMarkName);
@@ -10,26 +10,27 @@ export const superscriptType = markTypeFactory(superscriptMarkName);
 export const SuperscriptSpecs: ExtensionAuto = (builder) => {
     builder
         .configureMd((md) => md.use(sup, {log}))
-        .addMark(superscriptMarkName, () => ({
-            spec: {
-                excludes: '_',
-                parseDOM: [{tag: 'sup'}],
-                toDOM() {
-                    return ['sup'];
-                },
+        .addMarkSpec(superscriptMarkName, () => ({
+            excludes: '_',
+            parseDOM: [{tag: 'sup'}],
+            toDOM() {
+                return ['sup'];
             },
-            toMd: {
-                open: (state) => {
-                    state.escapeWhitespace = true;
-                    return '^';
-                },
-                close: (state) => {
-                    state.escapeWhitespace = false;
-                    return '^';
-                },
-                mixable: true,
-                expelEnclosingWhitespace: true,
+        }))
+        .addMarkdownTokenParserSpec('sup', () => ({
+            name: superscriptMarkName,
+            type: 'mark',
+        }))
+        .addMarkSerializerSpec(superscriptMarkName, () => ({
+            open: (state) => {
+                state.escapeWhitespace = true;
+                return '^';
             },
-            fromMd: {tokenSpec: {name: superscriptMarkName, type: 'mark'}},
+            close: (state) => {
+                state.escapeWhitespace = false;
+                return '^';
+            },
+            mixable: true,
+            expelEnclosingWhitespace: true,
         }));
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Superscript markdown extension to use the new builder APIs for mark specs, markdown token parser specs, and mark serializer specs, and update its imports to the new module paths.

Enhancements:
- Adopt new builder methods to separately register the superscript mark spec, markdown token parser spec, and mark serializer spec.
- Update SuperscriptSpecs imports to use the updated core and schema module paths.