### PR TITLE
refactor(Underline): use new builder methods to register marks

### DIFF
--- a/packages/editor/src/extensions/markdown/Underline/UnderlineSpecs/index.ts
+++ b/packages/editor/src/extensions/markdown/Underline/UnderlineSpecs/index.ts
@@ -1,7 +1,7 @@
 import insPlugin from 'markdown-it-ins';
 
-import type {ExtensionAuto} from '../../../../core';
-import {markTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {markTypeFactory} from 'src/utils/schema';
 
 export const underlineMarkName = 'ins';
 export const underlineType = markTypeFactory(underlineMarkName);
@@ -9,14 +9,20 @@ export const underlineType = markTypeFactory(underlineMarkName);
 export const UnderlineSpecs: ExtensionAuto = (builder) => {
     builder
         .configureMd((md) => md.use(insPlugin))
-        .addMark(underlineMarkName, () => ({
-            spec: {
-                parseDOM: [{tag: 'ins'}, {tag: 'u'}],
-                toDOM() {
-                    return ['ins'];
-                },
+        .addMarkSpec(underlineMarkName, () => ({
+            parseDOM: [{tag: 'ins'}, {tag: 'u'}],
+            toDOM() {
+                return ['ins'];
             },
-            toMd: {open: '++', close: '++', mixable: true, expelEnclosingWhitespace: true},
-            fromMd: {tokenSpec: {name: underlineMarkName, type: 'mark'}},
+        }))
+        .addMarkdownTokenParserSpec('ins', () => ({
+            name: underlineMarkName,
+            type: 'mark',
+        }))
+        .addMarkSerializerSpec(underlineMarkName, () => ({
+            open: '++',
+            close: '++',
+            mixable: true,
+            expelEnclosingWhitespace: true,
         }));
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Underline markdown extension to use the new builder APIs for registering mark specs, markdown token parsing, and mark serialization.

Enhancements:
- Switch UnderlineSpecs to the new addMarkSpec, addMarkdownTokenParserSpec, and addMarkSerializerSpec builder methods.
- Update imports to use the new core and schema module paths.