### PR TITLE
refactor(Monospace): use new builder methods to register marks

### DIFF
--- a/packages/editor/src/extensions/yfm/Monospace/MonospaceSpecs/index.ts
+++ b/packages/editor/src/extensions/yfm/Monospace/MonospaceSpecs/index.ts
@@ -1,8 +1,8 @@
 import {log} from '@diplodoc/transform/lib/log.js';
 import yfmPlugin from '@diplodoc/transform/lib/plugins/monospace.js';
 
-import type {ExtensionAuto} from '../../../../core';
-import {markTypeFactory} from '../../../../utils/schema';
+import type {ExtensionAuto} from '#core';
+import {markTypeFactory} from 'src/utils/schema';
 
 export const monospaceMarkName = 'monospace';
 export const monospaceType = markTypeFactory(monospaceMarkName);
@@ -10,24 +10,20 @@ export const monospaceType = markTypeFactory(monospaceMarkName);
 export const MonospaceSpecs: ExtensionAuto = (builder) => {
     builder
         .configureMd((md) => md.use(yfmPlugin, {log}))
-        .addMark(monospaceMarkName, () => ({
-            spec: {
-                parseDOM: [{tag: 'samp'}],
-                toDOM() {
-                    return ['samp'];
-                },
+        .addMarkSpec(monospaceMarkName, () => ({
+            parseDOM: [{tag: 'samp'}],
+            toDOM() {
+                return ['samp'];
             },
-            fromMd: {
-                tokenSpec: {
-                    name: monospaceMarkName,
-                    type: 'mark',
-                },
-            },
-            toMd: {
-                open: '##',
-                close: '##',
-                mixable: true,
-                expelEnclosingWhitespace: true,
-            },
+        }))
+        .addMarkdownTokenParserSpec('monospace', () => ({
+            name: monospaceMarkName,
+            type: 'mark',
+        }))
+        .addMarkSerializerSpec(monospaceMarkName, () => ({
+            open: '##',
+            close: '##',
+            mixable: true,
+            expelEnclosingWhitespace: true,
         }));
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Monospace extension to use the new builder APIs for registering mark specs, markdown token parsing, and mark serialization, and update imports to the current module paths.

Enhancements:
- Adopt separate builder methods for mark specs, markdown token parser specs, and mark serializer specs in the Monospace extension.
- Update Monospace extension imports to use the new core and utils module aliases.