### PR TITLE
fix(markup): correct Firefox caret height near placeholder

### DIFF
--- a/packages/editor/src/markup/codemirror/gravity.ts
+++ b/packages/editor/src/markup/codemirror/gravity.ts
@@ -33,6 +33,11 @@ export const gravityTheme = EditorView.baseTheme({
     '.cm-placeholder': {
         color: 'var(--g-color-text-secondary)',
     },
+    '@supports (-moz-appearance: none)': {
+        '.cm-widgetBuffer:has(+ .cm-placeholder)': {
+            verticalAlign: 'baseline',
+        },
+    },
     '.cm-content': {
         color: 'var(--g-color-text-primary)',
         caretColor: 'currentColor',


### PR DESCRIPTION
Fixes #1222

## Summary by Sourcery

Bug Fixes:
- Correct the Firefox caret height and alignment when it appears adjacent to a placeholder.